### PR TITLE
Fix frame count calculation bug, change some ui

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -35,6 +35,7 @@ from app.helpers.typing_helper import ControlTypes, FacesParametersTypes
 if TYPE_CHECKING:
     from app.ui.main_ui import MainWindow
 
+TAIL_TOLERANCE = 300
 
 class VideoProcessor(QObject):
     """
@@ -374,6 +375,30 @@ class VideoProcessor(QObject):
                     preview_target_height=target_height,
                 )
                 if not ret:
+                    fn = self.current_frame_number
+
+                    # 1) Segment mode: read failure near segment end -> treat as segment EOF/stop
+                    if self.is_processing_segments and self.current_segment_end_frame is not None:
+                        if fn >= self.current_segment_end_frame - TAIL_TOLERANCE:
+                            with self.state_lock:
+                                # Advance past the segment end to trigger display_next_frame()'s segment-end branch
+                                self.next_frame_to_display = self.current_segment_end_frame + 1
+                                # Optional: also advance the feeder's own frame counter to avoid other logic misinterpreting state
+                                self.current_frame_number = self.current_segment_end_frame + 1
+                            print(f"[INFO] Feeder: Treat read failure near segment tail as EOF (frame={fn}).")
+                            break
+
+                    # 2) Standard mode: read failure near max_frame -> treat as media EOF/stop
+                    if (not self.is_processing_segments) and (self.max_frame_number is not None):
+                        if fn >= self.max_frame_number - TAIL_TOLERANCE:
+                            with self.state_lock:
+                                # Advance past media end to trigger display_next_frame()'s "End of media reached" branch
+                                self.next_frame_to_display = self.max_frame_number + 1
+                                self.current_frame_number = self.max_frame_number + 1
+                            print(f"[INFO] Feeder: Treat read failure near media tail as EOF (frame={fn}).")
+                            break
+
+                    # 3) Non-tail failure: treat as a regular error (preserve original semantics)
                     print(
                         f"[ERROR] Feeder: Could not read frame {self.current_frame_number} (Mode: {'Segment' if is_segment_mode else 'Standard'})!"
                     )
@@ -957,6 +982,14 @@ class VideoProcessor(QObject):
                 read_successful = True
                 misc_helpers.seek_frame(self.media_capture, self.current_frame_number)
             else:
+                fn = self.current_frame_number
+                max_fn = self.max_frame_number
+                if fn >= max_fn - TAIL_TOLERANCE:
+                    print(
+                        f"[INFO] EOF reached at frame {fn} (max={max_fn}), stopping gracefully."
+                    )
+                    self.current_frame_number = max_fn + 1
+                    return None
                 print(
                     f"[ERROR] Cannot read frame {self.current_frame_number} for single processing!"
                 )

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -3136,8 +3136,9 @@ class FrameWorker(threading.Thread):
             )
 
         if parameters["ColorNoiseDecimalSlider"] > 0:
+            swap = swap.to(torch.float32)
             noise = (
-                (torch.rand_like(swap) - 0.5)
+                (torch.rand_like(swap, dtype=torch.float32) - 0.5)
                 * 2
                 * parameters["ColorNoiseDecimalSlider"]
             )

--- a/app/ui/widgets/actions/job_manager_actions.py
+++ b/app/ui/widgets/actions/job_manager_actions.py
@@ -1177,7 +1177,8 @@ def prompt_job_name(main_window: "MainWindow"):
             return
     # --- End Validation ---
 
-    dialog = widget_components.SaveJobDialog(main_window)
+    input_filename = Path(main_window.video_processor.media_path).stem
+    dialog = widget_components.SaveJobDialog(main_window, input_filename)
     if dialog.exec() == QtWidgets.QDialog.Accepted:
         job_name = dialog.job_name
         use_job_name_for_output = dialog.use_job_name_for_output
@@ -1199,12 +1200,14 @@ def prompt_job_name(main_window: "MainWindow"):
 
         # Validate output file name if provided
         if not use_job_name_for_output and output_file_name:
-            if not re.match(r"^[\w\- ]+$", output_file_name):
+            # Simple check for characters not allowed in filenames (e.g. Windows)
+            invalid_chars = '<>:"/\\|?*'
+            if any(ch in output_file_name for ch in invalid_chars) or re.search(r'[\x00-\x1f]', output_file_name):
                 QMessageBox.warning(
                     main_window,
                     "Invalid Output File Name",
                     "Output file name contains invalid characters.\n"
-                    "Only letters, numbers, spaces, dashes, and underscores are allowed.",
+                    "Characters not allowed: <> : \" / \\ | ? * or control characters.",
                 )
                 return
 

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -790,6 +790,46 @@ def record_video(main_window: "MainWindow", checked: bool):
                 )
 
     else:
+        # --- Stop confirmation (manual UI only) ---
+        # The record button is toggle-based, and many call sites do not check return
+        # values. Therefore, cancellation must be handled here without relying on
+        # callers.
+        #
+        # Do NOT prompt when this stop was initiated programmatically by Job Manager.
+        if (video_processor.is_processing_segments or video_processor.recording) and not job_mgr_flag:
+            try:
+                box = QtWidgets.QMessageBox(main_window)
+                box.setIcon(QtWidgets.QMessageBox.Warning)
+                box.setWindowTitle("Confirm stop")
+                box.setText("Stop the current recording?")
+                if video_processor.is_processing_segments:
+                    box.setInformativeText(
+                        "Segment recording will stop immediately. Output may be incomplete."
+                    )
+                else:
+                    box.setInformativeText(
+                        "Recording will stop immediately and finalize the output."
+                    )
+                box.setStandardButtons(
+                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+                )
+                box.setDefaultButton(QtWidgets.QMessageBox.No)
+
+                if box.exec() != QtWidgets.QMessageBox.Yes:
+                    # User declined. Re-arm the toggle to the ON state.
+                    main_window.buttonMediaRecord.blockSignals(True)
+                    main_window.buttonMediaRecord.setChecked(True)
+                    main_window.buttonMediaRecord.blockSignals(False)
+                    set_record_button_icon_to_stop(main_window)
+                    return
+            except Exception:
+                # If anything goes wrong with the dialog, fail safe by NOT stopping.
+                main_window.buttonMediaRecord.blockSignals(True)
+                main_window.buttonMediaRecord.setChecked(True)
+                main_window.buttonMediaRecord.blockSignals(False)
+                set_record_button_icon_to_stop(main_window)
+                return
+            
         if video_processor.is_processing_segments:
             print(
                 "[INFO] Record button released: User requested stop during segment processing. Finalizing..."
@@ -1238,7 +1278,7 @@ def process_batch_images(main_window: "MainWindow", process_all_faces: bool):
         original_target_faces = main_window.target_faces.copy()
 
     # 6. Setup Progress Dialog
-    progress_dialog = QtWidgets.QProgressDialog(
+    progress_dialog = widget_components.ProgressDialog(
         "Starting batch processing...",
         "Cancel",
         0,
@@ -1262,7 +1302,7 @@ def process_batch_images(main_window: "MainWindow", process_all_faces: bool):
             progress_dialog.setLabelText(f"Processing: {os.path.basename(media_path)}")
             QtWidgets.QApplication.processEvents()  # Keep UI responsive
 
-            if progress_dialog.wasCanceled():
+            if progress_dialog.confirmedCanceled():
                 break
 
             try:
@@ -1413,7 +1453,7 @@ def process_batch_images(main_window: "MainWindow", process_all_faces: bool):
                         QtWidgets.QApplication.processEvents()  # Process UI events (like cancel button)
 
                         # Check for cancellation *inside* the video wait loop
-                        if progress_dialog.wasCanceled():
+                        if progress_dialog.confirmedCanceled():
                             print(
                                 f"[WARN] Cancel detected during video processing: {media_path}. Aborting..."
                             )
@@ -1428,7 +1468,7 @@ def process_batch_images(main_window: "MainWindow", process_all_faces: bool):
                     # 3. At this point, record_video has completed (or been aborted)
                     # We must check *again* if the loop was exited due to cancellation
                     # to avoid incorrectly incrementing the 'processed_count'.
-                    if not progress_dialog.wasCanceled():
+                    if not progress_dialog.confirmedCanceled():
                         print(f"[INFO] Finished processing video: {media_path}")
                         processed_count += 1
                     else:
@@ -1454,7 +1494,7 @@ def process_batch_images(main_window: "MainWindow", process_all_faces: bool):
         progress_dialog.close()
 
         # 9. Show completion message
-        if progress_dialog.wasCanceled():
+        if progress_dialog.confirmedCanceled():
             result_msg = (
                 f"Batch processing cancelled.\n\n"
                 f"Processed: {processed_count}\n"

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -1377,7 +1377,111 @@ class LoadingDialog(QtWidgets.QDialog):
 
 # Custom progress dialog
 class ProgressDialog(QtWidgets.QProgressDialog):
-    pass
+    """
+    QProgressDialog with confirmation-before-cancel behavior that works with PySide6.
+
+    IMPORTANT:
+    - Do NOT rely on overriding cancel()/wasCanceled(); QProgressDialog's cancel is not virtual.
+    - Use the `canceled` signal to intercept cancellation.
+    - Batch code must check confirmedCanceled() instead of wasCanceled().
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._confirmed_cancelled = False
+        self._confirm_dialog_open = False
+
+        # Prevent Qt from auto-closing/resetting the dialog unexpectedly
+        try:
+            self.setAutoClose(False)
+        except Exception:
+            pass
+        try:
+            self.setAutoReset(False)
+        except Exception:
+            pass
+
+        # Ensure cancel text exists
+        try:
+            self.setCancelButtonText("Cancel")
+        except Exception:
+            pass
+
+        # Intercept Qt's cancel flow via signal (this is reliable in PySide6)
+        self.canceled.connect(self._on_canceled)
+
+    def confirmedCanceled(self) -> bool:
+        """Return True only if the user confirmed stopping."""
+        return self._confirmed_cancelled
+
+    def _on_canceled(self):
+        """
+        Qt has already marked the dialog as canceled and may hide it.
+        We show confirmation ASAP (queued to the event loop) and then either:
+        - confirm: keep _confirmed_cancelled=True (batch loop will stop)
+        - decline: reset & re-show dialog, and keep _confirmed_cancelled=False (batch continues)
+        """
+        if self._confirmed_cancelled:
+            return
+        if self._confirm_dialog_open:
+            return
+
+        # Defer confirmation to next event loop turn to avoid showing behind/after close
+        QtCore.QTimer.singleShot(0, self._show_confirm_and_apply)
+
+    def _show_confirm_and_apply(self):
+        if self._confirmed_cancelled:
+            return
+        if self._confirm_dialog_open:
+            return
+
+        self._confirm_dialog_open = True
+        try:
+            parent = self.parent() or self
+
+            box = QtWidgets.QMessageBox(parent)
+            box.setIcon(QtWidgets.QMessageBox.Warning)
+            box.setWindowTitle("Confirm stop")
+            box.setText("Stop the current task?")
+            box.setInformativeText(
+                "Processing will stop immediately.\n"
+                "Outputs may be incomplete."
+            )
+            box.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
+            box.setDefaultButton(QtWidgets.QMessageBox.No)
+
+            # Force on-top to avoid “dialog appears only after main window closes”
+            try:
+                box.setWindowFlag(QtCore.Qt.WindowStaysOnTopHint, True)
+            except Exception:
+                pass
+
+            ret = box.exec()
+
+            if ret == QtWidgets.QMessageBox.Yes:
+                self._confirmed_cancelled = True
+                # leave as-is; batch loop will see confirmedCanceled()==True and stop
+                return
+
+            # User declined: undo the cancel state and re-show progress dialog
+            self._confirmed_cancelled = False
+
+            # reset() clears internal canceled/hidden state; safe even if already hidden
+            try:
+                self.reset()
+            except Exception:
+                pass
+
+            try:
+                self.show()
+                self.raise_()
+                self.activateWindow()
+            except Exception:
+                pass
+
+        finally:
+            self._confirm_dialog_open = False
 
 
 class LoadLastWorkspaceDialog(QtWidgets.QDialog):
@@ -1441,7 +1545,7 @@ class JobLoadingDialog(QtWidgets.QDialog):
 
 
 class SaveJobDialog(QtWidgets.QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, input_filename=""):
         super().__init__(parent)
         self.setWindowTitle("Save Job")
         self.setWindowIcon(QtGui.QIcon(":/media/media/visomaster_small.png"))
@@ -1449,7 +1553,8 @@ class SaveJobDialog(QtWidgets.QDialog):
         # Widgets
         self.job_name_label = QtWidgets.QLabel("Job Name:")
         self.job_name_edit = QtWidgets.QLineEdit(self)
-        self.job_name_edit.setPlaceholderText("Enter job name")
+        #self.job_name_edit.setPlaceholderText("Enter job name")
+        self.job_name_edit.setText(input_filename)
 
         self.set_output_name_checkbox = QtWidgets.QCheckBox(
             "Use job name for output file name", self
@@ -1458,7 +1563,8 @@ class SaveJobDialog(QtWidgets.QDialog):
 
         self.output_name_label = QtWidgets.QLabel("Output File Name:")
         self.output_name_edit = QtWidgets.QLineEdit(self)
-        self.output_name_edit.setPlaceholderText("Leave blank for default")
+        #self.output_name_edit.setPlaceholderText("Leave blank for default")
+        self.output_name_edit.setText(input_filename)
 
         # Button box
         QBtn = QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel


### PR DESCRIPTION
1 Fix inaccurate frame count calculation causing job termination; 2 add job stop confirmation to prevent accidental cancellation; 3 default job name to video filename when saving.