### PR TITLE
Fixes error during job processing "Feeder: Could not read frame"

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -373,6 +373,11 @@ class VideoProcessor(QObject):
                     print(
                         f"[ERROR] Feeder: Could not read frame {self.current_frame_number} (Mode: {'Segment' if is_segment_mode else 'Standard'})!"
                     )
+                    if not is_segment_mode:
+                        self.max_frame_number = min(
+                            self.max_frame_number,
+                            max(0, self.current_frame_number - 1),
+                        )
                     break  # Stop reading
 
                 frame_num_to_process = self.current_frame_number

--- a/app/ui/widgets/actions/common_actions.py
+++ b/app/ui/widgets/actions/common_actions.py
@@ -182,10 +182,10 @@ def update_parameter(
         exec_function(*final_exec_args)
 
 
-def refresh_frame(main_window: "MainWindow"):
+def refresh_frame(main_window: "MainWindow", synchronous: bool = False):
     video_processor = main_window.video_processor
     if not video_processor.processing:
-        video_processor.process_current_frame()
+        video_processor.process_current_frame(synchronous=synchronous)
 
 
 # Function to Hide Elements conditionally from values in LayoutData (Currently supports using Selection box and Toggle button to hide other widgets)

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -281,7 +281,7 @@ class TargetMediaCardButton(CardButton):
         )
 
         main_window.loading_new_media = True
-        common_widget_actions.refresh_frame(main_window)
+        common_widget_actions.refresh_frame(main_window, synchronous=True)
 
         if main_window.control.get("AutoSwapToggle"):
             # Run detect on 0 frame or image


### PR DESCRIPTION
## Problem

`[ERROR] Feeder: Could not read frame 1828 (Mode: Standard)!`

I'd noticed that some videos (usually shorter ones) would have a decoding error near end of video. Video would not save until user manually stopped recording. (If left long enough I think a timeout eventually gets fired)

## Solve

I've handled that error and set the end of video to that decode video error frame number.

**This will result in the first decoded frame being treated as the "last" frame and the video output will be saved.**. _This is ideal for me but others may want to consider some optionality here_

Also fixed a race condition on job manager init by enabling sync loading