### PR TITLE
Fix: Job output timestamping, load sequencing, and detector input fallback

### DIFF
--- a/app/processors/face_detectors.py
+++ b/app/processors/face_detectors.py
@@ -1,4 +1,5 @@
 import threading
+import math
 from typing import TYPE_CHECKING, Dict, Any
 
 import torch
@@ -143,6 +144,62 @@ class FaceDetectors:
             det_img = (det_img - 127.5) / 128.0  # Normalize to [-1.0, 1.0] range
 
         return det_img, det_scale, input_size
+
+    def _infer_fixed_square_input_from_outputs(
+        self, ort_session, first_stride: int = 8
+    ) -> int | None:
+        """
+        Attempts to infer a fixed square model input size from the first detection head
+        output shape. For RetinaFace/SCRFD this head typically has shape {N,1} where
+        N = (input/stride)^2 * num_anchors and num_anchors is usually 2.
+        """
+        try:
+            outputs = ort_session.get_outputs()
+            if not outputs:
+                return None
+
+            shape = outputs[0].shape
+            if not shape or len(shape) < 1:
+                return None
+
+            n = shape[0]
+            if not isinstance(n, int) or n <= 0:
+                return None
+
+            # Try common anchor counts used by RetinaFace/SCRFD exports.
+            for anchors in (2, 1):
+                if n % anchors != 0:
+                    continue
+                cells = n // anchors
+                side = int(round(math.sqrt(cells)))
+                if side > 0 and side * side == cells:
+                    return side * first_stride
+        except Exception:
+            return None
+
+        return None
+
+    def _resolve_detector_input_size(
+        self, detect_mode: str, requested_input_size: tuple, ort_session
+    ) -> tuple:
+        """
+        Resolves the effective detection input size.
+        For fixed-shape RetinaFace/SCRFD exports, running at a mismatched size can spam
+        ONNX Runtime VerifyOutputSizes warnings. If a fixed square size is detectable,
+        prefer it over the requested value.
+        """
+        if detect_mode not in ("RetinaFace", "SCRFD"):
+            return requested_input_size
+
+        inferred_size = self._infer_fixed_square_input_from_outputs(ort_session)
+        if inferred_size is None:
+            return requested_input_size
+
+        requested_w, requested_h = requested_input_size
+        if requested_w == inferred_size and requested_h == inferred_size:
+            return requested_input_size
+
+        return (inferred_size, inferred_size)
 
     def _filter_detections_gpu(
         self,
@@ -564,7 +621,9 @@ class FaceDetectors:
         args.update(kwargs)
 
         if detect_mode in ["RetinaFace", "SCRFD"]:
-            args["input_size"] = input_size
+            args["input_size"] = self._resolve_detector_input_size(
+                detect_mode, input_size, ort_session
+            )
 
         # Run the detector — returns (det, kpss_5, kpss, det_scores)
         det, kpss_5, kpss, det_scores = detection_function(**args)

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -1624,6 +1624,25 @@ class VideoProcessor(QObject):
             # Fallback in case of an error
             return f"{total_seconds:.3f} seconds"
 
+    def _apply_job_timestamp_to_output_name(
+        self,
+        was_triggered_by_job: bool,
+        job_name: Optional[str],
+        use_job_name: bool,
+        output_file_name: Optional[str],
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Appends the standard output timestamp to job-driven names."""
+        if not was_triggered_by_job:
+            return job_name, output_file_name
+
+        timestamp = datetime.now().strftime(r"%Y_%m_%d_%H_%M_%S")
+        if use_job_name and job_name:
+            job_name = f"{job_name}_{timestamp}"
+        elif output_file_name:
+            output_file_name = f"{output_file_name}_{timestamp}"
+
+        return job_name, output_file_name
+
     def _log_processing_summary(
         self, processing_time_sec: float, num_frames_processed: int
     ):
@@ -2428,6 +2447,13 @@ class VideoProcessor(QObject):
                     else None
                 )
 
+                job_name, output_file_name = self._apply_job_timestamp_to_output_name(
+                    was_triggered_by_job,
+                    job_name,
+                    use_job_name,
+                    output_file_name,
+                )
+
                 final_file_path = misc_helpers.get_output_file_path(
                     self.media_path,
                     self.main_window.control["OutputMediaFolder"],
@@ -3026,6 +3052,13 @@ class VideoProcessor(QObject):
             getattr(self.main_window, "output_file_name", None)
             if was_triggered_by_job
             else None
+        )
+
+        job_name, output_file_name = self._apply_job_timestamp_to_output_name(
+            was_triggered_by_job,
+            job_name,
+            use_job_name,
+            output_file_name,
         )
 
         final_file_path = misc_helpers.get_output_file_path(

--- a/app/ui/widgets/actions/common_actions.py
+++ b/app/ui/widgets/actions/common_actions.py
@@ -619,6 +619,8 @@ def set_widgets_values_using_face_id_parameters(
         # print(f"Set widgets values using face_id {face_id}")
         parameters = main_window.parameters[face_id].copy()
     parameter_widgets = main_window.parameter_widgets
+    # Preserve outer suppression state so nested batch operations do not override it.
+    previous_batch_flag = getattr(main_window, "_batch_update_in_progress", False)
     # PERF-05: Set batch update flag to suppress per-widget refresh_frame calls during the loop
     main_window._batch_update_in_progress = True
     try:
@@ -631,9 +633,10 @@ def set_widgets_values_using_face_id_parameters(
                 _set_single_widget_value(widget, parameter_value)
                 widget.enable_refresh_frame = True
     finally:
-        main_window._batch_update_in_progress = False
-        # Trigger a single frame refresh after all widgets have been updated
-        refresh_frame(main_window)
+        main_window._batch_update_in_progress = previous_batch_flag
+        # Trigger a single refresh only if this function owns the outermost batch scope.
+        if not previous_batch_flag:
+            refresh_frame(main_window)
 
 
 def set_control_widgets_values(main_window: "MainWindow", enable_exec_func=True):

--- a/app/ui/widgets/actions/job_manager_actions.py
+++ b/app/ui/widgets/actions/job_manager_actions.py
@@ -513,6 +513,26 @@ def _load_job_markers(main_window: "MainWindow", data: dict):
     main_window.videoSeekSlider.update()
 
 
+def _begin_batch_refresh_suppression(main_window: "MainWindow") -> bool:
+    """Suppress intermediate frame refreshes and return the previous flag value."""
+    previous_batch_flag = getattr(main_window, "_batch_update_in_progress", False)
+    main_window._batch_update_in_progress = True
+    return previous_batch_flag
+
+
+def _restore_batch_refresh_state(main_window: "MainWindow", previous_batch_flag: bool):
+    """Restore the previous frame-refresh suppression state."""
+    main_window._batch_update_in_progress = previous_batch_flag
+
+
+def _restore_state_and_refresh(
+    main_window: "MainWindow", previous_batch_flag: bool
+):
+    """Restore suppression flag and run a single final frame refresh."""
+    _restore_batch_refresh_state(main_window, previous_batch_flag)
+    common_widget_actions.refresh_frame(main_window)
+
+
 def _validate_job_files_exist(data: dict) -> tuple[bool, str | None]:
     """
     (NEW) Performs a pre-flight check on job data *before* loading.
@@ -706,6 +726,7 @@ def load_job_workspace(main_window: "MainWindow", job_name: str):
     )
     progress_dialog.show()
     QtWidgets.QApplication.processEvents()
+    previous_batch_flag = _begin_batch_refresh_suppression(main_window)
 
     # --- Execute Loading Steps ---
     try:
@@ -803,7 +824,7 @@ def load_job_workspace(main_window: "MainWindow", job_name: str):
         main_window.videoSeekSlider.update()
 
         # Final refresh ensures graphics view is up-to-date after potential parameter changes
-        common_widget_actions.refresh_frame(main_window)
+        _restore_state_and_refresh(main_window, previous_batch_flag)
 
         # --- Re-enable all UI controls after loading ---
         layout_actions.enable_all_parameters_and_control_widget(main_window)
@@ -820,6 +841,7 @@ def load_job_workspace(main_window: "MainWindow", job_name: str):
             f"An error occurred while loading job '{job_name}':\n{e}",
         )
     finally:
+        _restore_batch_refresh_state(main_window, previous_batch_flag)
         progress_dialog.close()
 
 
@@ -858,6 +880,7 @@ def _restore_workspace_from_snapshot(main_window: "MainWindow", data: dict):
     progress_dialog.update_progress(0, total_steps, "Initializing restore...")
     progress_dialog.show()
     QtWidgets.QApplication.processEvents()
+    previous_batch_flag = _begin_batch_refresh_suppression(main_window)
 
     # --- Execute Loading Steps ---
     try:
@@ -961,7 +984,7 @@ def _restore_workspace_from_snapshot(main_window: "MainWindow", data: dict):
         main_window.videoSeekSlider.update()
 
         # Final refresh ensures graphics view is up-to-date
-        common_widget_actions.refresh_frame(main_window)
+        _restore_state_and_refresh(main_window, previous_batch_flag)
 
         # --- Re-enable all UI controls after restoring ---
         layout_actions.enable_all_parameters_and_control_widget(main_window)
@@ -978,6 +1001,7 @@ def _restore_workspace_from_snapshot(main_window: "MainWindow", data: dict):
             f"An error occurred while restoring the workspace:\n{e}",
         )
     finally:
+        _restore_batch_refresh_state(main_window, previous_batch_flag)
         progress_dialog.close()
 
 
@@ -1389,6 +1413,7 @@ def load_job_settings(main_window: "MainWindow", job_data: dict):
     Assumes master assets are already loaded.
     """
     print("[INFO] Load job settings called.")
+    previous_batch_flag = _begin_batch_refresh_suppression(main_window)
     try:
         # Store job name context for processing
         main_window.current_job_name = job_data.get("job_name_internal", "Unknown Job")
@@ -1397,10 +1422,10 @@ def load_job_settings(main_window: "MainWindow", job_data: dict):
         )
         main_window.output_file_name = job_data.get("output_file_name", None)
 
-        # --- Re-ordered loading logic ---
+        # During job restore, suppress intermediate refreshes so the first processed
+        # frame sees fully restored controls instead of stale pre-load state.
 
-        # 1. Select the media FIRST. This triggers the (asynchronous) loading
-        # of the first frame via process_current_frame.
+        # 1. Select the media.
         selected_media_id = job_data.get("selected_media_id", False)
         if (
             selected_media_id
@@ -1422,15 +1447,17 @@ def load_job_settings(main_window: "MainWindow", job_data: dict):
                 print("[ERROR] No target media loaded, cannot proceed.")
                 # This job will likely fail, but we must continue
 
-        # 2. Load target faces and parameters. This is safe.
+        # 2. Load target faces and parameters.
         _load_job_target_faces_and_params(main_window, job_data)
 
-        # 3. Load controls. This is now safe because the swap_button logic
-        #    is fixed (is_batch_load=True) and won't trigger a bad refresh.
+        # 3. Load controls/state.
         _load_job_controls_and_state(main_window, job_data, is_batch_load=True)
 
-        # 4. Load markers. This is safe.
+        # 4. Load markers.
         _load_job_markers(main_window, job_data)
+
+        # Run exactly one refresh with the final restored state.
+        _restore_state_and_refresh(main_window, previous_batch_flag)
 
         print(
             f"[INFO] Lightweight settings loaded for job: {main_window.current_job_name}"
@@ -1445,6 +1472,7 @@ def load_job_settings(main_window: "MainWindow", job_data: dict):
             f"An error occurred while loading settings for job:\n{e}",
         )
     finally:
+        _restore_batch_refresh_state(main_window, previous_batch_flag)
         # Allow pending UI events to process before signaling completion
         QtWidgets.QApplication.processEvents()
         # Use the instance event from the job_processor


### PR DESCRIPTION
This commit fixes three issues:
1. Job Output Missing Timestamps

2. Frame Refresh Race Condition During Job Load
3. Fixed-input detectors spammed ONNX warnings when requested size didn't match model expectations
