### PR TITLE
Add face detection pre-scan workflow and frame review tools

### DIFF
--- a/app/helpers/miscellaneous.py
+++ b/app/helpers/miscellaneous.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import cv2
 import time
+from bisect import bisect_left, bisect_right
 from collections import UserDict, OrderedDict
 import hashlib
 import numpy as np
@@ -9,7 +10,7 @@ from functools import wraps
 from datetime import datetime
 from pathlib import Path
 from torchvision.transforms import v2
-from typing import Dict, Mapping, Tuple, Optional, Any
+from typing import Dict, Mapping, Tuple, Optional, Any, Collection, Sequence
 import threading
 import subprocess
 import json
@@ -252,6 +253,90 @@ def copy_mapping_data(value: object) -> dict[str, Any]:
     if isinstance(value, Mapping):
         return dict(value)
     return {}
+
+
+def is_detected_face_eligible_for_matching(
+    kps: np.ndarray | None,
+    bbox: np.ndarray | None,
+    min_face_pixels: int,
+) -> bool:
+    """Return True when a detected face is valid enough for matching.
+
+    This mirrors the standard frame-worker gate used before recognition and
+    matching: keypoints must exist and be finite, and the shortest bbox side
+    must meet the minimum face-size threshold.
+    """
+    if kps is None or kps.size == 0:
+        return False
+    if np.any(np.isnan(kps)) or np.any(np.isinf(kps)):
+        return False
+    if bbox is None or bbox.size < 4:
+        return False
+
+    shortest_side = min(float(bbox[2] - bbox[0]), float(bbox[3] - bbox[1]))
+    return shortest_side >= float(min_face_pixels)
+
+
+def find_best_target_match(
+    detected_embedding: np.ndarray,
+    models_processor: Any,
+    target_faces: Mapping[object, Any],
+    face_parameters: Mapping[str, object],
+    default_params: Mapping[str, Any],
+    recognition_model: str,
+) -> tuple[Any | None, ParametersDict | None, float]:
+    """Return the best matching target face for a detected embedding.
+
+    The caller supplies the current face-parameter mapping and default params so
+    this helper can apply the same per-face threshold logic everywhere it is
+    used, including playback/render and issue scans.
+    """
+    best_target = None
+    best_params_pd = None
+    highest_sim = -1.0
+    default_params_dict = dict(default_params)
+
+    for target_id, target_face in target_faces.items():
+        face_id_str = str(getattr(target_face, "face_id", target_id))
+        face_specific_params = copy_mapping_data(face_parameters.get(face_id_str))
+        current_params_pd = ParametersDict(face_specific_params, default_params_dict)
+        target_embedding = target_face.get_embedding(recognition_model)
+        if not isinstance(target_embedding, np.ndarray) or target_embedding.size == 0:
+            continue
+
+        sim = models_processor.findCosineDistance(detected_embedding, target_embedding)
+        if sim >= current_params_pd["SimilarityThresholdSlider"] and sim > highest_sim:
+            highest_sim = sim
+            best_target = target_face
+            best_params_pd = current_params_pd
+
+    return best_target, best_params_pd, highest_sim
+
+
+def count_issue_scan_frames(
+    scan_ranges: Sequence[tuple[int, int]],
+    dropped_frames: Collection[int],
+) -> int:
+    """Count scan frames after excluding dropped render frames.
+
+    This keeps issue-scan progress and summary stats aligned with the frames that
+    render/output will actually keep.
+    """
+    normalized_dropped = sorted({int(frame) for frame in dropped_frames})
+    total_frames = 0
+
+    for start_frame, end_frame in scan_ranges:
+        normalized_start = int(start_frame)
+        normalized_end = int(end_frame)
+        if normalized_end < normalized_start:
+            continue
+
+        dropped_in_range = bisect_right(
+            normalized_dropped, normalized_end
+        ) - bisect_left(normalized_dropped, normalized_start)
+        total_frames += (normalized_end - normalized_start + 1) - dropped_in_range
+
+    return total_frames
 
 
 # --- Function Definitions ---

--- a/app/helpers/miscellaneous.py
+++ b/app/helpers/miscellaneous.py
@@ -243,6 +243,17 @@ class ParametersDict(UserDict):
             return self._default_parameters[key]
 
 
+def copy_mapping_data(value: object) -> dict[str, Any]:
+    """Return a plain dict copy when *value* is any mapping-like object.
+
+    This preserves `ParametersDict` and other `Mapping` subclasses while keeping
+    non-mapping inputs on a safe empty-dict fallback.
+    """
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
 # --- Function Definitions ---
 
 

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -2554,7 +2554,12 @@ class VideoProcessor(QObject):
             raise RuntimeError("Could not open the selected video for scanning.")
 
         scan_ranges = scan_ranges or self._get_issue_scan_ranges()
-        total_frames = sum((end - start + 1) for start, end in scan_ranges)
+        dropped_frames_snapshot = {
+            int(frame) for frame in getattr(self.main_window, "dropped_frames", set())
+        }
+        total_frames = misc_helpers.count_issue_scan_frames(
+            scan_ranges, dropped_frames_snapshot
+        )
         target_height = (
             target_height
             if target_height is not None
@@ -2588,6 +2593,10 @@ class VideoProcessor(QObject):
                 for frame_number in range(start_frame, end_frame + 1):
                     if is_cancelled and is_cancelled():
                         return None
+                    if frame_number in dropped_frames_snapshot:
+                        self.current_frame_number = frame_number + 1
+                        misc_helpers.seek_frame(capture, self.current_frame_number)
+                        continue
                     ret, frame_bgr = misc_helpers.read_frame(
                         capture,
                         self.media_rotation,
@@ -2623,6 +2632,7 @@ class VideoProcessor(QObject):
                         and isinstance(kpss_5, numpy.ndarray)
                         and kpss_5.shape[0] > 0
                     ):
+                        max_faces = min(bboxes.shape[0], kpss_5.shape[0])
                         frame_tensor = (
                             torch.from_numpy(frame_rgb.astype("uint8"))
                             .to(self.main_window.models_processor.device)
@@ -2636,7 +2646,15 @@ class VideoProcessor(QObject):
                         similarity_type = local_control.get(
                             "SimilarityTypeSelection", "Opal"
                         )
-                        for face_kps in kpss_5:
+                        for face_index in range(max_faces):
+                            face_kps = kpss_5[face_index]
+                            face_bbox = bboxes[face_index]
+                            if not misc_helpers.is_detected_face_eligible_for_matching(
+                                face_kps,
+                                face_bbox,
+                                FrameWorker._MIN_FACE_PIXELS,
+                            ):
+                                continue
                             face_emb, _ = (
                                 self.main_window.models_processor.run_recognize_direct(
                                     frame_tensor,
@@ -2659,38 +2677,16 @@ class VideoProcessor(QObject):
                     default_params = dict(self.main_window.default_parameters.data)
 
                     for detected_embedding in detected_embeddings:
-                        best_face_id = None
-                        best_score = -1.0
-                        for face_id, target_face in target_faces_snapshot.items():
-                            face_id_str = str(face_id)
-                            face_params_raw = local_params.get(face_id_str)
-                            face_params_mapping = misc_helpers.copy_mapping_data(
-                                face_params_raw
-                            )
-                            face_params_pd = misc_helpers.ParametersDict(
-                                face_params_mapping, default_params
-                            )
-                            target_embedding = target_face.get_embedding(
-                                recognition_model
-                            )
-                            if not (
-                                isinstance(target_embedding, numpy.ndarray)
-                                and target_embedding.size > 0
-                            ):
-                                continue
-                            score = (
-                                self.main_window.models_processor.findCosineDistance(
-                                    detected_embedding, target_embedding
-                                )
-                            )
-                            if (
-                                score >= face_params_pd["SimilarityThresholdSlider"]
-                                and score > best_score
-                            ):
-                                best_score = score
-                                best_face_id = face_id_str
-                        if best_face_id is not None:
-                            matched_face_ids.add(best_face_id)
+                        best_target, _, _ = misc_helpers.find_best_target_match(
+                            detected_embedding,
+                            self.main_window.models_processor,
+                            target_faces_snapshot,
+                            local_params,
+                            default_params,
+                            recognition_model,
+                        )
+                        if best_target is not None:
+                            matched_face_ids.add(str(best_target.face_id))
 
                     for face_id in issue_frames_by_face:
                         if face_id not in matched_face_ids:

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -2664,10 +2664,8 @@ class VideoProcessor(QObject):
                         for face_id, target_face in target_faces_snapshot.items():
                             face_id_str = str(face_id)
                             face_params_raw = local_params.get(face_id_str)
-                            face_params_mapping = (
-                                dict(face_params_raw)
-                                if isinstance(face_params_raw, dict)
-                                else cast(dict[str, object], {})
+                            face_params_mapping = misc_helpers.copy_mapping_data(
+                                face_params_raw
                             )
                             face_params_pd = misc_helpers.ParametersDict(
                                 face_params_mapping, default_params

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -29,7 +29,11 @@ from app.ui.widgets.actions import list_view_actions
 from app.ui.widgets.actions import save_load_actions
 from app.ui.widgets.settings_layout_data import CAMERA_BACKENDS
 import app.helpers.miscellaneous as misc_helpers
-from app.helpers.typing_helper import ControlTypes, FacesParametersTypes
+from app.helpers.typing_helper import (
+    ControlTypes,
+    FacesParametersTypes,
+    ParametersTypes,
+)
 
 if TYPE_CHECKING:
     from app.ui.main_ui import MainWindow
@@ -739,6 +743,17 @@ class VideoProcessor(QObject):
                 )
                 if in_flight_frames >= self.max_display_buffer_size:
                     time.sleep(0.005)  # Wait 5ms (buffer full)
+                    continue
+
+                if (
+                    is_segment_mode or self.recording
+                ) and self.current_frame_number in self.main_window.dropped_frames:
+                    self.skipped_frames.add(self.current_frame_number)
+                    self.total_skipped_frames += 1
+                    self.current_frame_number += 1
+                    misc_helpers.seek_frame(
+                        self.media_capture, self.current_frame_number
+                    )
                     continue
 
                 # 3. Determine Input Resolution (Global Resize)
@@ -2405,6 +2420,309 @@ class VideoProcessor(QObject):
         print(f"[INFO] Identified {len(segments)} continuous frame segment(s)")
 
         return segments
+
+    def _get_issue_scan_ranges(self) -> List[Tuple[int, int]]:
+        """Return the frame ranges that a scan should inspect."""
+        max_frame = int(self.max_frame_number)
+        complete_segments: List[Tuple[int, int]] = []
+        open_start_frame: Optional[int] = None
+
+        for start_frame, end_frame in self.main_window.job_marker_pairs:
+            if start_frame is None:
+                continue
+            normalized_start = int(start_frame)
+            if end_frame is None:
+                open_start_frame = normalized_start
+                continue
+
+            normalized_end = int(end_frame)
+            if normalized_end >= normalized_start:
+                complete_segments.append((normalized_start, normalized_end))
+
+        scan_ranges = sorted(complete_segments)
+        if open_start_frame is not None and open_start_frame <= max_frame:
+            scan_ranges.append((open_start_frame, max_frame))
+
+        if scan_ranges:
+            return scan_ranges
+
+        return [(0, max_frame)]
+
+    def describe_issue_scan_scope(
+        self, scan_ranges: Optional[List[Tuple[int, int]]] = None
+    ) -> str:
+        """Return a short human-readable description of the current scan scope."""
+        scan_ranges = scan_ranges or self._get_issue_scan_ranges()
+
+        complete_segments = 0
+        open_start_frame: Optional[int] = None
+        for start_frame, end_frame in self.main_window.job_marker_pairs:
+            if start_frame is None:
+                continue
+            if end_frame is None:
+                open_start_frame = int(start_frame)
+            elif int(end_frame) >= int(start_frame):
+                complete_segments += 1
+
+        if complete_segments and open_start_frame is not None:
+            range_label = "range" if complete_segments == 1 else "ranges"
+            return (
+                f"Scanning {complete_segments} marked {range_label} "
+                f"and record start frame {open_start_frame} to end"
+            )
+        if complete_segments:
+            range_label = "range" if complete_segments == 1 else "ranges"
+            return f"Scanning {complete_segments} marked {range_label}"
+        if open_start_frame is not None:
+            return f"Scanning from record start frame {open_start_frame}"
+        return "Scanning full clip"
+
+    @staticmethod
+    def _compute_longest_issue_run(issue_frames: list[int]) -> int:
+        longest_issue_run = 0
+        current_run = 0
+        previous_frame = None
+        for frame_number in sorted(set(issue_frames)):
+            if previous_frame is not None and frame_number == previous_frame + 1:
+                current_run += 1
+            else:
+                current_run = 1
+            longest_issue_run = max(longest_issue_run, current_run)
+            previous_frame = frame_number
+        return longest_issue_run
+
+    def _resolve_scan_state_for_frame(
+        self,
+        frame_number: int,
+        base_control: ControlTypes,
+        base_params: FacesParametersTypes,
+        target_faces_snapshot: Optional[dict] = None,
+    ) -> tuple[ControlTypes, FacesParametersTypes]:
+        """Resolve the effective control/parameter state for a scan frame.
+
+        This mirrors playback/render marker semantics: if a marker exists at or
+        before the frame, its parameter/control payload becomes the active state
+        for that frame; otherwise the scan-start state remains active.
+        """
+        marker_data = video_control_actions._get_marker_data_for_position(  # type: ignore[attr-defined]
+            self.main_window, frame_number
+        )
+        if not marker_data:
+            return (
+                cast(ControlTypes, copy.deepcopy(base_control)),
+                cast(FacesParametersTypes, copy.deepcopy(base_params)),
+            )
+
+        local_params = cast(
+            FacesParametersTypes, copy.deepcopy(marker_data.get("parameters", {}))
+        )
+        local_control: ControlTypes = cast(ControlTypes, {})
+        for widget_name, widget in self.main_window.parameter_widgets.items():
+            if widget_name in self.main_window.control:
+                local_control[widget_name] = widget.default_value
+
+        control_data = marker_data.get("control")
+        if isinstance(control_data, dict):
+            local_control.update(cast(ControlTypes, control_data).copy())
+
+        # Mirror the playback helper behavior by ensuring every current target
+        # face has a parameter dict, falling back to defaults when missing.
+        for face_id in (target_faces_snapshot or self.main_window.target_faces).keys():
+            face_id_str = str(face_id)
+            if face_id_str not in local_params:
+                local_params[face_id_str] = cast(
+                    ParametersTypes,
+                    copy.deepcopy(self.main_window.default_parameters.data),
+                )
+
+        return local_control, local_params
+
+    def scan_issue_frames(
+        self,
+        progress_callback=None,
+        is_cancelled=None,
+        scan_ranges: Optional[List[Tuple[int, int]]] = None,
+        target_height: Optional[int] = None,
+        base_control: Optional[dict] = None,
+        base_params: Optional[dict] = None,
+        target_faces_snapshot: Optional[dict] = None,
+        reset_frame_number: Optional[int] = None,
+    ) -> Optional[dict]:
+        """Run a full-frame detection scan and return issue-frame results."""
+        capture = cv2.VideoCapture(self.media_path)
+        if not capture or not capture.isOpened():
+            raise RuntimeError("Could not open the selected video for scanning.")
+
+        scan_ranges = scan_ranges or self._get_issue_scan_ranges()
+        total_frames = sum((end - start + 1) for start, end in scan_ranges)
+        target_height = (
+            target_height
+            if target_height is not None
+            else self._get_target_input_height()
+        )
+        base_control = cast(
+            ControlTypes, copy.deepcopy(base_control or self.main_window.control)
+        )
+        base_params = cast(
+            FacesParametersTypes,
+            copy.deepcopy(base_params or self.main_window.parameters),
+        )
+        target_faces_snapshot = dict(
+            target_faces_snapshot or self.main_window.target_faces
+        )
+        previous_last_detected_faces = copy.deepcopy(self.last_detected_faces)
+        previous_smoothed_kps = copy.deepcopy(self._smoothed_kps)
+        total_frames_scanned = 0
+        issue_frames_by_face: dict[str, set[int]] = {
+            str(face_id): set() for face_id in target_faces_snapshot.keys()
+        }
+
+        try:
+            self.last_detected_faces = []
+            self._smoothed_kps = {}
+
+            for start_frame, end_frame in scan_ranges:
+                misc_helpers.seek_frame(capture, start_frame)
+                self.current_frame_number = start_frame
+
+                for frame_number in range(start_frame, end_frame + 1):
+                    if is_cancelled and is_cancelled():
+                        return None
+                    ret, frame_bgr = misc_helpers.read_frame(
+                        capture,
+                        self.media_rotation,
+                        preview_target_height=target_height,
+                    )
+                    if not ret or not isinstance(frame_bgr, numpy.ndarray):
+                        for face_id in issue_frames_by_face:
+                            issue_frames_by_face[face_id].add(frame_number)
+                        self.current_frame_number = frame_number + 1
+                        misc_helpers.seek_frame(capture, self.current_frame_number)
+                        total_frames_scanned += 1
+                        if progress_callback:
+                            progress_callback(
+                                total_frames_scanned, total_frames, frame_number
+                            )
+                        continue
+
+                    frame_rgb = numpy.ascontiguousarray(frame_bgr[..., ::-1])
+                    local_control, local_params = self._resolve_scan_state_for_frame(
+                        frame_number,
+                        base_control,
+                        base_params,
+                        target_faces_snapshot,
+                    )
+                    self.current_frame_number = frame_number
+                    bboxes, kpss_5, _ = self._run_sequential_detection(
+                        frame_rgb, local_control, local_params
+                    )
+                    detected_embeddings: list[numpy.ndarray] = []
+                    if (
+                        isinstance(bboxes, numpy.ndarray)
+                        and bboxes.shape[0] > 0
+                        and isinstance(kpss_5, numpy.ndarray)
+                        and kpss_5.shape[0] > 0
+                    ):
+                        frame_tensor = (
+                            torch.from_numpy(frame_rgb.astype("uint8"))
+                            .to(self.main_window.models_processor.device)
+                            .permute(2, 0, 1)
+                        )
+                        recognition_model = str(
+                            local_control.get(
+                                "RecognitionModelSelection", "arcface_128"
+                            )
+                        )
+                        similarity_type = local_control.get(
+                            "SimilarityTypeSelection", "Opal"
+                        )
+                        for face_kps in kpss_5:
+                            face_emb, _ = (
+                                self.main_window.models_processor.run_recognize_direct(
+                                    frame_tensor,
+                                    face_kps,
+                                    similarity_type,
+                                    recognition_model,
+                                )
+                            )
+                            if (
+                                isinstance(face_emb, numpy.ndarray)
+                                and face_emb.size > 0
+                            ):
+                                detected_embeddings.append(face_emb)
+                        del frame_tensor
+
+                    matched_face_ids: set[str] = set()
+                    recognition_model = str(
+                        local_control.get("RecognitionModelSelection", "arcface_128")
+                    )
+                    default_params = dict(self.main_window.default_parameters.data)
+
+                    for detected_embedding in detected_embeddings:
+                        best_face_id = None
+                        best_score = -1.0
+                        for face_id, target_face in target_faces_snapshot.items():
+                            face_id_str = str(face_id)
+                            face_params_raw = local_params.get(face_id_str)
+                            face_params_mapping = (
+                                dict(face_params_raw)
+                                if isinstance(face_params_raw, dict)
+                                else cast(dict[str, object], {})
+                            )
+                            face_params_pd = misc_helpers.ParametersDict(
+                                face_params_mapping, default_params
+                            )
+                            target_embedding = target_face.get_embedding(
+                                recognition_model
+                            )
+                            if not (
+                                isinstance(target_embedding, numpy.ndarray)
+                                and target_embedding.size > 0
+                            ):
+                                continue
+                            score = (
+                                self.main_window.models_processor.findCosineDistance(
+                                    detected_embedding, target_embedding
+                                )
+                            )
+                            if (
+                                score >= face_params_pd["SimilarityThresholdSlider"]
+                                and score > best_score
+                            ):
+                                best_score = score
+                                best_face_id = face_id_str
+                        if best_face_id is not None:
+                            matched_face_ids.add(best_face_id)
+
+                    for face_id in issue_frames_by_face:
+                        if face_id not in matched_face_ids:
+                            issue_frames_by_face[face_id].add(frame_number)
+                    total_frames_scanned += 1
+                    if progress_callback:
+                        progress_callback(
+                            total_frames_scanned, total_frames, frame_number
+                        )
+
+            faces_with_issues = sum(
+                1 for frames in issue_frames_by_face.values() if frames
+            )
+            return {
+                "issue_frames_by_face": {
+                    face_id: sorted(frames)
+                    for face_id, frames in issue_frames_by_face.items()
+                },
+                "frames_scanned": total_frames_scanned,
+                "faces_with_issues": faces_with_issues,
+            }
+        finally:
+            self.last_detected_faces = previous_last_detected_faces
+            self._smoothed_kps = previous_smoothed_kps
+            self.current_frame_number = (
+                reset_frame_number
+                if reset_frame_number is not None
+                else int(self.main_window.videoSeekSlider.value())
+            )
+            misc_helpers.release_capture(capture)
 
     def _extract_audio_segments(
         self, segments: List[Tuple[int, int]], temp_audio_dir: str

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -22,9 +22,11 @@ from app.processors.utils import faceutil
 
 from app.helpers.miscellaneous import (
     ParametersDict,
+    find_best_target_match,
     get_scaling_transforms,
     draw_bounding_boxes_on_detected_faces,
     paint_landmarks_on_image,
+    is_detected_face_eligible_for_matching,
     keypoints_adjustments,
     get_grid_for_pasting,
 )
@@ -539,46 +541,25 @@ class FrameWorker(threading.Thread):
                 taken under self.lock.  If None, falls back to reading the live dict
                 (single-frame / legacy callers).
         """
-        best_target_button = None
-        best_params_pd = None
-        highest_sim = -1.0
-
         # FW-RACE-01: use the snapshot when available; otherwise fall back to live dict.
         if target_faces_snapshot is not None:
-            faces_to_iterate = list(target_faces_snapshot.items())
+            faces_to_iterate = dict(target_faces_snapshot)
         else:
             with self.lock:
-                faces_to_iterate = list(self.main_window.target_faces.items())
+                faces_to_iterate = dict(self.main_window.target_faces)
 
         # FW-RACE-05: snapshot default_parameters under lock once
         with self.lock:
             default_params_dict = dict(self.main_window.default_parameters.data)
 
-        for target_id, target_button_widget in faces_to_iterate:
-            face_specific_params_dict: dict = cast(
-                dict, self.parameters.get(target_id, {})
-            )
-
-            current_params_pd = ParametersDict(
-                dict(face_specific_params_dict), cast(dict, default_params_dict)
-            )
-            target_embedding_np = target_button_widget.get_embedding(
-                control_global["RecognitionModelSelection"]
-            )
-            if target_embedding_np is None:
-                continue
-            sim = self.models_processor.findCosineDistance(
-                detected_embedding_np, target_embedding_np
-            )
-
-            if (
-                sim >= current_params_pd["SimilarityThresholdSlider"]
-                and sim > highest_sim
-            ):
-                highest_sim = sim
-                best_target_button = target_button_widget
-                best_params_pd = current_params_pd
-        return best_target_button, best_params_pd, highest_sim
+        return find_best_target_match(
+            detected_embedding_np,
+            self.models_processor,
+            faces_to_iterate,
+            self.parameters,
+            cast(dict, default_params_dict),
+            str(control_global["RecognitionModelSelection"]),
+        )
 
     def _process_single_vr_perspective_crop_multi(
         self,
@@ -2038,9 +2019,6 @@ class FrameWorker(threading.Thread):
                 bypass_bytetrack=True,  # Bypassing ByteTrack to avoid corrupting the global Kalman filter state
             )
 
-        img_h_for_kps = img.shape[-2]
-        img_w_for_kps = img.shape[-1]
-
         if (
             isinstance(kpss_5, np.ndarray)
             and kpss_5.shape[0] > 0
@@ -2048,12 +2026,9 @@ class FrameWorker(threading.Thread):
             and len(kpss_5) > 0
         ):
             for i in range(len(kpss_5)):
-                if not self._is_kps_valid(kpss_5[i], img_h_for_kps, img_w_for_kps):
-                    continue
                 _bbox_i = bboxes[i]
-                if (
-                    min(_bbox_i[2] - _bbox_i[0], _bbox_i[3] - _bbox_i[1])
-                    < self._MIN_FACE_PIXELS
+                if not is_detected_face_eligible_for_matching(
+                    kpss_5[i], _bbox_i, self._MIN_FACE_PIXELS
                 ):
                     continue  # too small to produce meaningful swap
                 face_emb, _ = self.models_processor.run_recognize_direct(

--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -123,6 +123,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self.current_widget_parameters: ParametersTypes = {}
 
         self.markers: MarkerTypes = {}  # Video Markers (Contains parameters for each face)
+        self.issue_frames_by_face: dict[str, set[int]] = {}
+        self.issue_frames: set[int] = set()
+        self.dropped_frames: set[int] = set()
+        self.scan_tools_expanded = False
+        self.scan_issue_worker = None
         self.parameters_list = {}
         self.control: ControlTypes = {}
         self.parameter_widgets: ParametersWidgetTypes = {}
@@ -254,6 +259,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self.previousMarkerButton.clicked.connect(
             partial(video_control_actions.move_slider_to_previous_nearest_marker, self)
         )
+        video_control_actions.add_scan_review_controls(self)
 
         self.viewFullScreenButton.clicked.connect(
             partial(video_control_actions.view_fullscreen, self)
@@ -500,6 +506,18 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         )
         self.build_progress_dialog.setRange(0, 0)  # Indeterminate (busy) mode
         self.build_progress_dialog.close()  # Ensure it's hidden on startup
+
+        self.scan_progress_dialog = QtWidgets.QProgressDialog(self)
+        scan_flags = self.scan_progress_dialog.windowFlags()
+        scan_flags &= ~QtCore.Qt.WindowCloseButtonHint
+        self.scan_progress_dialog.setWindowFlags(scan_flags)
+        self.scan_progress_dialog.setWindowModality(
+            QtCore.Qt.WindowModality.WindowModal
+        )
+        self.scan_progress_dialog.setCancelButtonText("Abort")
+        self.scan_progress_dialog.setAutoClose(False)
+        self.scan_progress_dialog.setAutoReset(False)
+        self.scan_progress_dialog.close()
 
     def update_denoiser_controls_visibility_for_pass(
         self, pass_suffix: str, current_mode_text: str

--- a/app/ui/widgets/actions/card_actions.py
+++ b/app/ui/widgets/actions/card_actions.py
@@ -24,12 +24,23 @@ def clear_target_faces(main_window: "MainWindow", refresh_frame=True):
         target_face.deleteLater()
     main_window.target_faces.clear()
     main_window.parameters.clear()
+    if hasattr(main_window, "issue_frames_by_face"):
+        main_window.issue_frames_by_face.clear()
+    if hasattr(main_window, "issue_frames"):
+        main_window.issue_frames.clear()
+    if hasattr(main_window, "videoSeekSlider"):
+        main_window.videoSeekSlider.issue_markers = set()
+        main_window.videoSeekSlider.issue_markers_sorted = []
+        main_window.videoSeekSlider.update()
 
     main_window.selected_target_face_id = None
     # Set Parameter widget values to default
     common_widget_actions.set_widgets_values_using_face_id_parameters(
         main_window=main_window, face_id=None
     )
+    from app.ui.widgets.actions import video_control_actions
+
+    video_control_actions.update_scan_review_button_states(main_window)
     if refresh_frame:
         common_widget_actions.refresh_frame(main_window=main_window)
 
@@ -229,5 +240,8 @@ def find_target_faces(main_window: "MainWindow"):
     if main_window.video_processor.processing:
         main_window.video_processor.stop_processing()
     common_widget_actions.refresh_frame(main_window)
+    from app.ui.widgets.actions import video_control_actions
+
+    video_control_actions.update_scan_review_button_states(main_window)
 
     common_widget_actions.update_gpu_memory_progressbar(main_window)

--- a/app/ui/widgets/actions/common_actions.py
+++ b/app/ui/widgets/actions/common_actions.py
@@ -54,7 +54,7 @@ def create_and_show_toast_message(
     toast = Toast(main_window)
     toast.setTitle(title)
     toast.setText(message)
-    toast.setDuration(1400)
+    toast.setDuration(10000)
     toast.setPosition(ToastPosition.TOP_RIGHT)  # Default: ToastPosition.BOTTOM_RIGHT
     toast.applyPreset(style_preset_map[style_type])  # Apply style preset
     toast.show()

--- a/app/ui/widgets/actions/job_manager_actions.py
+++ b/app/ui/widgets/actions/job_manager_actions.py
@@ -511,11 +511,35 @@ def _load_job_markers(main_window: "MainWindow", data: dict):
             int(marker_position),
         )
 
+    loaded_issue_frames_by_face = data.get("issue_frames_by_face")
+    if loaded_issue_frames_by_face is not None:
+        video_control_actions.set_issue_frames_by_face(
+            main_window, loaded_issue_frames_by_face
+        )
+    else:
+        selected_face_id = getattr(main_window, "selected_target_face_id", None)
+        if selected_face_id is None and getattr(main_window, "target_faces", {}):
+            selected_face_id = str(next(iter(main_window.target_faces.keys())))
+        if selected_face_id is not None:
+            video_control_actions.set_issue_frames_for_face(
+                main_window, selected_face_id, data.get("issue_frames", [])
+            )
+        else:
+            video_control_actions.set_issue_frames_by_face(main_window, {})
+    video_control_actions.set_dropped_frames(
+        main_window, data.get("dropped_frames", [])
+    )
+
     # Load job marker pairs (segments)
     main_window.job_marker_pairs = data.get("job_marker_pairs", [])
 
     # Update slider visuals to show markers
     main_window.videoSeekSlider.update()
+    video_control_actions.update_drop_frame_button_label(main_window)
+    if hasattr(main_window, "scanToolsToggleButton"):
+        video_control_actions.set_scan_tools_expanded(
+            main_window, data.get("scan_tools_expanded", False)
+        )
 
 
 def _begin_batch_refresh_suppression(main_window: "MainWindow") -> bool:
@@ -1092,6 +1116,12 @@ def _serialize_job_data(main_window: "MainWindow") -> dict:
         "target_faces_data": target_faces_data,
         "control": control_to_save,
         "markers": markers_to_save,
+        "issue_frames_by_face": {
+            str(face_id): sorted(frames)
+            for face_id, frames in main_window.issue_frames_by_face.items()
+        },
+        "dropped_frames": sorted(main_window.dropped_frames),
+        "scan_tools_expanded": getattr(main_window, "scan_tools_expanded", False),
         "job_marker_pairs": copy.deepcopy(main_window.job_marker_pairs),
         "selected_media_id": selected_media_id,
         "swap_faces_enabled": main_window.swapfacesButton.isChecked(),

--- a/app/ui/widgets/actions/layout_actions.py
+++ b/app/ui/widgets/actions/layout_actions.py
@@ -714,6 +714,18 @@ def set_all_parameters_and_control_widgets_enabled(
     main_window.previousMarkerButton.setDisabled(disabled)
     main_window.frameAdvanceButton.setDisabled(disabled)
     main_window.frameRewindButton.setDisabled(disabled)
+    for attr_name in (
+        "scanToolsToggleButton",
+        "runScanButton",
+        "clearScanResultsButton",
+        "prevIssueButton",
+        "nextIssueButton",
+        "dropFrameButton",
+        "dropAllIssueFramesButton",
+        "clearDroppedFramesButton",
+    ):
+        if hasattr(main_window, attr_name):
+            getattr(main_window, attr_name).setDisabled(disabled)
 
     # Compare checkboxes
     main_window.faceCompareCheckBox.setDisabled(disabled)

--- a/app/ui/widgets/actions/save_load_actions.py
+++ b/app/ui/widgets/actions/save_load_actions.py
@@ -418,11 +418,32 @@ def load_saved_workspace(
                     marker_data["control"],
                     int(marker_position),
                 )
+            loaded_issue_frames_by_face = data.get("issue_frames_by_face")
+            if loaded_issue_frames_by_face is not None:
+                video_control_actions.set_issue_frames_by_face(
+                    main_window, loaded_issue_frames_by_face
+                )
+            else:
+                selected_face_id = getattr(main_window, "selected_target_face_id", None)
+                if selected_face_id is None and getattr(
+                    main_window, "target_faces", {}
+                ):
+                    selected_face_id = str(next(iter(main_window.target_faces.keys())))
+                if selected_face_id is not None:
+                    video_control_actions.set_issue_frames_for_face(
+                        main_window, selected_face_id, data.get("issue_frames", [])
+                    )
+                else:
+                    video_control_actions.set_issue_frames_by_face(main_window, {})
+            video_control_actions.set_dropped_frames(
+                main_window, data.get("dropped_frames", [])
+            )
             # main_window.videoSeekSlider.setValue(0)
             # video_control_actions.update_widget_values_from_markers(main_window, 0)
 
             # Update slider visuals after loading markers
             main_window.videoSeekSlider.update()
+            video_control_actions.update_drop_frame_button_label(main_window)
 
             # Set target media and input faces folder names
             main_window.last_target_media_folder_path = data.get(
@@ -538,6 +559,10 @@ def load_saved_workspace(
             main_window.filterWebcamsCheckBox.setChecked(
                 window_state.get("filterWebcamsCheckBox", False)
             )
+            if hasattr(main_window, "scanToolsToggleButton"):
+                video_control_actions.set_scan_tools_expanded(
+                    main_window, window_state.get("scan_tools_expanded", False)
+                )
             filter_actions.filter_target_videos(main_window)
             list_view_actions.load_target_webcams(main_window)
 
@@ -587,6 +612,7 @@ def save_current_workspace(
         "filterImagesCheckBox": main_window.filterImagesCheckBox.isChecked(),
         "filterVideosCheckBox": main_window.filterVideosCheckBox.isChecked(),
         "filterWebcamsCheckBox": main_window.filterWebcamsCheckBox.isChecked(),
+        "scan_tools_expanded": getattr(main_window, "scan_tools_expanded", False),
         "dock_state": dock_state_data,
     }
 
@@ -710,6 +736,11 @@ def save_current_workspace(
         "target_faces_data": target_faces_data,
         "embeddings_data": embeddings_data,
         "markers": markers_to_save,
+        "issue_frames_by_face": {
+            str(face_id): sorted(frames)
+            for face_id, frames in main_window.issue_frames_by_face.items()
+        },
+        "dropped_frames": sorted(main_window.dropped_frames),
         "job_marker_pairs": main_window.job_marker_pairs,  # Save the list of tuples
         "last_target_media_folder_path": main_window.last_target_media_folder_path,
         "last_input_media_folder_path": main_window.last_input_media_folder_path,
@@ -857,8 +888,14 @@ def save_current_job(main_window: "MainWindow"):
         "markers": convert_markers_to_supported_type(
             main_window, copy.deepcopy(main_window.markers), dict
         ),
+        "issue_frames_by_face": {
+            str(face_id): sorted(frames)
+            for face_id, frames in main_window.issue_frames_by_face.items()
+        },
+        "dropped_frames": sorted(main_window.dropped_frames),
         "control": main_window.control.copy(),
         "job_marker_pairs": main_window.job_marker_pairs,
+        "scan_tools_expanded": getattr(main_window, "scan_tools_expanded", False),
         "current_widget_parameters": main_window.current_widget_parameters.data.copy()
         if isinstance(
             main_window.current_widget_parameters, misc_helpers.ParametersDict

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, cast
 import copy
 from functools import partial
 import os
+from pathlib import Path
 import traceback
 
 from PySide6.QtCore import QPoint
@@ -23,6 +24,7 @@ from app.ui.widgets.actions import graphics_view_actions
 import app.ui.widgets.actions.layout_actions as layout_actions
 from app.ui.widgets.actions import card_actions
 from app.ui.widgets import widget_components
+from app.ui.widgets import ui_workers
 
 
 def set_up_video_seek_line_edit(main_window: "MainWindow"):
@@ -44,9 +46,13 @@ def set_up_video_seek_slider(main_window: "MainWindow"):
     """
     main_window.videoSeekSlider.markers = set()  # Store unique tick positions
     main_window.videoSeekSlider.markers_sorted = []  # Sorted list for iteration in paintEvent
+    main_window.videoSeekSlider.issue_markers = set()
+    main_window.videoSeekSlider.issue_markers_sorted = []
+    main_window.videoSeekSlider.dropped_markers = set()
+    main_window.videoSeekSlider.dropped_markers_sorted = []
     main_window.videoSeekSlider.setTickPosition(
         QtWidgets.QSlider.TickPosition.TicksBelow
-    )  # Default position for tick marks
+    )
 
     def add_marker_and_paint(self: QtWidgets.QSlider, value=None):
         """Add a tick mark at a specific slider value."""
@@ -67,6 +73,56 @@ def set_up_video_seek_slider(main_window: "MainWindow"):
             self.markers.remove(value)
             if value in self.markers_sorted:
                 self.markers_sorted.remove(value)
+            self.update()
+
+    def _add_sorted_marker(
+        marker_set: set[int], marker_list: list[int], value: int
+    ) -> bool:
+        if value not in marker_set:
+            marker_set.add(value)
+            marker_list.append(value)
+            marker_list.sort()
+            return True
+        return False
+
+    def _remove_sorted_marker(
+        marker_set: set[int], marker_list: list[int], value: int
+    ) -> bool:
+        if value in marker_set:
+            marker_set.remove(value)
+            if value in marker_list:
+                marker_list.remove(value)
+            return True
+        return False
+
+    def add_issue_marker_and_paint(self: QtWidgets.QSlider, value=None):
+        if value is None or isinstance(value, bool):
+            value = self.value()
+        if self.minimum() <= value <= self.maximum() and _add_sorted_marker(
+            self.issue_markers, self.issue_markers_sorted, value
+        ):
+            self.update()
+
+    def remove_issue_marker_and_paint(self: QtWidgets.QSlider, value=None):
+        if value is None or isinstance(value, bool):
+            value = self.value()
+        if _remove_sorted_marker(self.issue_markers, self.issue_markers_sorted, value):
+            self.update()
+
+    def add_dropped_marker_and_paint(self: QtWidgets.QSlider, value=None):
+        if value is None or isinstance(value, bool):
+            value = self.value()
+        if self.minimum() <= value <= self.maximum() and _add_sorted_marker(
+            self.dropped_markers, self.dropped_markers_sorted, value
+        ):
+            self.update()
+
+    def remove_dropped_marker_and_paint(self: QtWidgets.QSlider, value=None):
+        if value is None or isinstance(value, bool):
+            value = self.value()
+        if _remove_sorted_marker(
+            self.dropped_markers, self.dropped_markers_sorted, value
+        ):
             self.update()
 
     def paintEvent(self: QtWidgets.QSlider, event: QtGui.QPaintEvent):
@@ -123,61 +179,79 @@ def set_up_video_seek_slider(main_window: "MainWindow"):
         painter.setBrush(QtGui.QBrush(QtGui.QColor("white")))  # Handle fill color
         painter.drawRect(handle_rect)
 
-        # Draw markers (if any)
+        def marker_x_for_value(value: int) -> float:
+            marker_normalized_value = (value - self.minimum()) / (
+                self.maximum() - self.minimum()
+            )
+            return groove_start + marker_normalized_value * groove_width
+
+        # Draw issue markers underneath saved markers.
+        if self.issue_markers:
+            issue_pen = QtGui.QPen(QtGui.QColor("#ff9800"), 3)
+            issue_pen.setCapStyle(QtCore.Qt.PenCapStyle.SquareCap)
+            painter.setPen(issue_pen)
+            issue_top = groove_y - 2
+            issue_bottom = groove_y + 2
+            for value in self.issue_markers_sorted:
+                if value in self.dropped_markers:
+                    continue
+                marker_x = marker_x_for_value(value)
+                painter.drawLine(marker_x, issue_top, marker_x, issue_bottom)
+
+        # Draw standard markers (if any)
         if self.markers:
             painter.setPen(
                 QtGui.QPen(QtGui.QColor("#4090a3"), 3)
             )  # Marker color and thickness
             for value in self.markers_sorted:
-                # Calculate marker position
-                marker_normalized_value = (value - self.minimum()) / (
-                    self.maximum() - self.minimum()
-                )
-                marker_x = groove_start + marker_normalized_value * groove_width
+                marker_x = marker_x_for_value(value)
                 painter.drawLine(
                     marker_x, groove_rect.top(), marker_x, groove_rect.bottom()
                 )
+
+        # Draw dropped markers above all frame markers.
+        if self.dropped_markers:
+            painter.setPen(QtGui.QPen(QtGui.QColor("#e8483c"), 3))
+            for value in self.dropped_markers_sorted:
+                marker_x = marker_x_for_value(value)
+                painter.drawLine(
+                    marker_x, groove_rect.top(), marker_x, groove_rect.bottom()
+                )
+
         # Draw Job Start/End Brackets on the groove line
-        painter.setFont(
-            QtGui.QFont("Arial", 16, QtGui.QFont.Bold)
-        )  # Increased font size from 12 to 16
+        painter.setFont(QtGui.QFont("Arial", 16, QtGui.QFont.Bold))
         font_metrics = painter.fontMetrics()
         bracket_height = font_metrics.height()
         bracket_y_pos = groove_y + (bracket_height // 4)
 
-        # Iterate through all defined job marker pairs
         for start_frame, end_frame in main_window.job_marker_pairs:
             if start_frame is not None:
-                start_normalized_value = (start_frame - self.minimum()) / (
-                    self.maximum() - self.minimum()
-                )
-                start_x = groove_start + start_normalized_value * groove_width
-                # Draw the green start bracket
-                painter.setPen(
-                    QtGui.QPen(QtGui.QColor("#4CAF50"), 1)
-                )  # Green for start bracket
-                painter.drawText(
-                    int(start_x - 4), int(bracket_y_pos), "["
-                )  # Adjusted X offset slightly
+                start_x = marker_x_for_value(int(start_frame))
+                painter.setPen(QtGui.QPen(QtGui.QColor("#4CAF50"), 1))
+                painter.drawText(int(start_x - 4), int(bracket_y_pos), "[")
 
             if end_frame is not None:
-                end_normalized_value = (end_frame - self.minimum()) / (
-                    self.maximum() - self.minimum()
-                )
-                end_x = groove_start + end_normalized_value * groove_width
-                # Draw the red end bracket
-                painter.setPen(
-                    QtGui.QPen(QtGui.QColor("#e8483c"), 1)
-                )  # Red for end bracket
-                painter.drawText(
-                    int(end_x - 4), int(bracket_y_pos), "]"
-                )  # Adjusted X offset slightly
+                end_x = marker_x_for_value(int(end_frame))
+                painter.setPen(QtGui.QPen(QtGui.QColor("#e8483c"), 1))
+                painter.drawText(int(end_x - 4), int(bracket_y_pos), "]")
 
     main_window.videoSeekSlider.add_marker_and_paint = partial(
         add_marker_and_paint, main_window.videoSeekSlider
     )
     main_window.videoSeekSlider.remove_marker_and_paint = partial(
         remove_marker_and_paint, main_window.videoSeekSlider
+    )
+    main_window.videoSeekSlider.add_issue_marker_and_paint = partial(
+        add_issue_marker_and_paint, main_window.videoSeekSlider
+    )
+    main_window.videoSeekSlider.remove_issue_marker_and_paint = partial(
+        remove_issue_marker_and_paint, main_window.videoSeekSlider
+    )
+    main_window.videoSeekSlider.add_dropped_marker_and_paint = partial(
+        add_dropped_marker_and_paint, main_window.videoSeekSlider
+    )
+    main_window.videoSeekSlider.remove_dropped_marker_and_paint = partial(
+        remove_dropped_marker_and_paint, main_window.videoSeekSlider
     )
     main_window.videoSeekSlider.paintEvent = partial(
         paintEvent, main_window.videoSeekSlider
@@ -458,6 +532,520 @@ def move_slider_to_previous_nearest_marker(main_window: "MainWindow"):
     move_slider_to_nearest_marker(main_window, "previous")
 
 
+def add_scan_review_controls(main_window: "MainWindow"):
+    """Creates a collapsible second row of scan/review controls."""
+    if hasattr(main_window, "scanToolsToggleButton"):
+        return
+
+    def create_divider(parent, height: int = 16, margin: int = 12):
+        divider_container = QtWidgets.QWidget(parent)
+        divider_layout = QtWidgets.QHBoxLayout(divider_container)
+        divider_layout.setContentsMargins(margin, 0, margin, 0)
+        divider_layout.setSpacing(0)
+        divider = QtWidgets.QFrame(divider_container)
+        divider.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+        divider.setFrameShadow(QtWidgets.QFrame.Shadow.Plain)
+        divider.setLineWidth(1)
+        divider.setMidLineWidth(0)
+        divider.setFixedHeight(height)
+        divider.setStyleSheet("color: rgba(180, 180, 180, 110);")
+        divider_layout.addWidget(divider)
+        return divider_container
+
+    toggle_button = QtWidgets.QPushButton("Scan Tools")
+    toggle_button.setCheckable(True)
+    toggle_button.setChecked(False)
+    toggle_button.setFlat(True)
+    toggle_button.setToolTip("Show or hide the scan tools.")
+    toggle_button.clicked.connect(
+        lambda checked: set_scan_tools_expanded(main_window, checked)
+    )
+    main_window.scanToolsToggleButton = toggle_button
+    media_layout = main_window.horizontalLayoutMediaButtons
+    media_layout.addWidget(toggle_button)
+
+    section = QtWidgets.QWidget(main_window)
+    section_layout = QtWidgets.QVBoxLayout(section)
+    section_layout.setContentsMargins(0, 0, 0, 0)
+    section_layout.setSpacing(4)
+
+    container = QtWidgets.QWidget(section)
+    container_layout = QtWidgets.QHBoxLayout(container)
+    container_layout.setContentsMargins(0, 0, 0, 0)
+    container_layout.setSpacing(6)
+    main_window.scanControlsLayout = container_layout
+    main_window.scanControlsContainer = container
+    left_group = QtWidgets.QWidget(container)
+    left_layout = QtWidgets.QHBoxLayout(left_group)
+    left_layout.setContentsMargins(0, 0, 0, 0)
+    left_layout.setSpacing(6)
+    navigation_group = QtWidgets.QWidget(container)
+    navigation_layout = QtWidgets.QHBoxLayout(navigation_group)
+    navigation_layout.setContentsMargins(0, 0, 0, 0)
+    navigation_layout.setSpacing(6)
+    frame_group = QtWidgets.QWidget(container)
+    frame_layout = QtWidgets.QHBoxLayout(frame_group)
+    frame_layout.setContentsMargins(0, 0, 0, 0)
+    frame_layout.setSpacing(6)
+    cleanup_group = QtWidgets.QWidget(container)
+    cleanup_layout = QtWidgets.QHBoxLayout(cleanup_group)
+    cleanup_layout.setContentsMargins(0, 0, 0, 0)
+    cleanup_layout.setSpacing(6)
+    main_window.scanControlsLeftGroup = left_group
+    main_window.scanControlsNavigationGroup = navigation_group
+    main_window.scanControlsFrameGroup = frame_group
+    main_window.scanControlsCleanupGroup = cleanup_group
+
+    run_scan_button = QtWidgets.QPushButton("Scan for Issues")
+    run_scan_button.setToolTip(
+        "Scans the current render range using your current settings.\n"
+        "If record markers exist, only those ranges are scanned.\n"
+        "Saved settings markers are applied during the scan.\n"
+        "Flags likely issue frames for the selected target face.\n"
+        "Single-frame preview may differ from playback on borderline frames."
+    )
+    run_scan_button.setFlat(True)
+    run_scan_button.setSizePolicy(
+        QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
+    )
+    run_scan_button.clicked.connect(lambda: run_issue_scan(main_window))
+    main_window.runScanButton = run_scan_button
+
+    button_specs = [
+        (
+            "prevIssueButton",
+            "Prev Issue",
+            "Move to the previous issue frame for the selected target face.",
+            lambda: move_slider_to_previous_issue(main_window),
+            "navigation",
+        ),
+        (
+            "nextIssueButton",
+            "Next Issue",
+            "Move to the next issue frame for the selected target face.",
+            lambda: move_slider_to_next_issue(main_window),
+            "navigation",
+        ),
+        (
+            "dropFrameButton",
+            "Drop Frame",
+            "Drops the current frame from render output.",
+            lambda: toggle_drop_frame(main_window),
+            "frame",
+        ),
+        (
+            "dropAllIssueFramesButton",
+            "Drop Issue Frames",
+            "Marks the selected target face's issue frames as dropped.\n"
+            "Dropped frames are excluded from render output.",
+            lambda: drop_all_issue_frames(main_window),
+            "frame",
+        ),
+        (
+            "clearScanResultsButton",
+            "Clear Issues",
+            "Removes the current scan issue markers.\nDoes not affect dropped frames.",
+            lambda: clear_scan_results(main_window),
+            "cleanup",
+        ),
+        (
+            "clearDroppedFramesButton",
+            "Restore Dropped",
+            "Restores all dropped frames to render output.",
+            lambda: clear_dropped_frames(main_window),
+            "cleanup",
+        ),
+    ]
+
+    left_layout.addWidget(run_scan_button)
+
+    for attr_name, text, tooltip, handler, group_name in button_specs:
+        button = QtWidgets.QPushButton(text)
+        button.setToolTip(tooltip)
+        button.setFlat(True)
+        button.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
+        )
+        button.clicked.connect(handler)
+        setattr(main_window, attr_name, button)
+        if group_name == "left":
+            target_layout = left_layout
+        elif group_name == "navigation":
+            target_layout = navigation_layout
+        elif group_name == "frame":
+            target_layout = frame_layout
+        else:
+            target_layout = cleanup_layout
+        target_layout.addWidget(button)
+
+    container_layout.addStretch(1)
+    container_layout.addWidget(left_group, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
+    container_layout.addWidget(create_divider(container))
+    container_layout.addWidget(
+        navigation_group, 0, QtCore.Qt.AlignmentFlag.AlignHCenter
+    )
+    container_layout.addWidget(create_divider(container))
+    container_layout.addWidget(frame_group, 0, QtCore.Qt.AlignmentFlag.AlignHCenter)
+    container_layout.addWidget(create_divider(container))
+    container_layout.addWidget(cleanup_group, 0, QtCore.Qt.AlignmentFlag.AlignRight)
+    container_layout.addStretch(1)
+    section_layout.addWidget(container)
+    main_window.scanToolsSection = section
+    main_window.verticalLayoutMediaControls.addWidget(section)
+    set_scan_tools_expanded(
+        main_window, getattr(main_window, "scan_tools_expanded", False)
+    )
+
+    update_drop_frame_button_label(main_window)
+    update_scan_review_button_states(main_window)
+
+
+# --- Scan / Issue / Drop UI state helpers ---
+def set_scan_tools_expanded(main_window: "MainWindow", expanded: bool):
+    """Shows or hides the scan-tools row and updates the toggle label."""
+    main_window.scan_tools_expanded = expanded
+    toggle_button = getattr(main_window, "scanToolsToggleButton", None)
+    container = getattr(main_window, "scanControlsContainer", None)
+    if toggle_button is not None:
+        toggle_button.blockSignals(True)
+        toggle_button.setChecked(expanded)
+        toggle_button.blockSignals(False)
+    if container is not None:
+        container.setVisible(expanded)
+
+
+def update_drop_frame_button_label(main_window: "MainWindow"):
+    """Updates the drop-frame button text to reflect the current frame state."""
+    button = getattr(main_window, "dropFrameButton", None)
+    if button is None:
+        return
+    current_frame = int(main_window.videoSeekSlider.value())
+    if current_frame in main_window.dropped_frames:
+        button.setText("Restore Frame")
+        button.setToolTip("Restore this frame so it is included in render output.")
+    else:
+        button.setText("Drop Frame")
+        button.setToolTip("Drop this frame from render output.")
+
+
+def update_scan_review_button_states(main_window: "MainWindow"):
+    """Enable scan/review actions based on available target-face context."""
+    has_target_faces = bool(getattr(main_window, "target_faces", {}))
+    has_selected_face = (
+        getattr(main_window, "selected_target_face_id", None) is not None
+    )
+
+    scan_button = getattr(main_window, "runScanButton", None)
+    if scan_button is not None:
+        scan_button.setEnabled(has_target_faces)
+
+    for button_name in (
+        "runScanButton",
+        "prevIssueButton",
+        "nextIssueButton",
+        "dropAllIssueFramesButton",
+    ):
+        button = getattr(main_window, button_name, None)
+        if button is not None:
+            if button_name == "runScanButton":
+                continue
+            button.setEnabled(has_selected_face)
+
+
+def _set_slider_marker_values(
+    slider: QtWidgets.QSlider,
+    attr_set_name: str,
+    attr_sorted_name: str,
+    values: list[int],
+):
+    slider_set = set(values)
+    setattr(slider, attr_set_name, slider_set)
+    setattr(slider, attr_sorted_name, sorted(slider_set))
+
+
+def get_selected_face_issue_frames(main_window: "MainWindow") -> set[int]:
+    selected_face_id = getattr(main_window, "selected_target_face_id", None)
+    if selected_face_id is None:
+        return set()
+    return set(main_window.issue_frames_by_face.get(str(selected_face_id), set()))
+
+
+def refresh_issue_frames_for_selected_face(main_window: "MainWindow"):
+    """Refresh visible issue markers to match the currently selected target face."""
+    visible_issue_frames = get_selected_face_issue_frames(main_window)
+    main_window.issue_frames = visible_issue_frames
+    _set_slider_marker_values(
+        main_window.videoSeekSlider,
+        "issue_markers",
+        "issue_markers_sorted",
+        list(visible_issue_frames),
+    )
+    main_window.videoSeekSlider.update()
+    update_scan_review_button_states(main_window)
+
+
+def set_issue_frames_for_face(main_window: "MainWindow", face_id, frames):
+    """Stores issue frames for a specific target face and refreshes visible markers if selected."""
+    if face_id is None:
+        return
+    normalized = {int(frame) for frame in frames}
+    main_window.issue_frames_by_face[str(face_id)] = normalized
+    if str(face_id) == str(getattr(main_window, "selected_target_face_id", None)):
+        refresh_issue_frames_for_selected_face(main_window)
+
+
+def set_issue_frames_by_face(main_window: "MainWindow", frames_by_face):
+    """Replaces all stored issue results and refreshes visible markers for the selected face."""
+    normalized_mapping: dict[str, set[int]] = {}
+    for face_id, frames in (frames_by_face or {}).items():
+        normalized_mapping[str(face_id)] = {int(frame) for frame in frames}
+    main_window.issue_frames_by_face = normalized_mapping
+    refresh_issue_frames_for_selected_face(main_window)
+
+
+def set_dropped_frames(main_window: "MainWindow", frames):
+    """Replaces the current dropped-frame set and refreshes slider visuals."""
+    normalized = {int(frame) for frame in frames}
+    main_window.dropped_frames = normalized
+    _set_slider_marker_values(
+        main_window.videoSeekSlider,
+        "dropped_markers",
+        "dropped_markers_sorted",
+        list(normalized),
+    )
+    main_window.videoSeekSlider.update()
+    update_drop_frame_button_label(main_window)
+
+
+def clear_scan_results(main_window: "MainWindow"):
+    selected_face_id = getattr(main_window, "selected_target_face_id", None)
+    if selected_face_id is None:
+        main_window.issue_frames_by_face.clear()
+    else:
+        main_window.issue_frames_by_face[str(selected_face_id)] = set()
+    refresh_issue_frames_for_selected_face(main_window)
+
+
+def clear_dropped_frames(main_window: "MainWindow"):
+    set_dropped_frames(main_window, [])
+
+
+def toggle_drop_frame(main_window: "MainWindow"):
+    current_position = int(main_window.videoSeekSlider.value())
+    if current_position in main_window.dropped_frames:
+        main_window.dropped_frames.remove(current_position)
+        main_window.videoSeekSlider.remove_dropped_marker_and_paint(current_position)
+    else:
+        main_window.dropped_frames.add(current_position)
+        main_window.videoSeekSlider.add_dropped_marker_and_paint(current_position)
+    update_drop_frame_button_label(main_window)
+
+
+def drop_all_issue_frames(main_window: "MainWindow"):
+    selected_issue_frames = get_selected_face_issue_frames(main_window)
+    if not selected_issue_frames:
+        return
+    reply = QtWidgets.QMessageBox.question(
+        main_window,
+        "Drop Issue Frames",
+        "Mark all current issue frames as dropped for render output?",
+        QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+        QtWidgets.QMessageBox.No,
+    )
+    if reply != QtWidgets.QMessageBox.Yes:
+        return
+    merged = set(main_window.dropped_frames)
+    merged.update(selected_issue_frames)
+    set_dropped_frames(main_window, merged)
+
+
+# --- Issue scan execution / progress helpers ---
+def _move_slider_to_nearest_issue(main_window: "MainWindow", direction: str):
+    current_position = int(main_window.videoSeekSlider.value())
+    review_frames = sorted(
+        get_selected_face_issue_frames(main_window) | set(main_window.dropped_frames)
+    )
+    if not review_frames:
+        return
+
+    new_position = None
+    if direction == "next":
+        filtered = [frame for frame in review_frames if frame > current_position]
+        new_position = filtered[0] if filtered else None
+    else:
+        filtered = [frame for frame in review_frames if frame < current_position]
+        new_position = filtered[-1] if filtered else None
+
+    if new_position is not None:
+        main_window.videoSeekSlider.setValue(new_position)
+        main_window.video_processor.process_current_frame()
+
+
+def move_slider_to_next_issue(main_window: "MainWindow"):
+    _move_slider_to_nearest_issue(main_window, "next")
+
+
+def move_slider_to_previous_issue(main_window: "MainWindow"):
+    _move_slider_to_nearest_issue(main_window, "previous")
+
+
+def _handle_issue_scan_progress(
+    main_window: "MainWindow",
+    scope_text: str,
+    processed: int,
+    total: int,
+    frame_number: int,
+):
+    dialog = main_window.scan_progress_dialog
+    dialog.setMaximum(max(total, 1))
+    dialog.setValue(min(processed, max(total, 1)))
+    dialog.setLabelText(f"{scope_text}\nScanning frame {frame_number} of {total}...")
+    QtCore.QCoreApplication.processEvents()
+
+
+def _cleanup_issue_scan_worker(main_window: "MainWindow"):
+    worker = getattr(main_window, "scan_issue_worker", None)
+    if worker is not None:
+        worker.deleteLater()
+        main_window.scan_issue_worker = None
+
+
+def _finish_issue_scan_dialog(main_window: "MainWindow"):
+    dialog = main_window.scan_progress_dialog
+    try:
+        dialog.canceled.disconnect()
+    except RuntimeError:
+        pass
+    dialog.close()
+
+
+def _handle_issue_scan_completed(
+    main_window: "MainWindow",
+    issue_frames_by_face: dict,
+    frames_scanned: int,
+    faces_with_issues: int,
+    scope_text: str,
+    elapsed_seconds: float,
+):
+    set_issue_frames_by_face(main_window, issue_frames_by_face)
+    _finish_issue_scan_dialog(main_window)
+    _cleanup_issue_scan_worker(main_window)
+    total_issue_frames = sum(
+        len(set(frames)) for frames in issue_frames_by_face.values()
+    )
+    scan_fps = (frames_scanned / elapsed_seconds) if elapsed_seconds > 0 else 0.0
+    print(
+        f"[INFO] Scan: Scope: {scope_text.removeprefix('Scanning ')} | Frames: {frames_scanned} | Time: {elapsed_seconds:.1f}s | FPS: {scan_fps:.1f} | Issues: {total_issue_frames} | Faces with issues: {faces_with_issues}"
+    )
+    if total_issue_frames:
+        common_widget_actions.create_and_show_toast_message(
+            main_window,
+            "Scan Complete",
+            f"Scanned {frames_scanned} frames in {elapsed_seconds:.1f}s ({scan_fps:.1f} FPS). Found {total_issue_frames} issues across {faces_with_issues} faces.",
+        )
+    else:
+        common_widget_actions.create_and_show_toast_message(
+            main_window,
+            "Scan Complete",
+            f"Scanned {frames_scanned} frames in {elapsed_seconds:.1f}s ({scan_fps:.1f} FPS). No issue frames found.",
+        )
+
+
+def _handle_issue_scan_cancelled(main_window: "MainWindow"):
+    _finish_issue_scan_dialog(main_window)
+    _cleanup_issue_scan_worker(main_window)
+    common_widget_actions.create_and_show_toast_message(
+        main_window,
+        "Scan Cancelled",
+        "Issue scan aborted. Previous scan results were kept.",
+        style_type="warning",
+    )
+
+
+def _handle_issue_scan_failed(main_window: "MainWindow", error_message: str):
+    _finish_issue_scan_dialog(main_window)
+    _cleanup_issue_scan_worker(main_window)
+    common_widget_actions.create_and_show_messagebox(
+        main_window,
+        "Scan Failed",
+        error_message,
+        main_window.scan_progress_dialog,
+    )
+
+
+def run_issue_scan(main_window: "MainWindow"):
+    video_processor = main_window.video_processor
+    if not getattr(main_window, "target_faces", {}):
+        common_widget_actions.create_and_show_messagebox(
+            main_window,
+            "Scan Not Available",
+            "No target faces found. Use Find Faces before running a scan.",
+            main_window.videoSeekSlider,
+        )
+        return
+    if video_processor.file_type != "video" or not video_processor.media_path:
+        common_widget_actions.create_and_show_messagebox(
+            main_window,
+            "Scan Not Available",
+            "Issue scans are only available when a video is loaded.",
+            main_window.videoSeekSlider,
+        )
+        return
+    if not Path(video_processor.media_path).is_file():
+        common_widget_actions.create_and_show_messagebox(
+            main_window,
+            "Scan Not Available",
+            "The selected video could not be found on disk.",
+            main_window.videoSeekSlider,
+        )
+        return
+    if getattr(main_window, "scan_issue_worker", None) is not None:
+        return
+
+    was_processing = video_processor.stop_processing()
+    if was_processing:
+        print("[INFO] Stopped active processing before running issue scan.")
+
+    worker = ui_workers.IssueScanWorker(main_window)
+    main_window.scan_issue_worker = worker
+    scope_text = worker._scan_scope_text
+    worker.progress.connect(
+        lambda processed, total, frame_number: _handle_issue_scan_progress(
+            main_window, scope_text, processed, total, frame_number
+        )
+    )
+    worker.completed.connect(
+        lambda issue_frames_by_face, frames_scanned, faces_with_issues, completed_scope_text, elapsed_seconds: (
+            _handle_issue_scan_completed(
+                main_window,
+                issue_frames_by_face,
+                frames_scanned,
+                faces_with_issues,
+                completed_scope_text,
+                elapsed_seconds,
+            )
+        )
+    )
+    worker.cancelled.connect(lambda: _handle_issue_scan_cancelled(main_window))
+    worker.failed.connect(
+        lambda error_message: _handle_issue_scan_failed(main_window, error_message)
+    )
+
+    dialog = main_window.scan_progress_dialog
+    try:
+        dialog.canceled.disconnect()
+    except RuntimeError:
+        pass
+    dialog.setWindowTitle("Scan")
+    dialog.setLabelText(f"{scope_text}\nPreparing scan...")
+    dialog.setRange(0, 1)
+    dialog.setValue(0)
+    dialog.setMinimumWidth(420)
+    dialog.canceled.connect(worker.cancel)
+    dialog.show()
+    worker.start()
+
+
 def remove_face_parameters_and_control_from_markers(main_window: "MainWindow", face_id):
     """
     Removes all stored parameter entries for *face_id* from every marker.
@@ -476,11 +1064,13 @@ def remove_face_parameters_and_control_from_markers(main_window: "MainWindow", f
 
 
 def remove_all_markers(main_window: "MainWindow"):
-    """Removes every standard marker and clears all job marker pairs."""
+    """Removes all standard, issue, and dropped-frame markers plus job pairs."""
     standard_markers_positions = list(main_window.markers.keys())
     for marker_position in standard_markers_positions:
         remove_marker(main_window, marker_position)
     main_window.markers.clear()
+    set_issue_frames_by_face(main_window, {})
+    set_dropped_frames(main_window, [])
     if main_window.job_marker_pairs:
         print("[INFO] Clearing job marker pairs.")
         main_window.job_marker_pairs.clear()
@@ -548,10 +1138,19 @@ def rewind_video_slider_by_n_frames(main_window: "MainWindow", n=None):
 
 
 def delete_all_markers(main_window: "MainWindow"):
-    """Clears all marker positions from the slider and the markers dict without removing job pairs."""
+    """Clears all slider marker overlays and marker dictionaries without removing job pairs."""
     main_window.videoSeekSlider.markers = set()
+    main_window.videoSeekSlider.markers_sorted = []
+    main_window.videoSeekSlider.issue_markers = set()
+    main_window.videoSeekSlider.issue_markers_sorted = []
+    main_window.videoSeekSlider.dropped_markers = set()
+    main_window.videoSeekSlider.dropped_markers_sorted = []
     main_window.videoSeekSlider.update()
     main_window.markers.clear()
+    main_window.issue_frames_by_face.clear()
+    main_window.issue_frames.clear()
+    main_window.dropped_frames.clear()
+    update_drop_frame_button_label(main_window)
 
 
 def view_fullscreen(main_window: "MainWindow"):
@@ -1014,6 +1613,7 @@ def on_change_video_seek_slider(main_window: "MainWindow", new_position=0):
 
     video_processor.current_frame_number = new_position
     video_processor.next_frame_to_display = new_position
+    update_drop_frame_button_label(main_window)
     if video_processor.media_capture:
         misc_helpers.seek_frame(video_processor.media_capture, new_position)
 

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -3,6 +3,8 @@ from functools import partial
 from typing import TYPE_CHECKING, Dict
 import traceback
 import os
+import threading
+import time
 
 import torch
 import numpy
@@ -158,6 +160,59 @@ class TargetMediaLoaderWorker(qtc.QThread):
         self.wait(1000)
         if self.isRunning():
             self.terminate()
+
+
+class IssueScanWorker(qtc.QThread):
+    progress = qtc.Signal(int, int, int)
+    completed = qtc.Signal(object, int, int, str, float)
+    cancelled = qtc.Signal()
+    failed = qtc.Signal(str)
+
+    def __init__(self, main_window: "MainWindow", parent=None):
+        super().__init__(parent)
+        self.main_window = main_window
+        self._cancel_event = threading.Event()
+        self._scan_ranges = main_window.video_processor._get_issue_scan_ranges()
+        self._scan_scope_text = main_window.video_processor.describe_issue_scan_scope(
+            self._scan_ranges
+        )
+        self._target_height = main_window.video_processor._get_target_input_height()
+        self._base_control = main_window.control.copy()
+        self._base_params = {
+            face_id: params.copy() for face_id, params in main_window.parameters.items()
+        }
+        self._target_faces_snapshot = dict(main_window.target_faces)
+        self._reset_frame_number = int(main_window.videoSeekSlider.value())
+
+    def cancel(self):
+        self._cancel_event.set()
+
+    def run(self):
+        try:
+            start_time = time.monotonic()
+            result = self.main_window.video_processor.scan_issue_frames(
+                progress_callback=self.progress.emit,
+                is_cancelled=self._cancel_event.is_set,
+                scan_ranges=self._scan_ranges,
+                target_height=self._target_height,
+                base_control=self._base_control,
+                base_params=self._base_params,
+                target_faces_snapshot=self._target_faces_snapshot,
+                reset_frame_number=self._reset_frame_number,
+            )
+            if result is None:
+                self.cancelled.emit()
+                return
+            elapsed_seconds = time.monotonic() - start_time
+            self.completed.emit(
+                result["issue_frames_by_face"],
+                result["frames_scanned"],
+                result["faces_with_issues"],
+                self._scan_scope_text,
+                elapsed_seconds,
+            )
+        except Exception as exc:
+            self.failed.emit(str(exc))
 
 
 class InputFacesLoaderWorker(qtc.QThread):

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -643,6 +643,8 @@ class TargetFaceCardButton(CardButton):
 
         main_window.selected_target_face_id = self.face_id
         main_window.current_kv_tensors_map = self.assigned_kv_map
+        video_control_actions.refresh_issue_frames_for_selected_face(main_window)
+        video_control_actions.update_scan_review_button_states(main_window)
 
         common_widget_actions.set_widgets_values_using_face_id_parameters(
             main_window=main_window, face_id=self.face_id
@@ -873,6 +875,8 @@ class TargetFaceCardButton(CardButton):
         main_window.target_faces.pop(self.face_id)
         # Pop parameters using the target's face_id
         main_window.parameters.pop(self.face_id)
+        if hasattr(main_window, "issue_frames_by_face"):
+            main_window.issue_frames_by_face.pop(str(self.face_id), None)
         # Click and Select the first target face if target_faces are not empty
         if main_window.target_faces:
             list(main_window.target_faces.values())[0].click()
@@ -883,6 +887,8 @@ class TargetFaceCardButton(CardButton):
                 main_window, face_id=None
             )
             main_window.selected_target_face_id = None
+            video_control_actions.refresh_issue_frames_for_selected_face(main_window)
+        video_control_actions.update_scan_review_button_states(main_window)
 
         video_control_actions.remove_face_parameters_and_control_from_markers(
             main_window, self.face_id

--- a/tests/unit/helpers/test_miscellaneous.py
+++ b/tests/unit/helpers/test_miscellaneous.py
@@ -5,7 +5,11 @@ MISC-* tests for pure utility functions in app.helpers.miscellaneous
 import numpy as np
 import pytest
 from app.helpers.miscellaneous import (
+    count_issue_scan_frames,
+    ParametersDict,
+    find_best_target_match,
     is_image_file,
+    is_detected_face_eligible_for_matching,
     is_video_file,
     get_file_type,
     get_scaling_transforms,
@@ -169,6 +173,85 @@ def test_video_extensions_are_lowercase_dotted():
 
 def test_no_overlap_between_image_and_video_extensions():
     assert set(image_extensions).isdisjoint(set(video_extensions))
+
+
+# ---------------------------------------------------------------------------
+# MISC-05/06 - shared scan/render matching helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_detected_face_eligible_for_matching_rejects_small_bbox():
+    kps = np.array(
+        [[10.0, 10.0], [20.0, 10.0], [15.0, 15.0], [11.0, 20.0], [19.0, 20.0]],
+        dtype=np.float32,
+    )
+    tiny_bbox = np.array([0.0, 0.0, 18.0, 30.0], dtype=np.float32)
+    assert is_detected_face_eligible_for_matching(kps, tiny_bbox, 20) is False
+
+
+def test_is_detected_face_eligible_for_matching_accepts_valid_face():
+    kps = np.array(
+        [[10.0, 10.0], [20.0, 10.0], [15.0, 15.0], [11.0, 20.0], [19.0, 20.0]],
+        dtype=np.float32,
+    )
+    bbox = np.array([0.0, 0.0, 30.0, 30.0], dtype=np.float32)
+    assert is_detected_face_eligible_for_matching(kps, bbox, 20) is True
+
+
+class _DummyTargetFace:
+    def __init__(self, face_id: int, embedding_store: dict[str, np.ndarray]):
+        self.face_id = face_id
+        self._embedding_store = embedding_store
+
+    def get_embedding(self, recognition_model: str) -> np.ndarray | None:
+        return self._embedding_store.get(recognition_model)
+
+
+class _DummyModelsProcessor:
+    @staticmethod
+    def findCosineDistance(
+        detected_embedding: np.ndarray, target_embedding: np.ndarray
+    ) -> float:
+        return float(np.dot(detected_embedding, target_embedding) * 100.0)
+
+
+def test_find_best_target_match_respects_parameters_dict_thresholds():
+    defaults = {"SimilarityThresholdSlider": 60}
+    face_params = {
+        "1": ParametersDict({"SimilarityThresholdSlider": 95}, defaults),
+        "2": ParametersDict({"SimilarityThresholdSlider": 70}, defaults),
+    }
+    targets = {
+        1: _DummyTargetFace(1, {"arcface_128": np.array([0.90], dtype=np.float32)}),
+        2: _DummyTargetFace(2, {"arcface_128": np.array([0.80], dtype=np.float32)}),
+    }
+
+    best_target, best_params, best_score = find_best_target_match(
+        np.array([1.0], dtype=np.float32),
+        _DummyModelsProcessor(),
+        targets,
+        face_params,
+        defaults,
+        "arcface_128",
+    )
+
+    assert best_target is not None
+    assert best_target.face_id == 2
+    assert best_params is not None
+    assert best_params["SimilarityThresholdSlider"] == 70
+    assert best_score == pytest.approx(80.0)
+
+
+def test_count_issue_scan_frames_excludes_dropped_frames():
+    scan_ranges = [(0, 9), (20, 24)]
+    dropped_frames = {2, 3, 22}
+    assert count_issue_scan_frames(scan_ranges, dropped_frames) == 12
+
+
+def test_count_issue_scan_frames_returns_zero_when_all_frames_dropped():
+    scan_ranges = [(10, 12)]
+    dropped_frames = {10, 11, 12}
+    assert count_issue_scan_frames(scan_ranges, dropped_frames) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/helpers/test_parameters_dict.py
+++ b/tests/unit/helpers/test_parameters_dict.py
@@ -3,7 +3,7 @@ PD-* tests for app.helpers.miscellaneous.ParametersDict
 """
 
 import pytest
-from app.helpers.miscellaneous import ParametersDict
+from app.helpers.miscellaneous import ParametersDict, copy_mapping_data
 
 
 @pytest.fixture
@@ -84,3 +84,17 @@ def test_len_and_iteration(defaults):
     pd = ParametersDict({"alpha": 5, "beta": "x"}, defaults)
     assert len(pd) == 2
     assert set(pd.keys()) == {"alpha", "beta"}
+
+
+# PD-09: mapping copy helper must preserve ParametersDict contents
+def test_copy_mapping_data_accepts_parameters_dict(defaults):
+    pd = ParametersDict({"alpha": 5, "beta": "x"}, defaults)
+    copied = copy_mapping_data(pd)
+    assert copied == {"alpha": 5, "beta": "x"}
+    assert isinstance(copied, dict)
+
+
+# PD-10: non-mapping inputs fall back to an empty dict
+def test_copy_mapping_data_rejects_non_mapping():
+    assert copy_mapping_data(None) == {}
+    assert copy_mapping_data(123) == {}


### PR DESCRIPTION
## Overview

This PR adds a pre-scan workflow for identifying likely issue frames before recording.

It gives users a way to:
- scan a loaded video for likely problem frames
- review those frames on the timeline
- use existing saved settings markers to apply fixes across sections of the clip
- jump between issues
- drop individual frames or all issue frames before recording if needed

## What Changed

- Added `Scan for Issues` and scan-review controls near the player timeline
- Added orange timeline markers for issue frames
- Added red timeline markers for dropped frames
- Added per-face issue storage, so scan results follow the selected target face
- Added marker-aware scanning, so saved settings markers are applied during the scan
- Added record-range-aware scanning, so scans follow record start/end ranges when present
- Added persistence for issue frames, dropped frames, and scan-tools UI state in workspace/job save-load
- Updated recording/render flow so dropped frames are excluded from output

## Notes

- The intended workflow is to scan for likely issue frames, adjust settings with existing markers where possible, then drop any remaining bad frames if needed
- Issue scan results are stored per target face, while dropped frames remain global
- Scan uses the current user settings and applies saved settings markers as it moves through the timeline
- Single-frame preview can still differ from playback on some borderline frames, so this is intended as a practical review/QC tool rather than a perfect single-frame predictor

## Validation

Manually tested:
- single-face and multi-face scans
- different per-face similarity thresholds
- saved settings markers across multiple sections
- record-range-only scans
- per-face issue marker switching
- dropped-frame recording
- workspace/job save-load

Checks run:
- `pre-commit run --all-files`
  - passes except for existing baseline `mypy` failures in `app/processors/face_masks.py` and `app/processors/workers/frame_worker.py`
- `python -m pytest`
  - `318 passed, 5 failed`
  - remaining failures appear unrelated to this feature