### PR TITLE
Add relative lids plus retargeted gaze eye mode

### DIFF
--- a/app/processors/frame_edits.py
+++ b/app/processors/frame_edits.py
@@ -350,6 +350,22 @@ class FrameEdits:
                 x_target = x_proj + (refinement_exp - default_delta_exp) + extra_delta
                 return (x_target - x_s) * multiplier
 
+            def merge_eye_motion_candidates(relative_motion, absolute_motion):
+                """
+                Stable gaze eye merge:
+                - keep horizontal gaze direction from the absolute + retargeted eye motion
+                - keep eyelid/blink shape from the relative eye motion
+                """
+                merged_motion = relative_motion.clone()
+
+                # Landmark 11/15 X is the clearest eyeball-direction signal.
+                # Keep vertical and depth motion relative so eyelid/open-close
+                # behavior stays as close as possible to the good relative result.
+                merged_motion[:, 11, 0] = absolute_motion[:, 11, 0]
+                merged_motion[:, 15, 0] = absolute_motion[:, 15, 0]
+
+                return merged_motion
+
             accumulated_motion = torch.zeros_like(x_s)
 
             # --- MODE PROCESSING ---
@@ -430,6 +446,12 @@ class FrameEdits:
                 flag_relative_eyes = parameters.get(
                     "FaceExpressionRelativeEyesToggle", False
                 )
+                flag_retarget_eyes = parameters.get(
+                    "FaceExpressionRetargetingEyesBothEnableToggle", False
+                )
+                flag_stable_gaze_eyes = parameters.get(
+                    "FaceExpressionStableGazeEyesToggle", False
+                )
                 flag_relative_lips = parameters.get(
                     "FaceExpressionRelativeLipsToggle", False
                 )
@@ -480,9 +502,7 @@ class FrameEdits:
 
                 if flag_activate_eyes:
                     eyes_retarget_delta = 0
-                    if parameters.get(
-                        "FaceExpressionRetargetingEyesBothEnableToggle", False
-                    ):
+                    if flag_retarget_eyes:
                         eye_mult = parameters.get(
                             "FaceExpressionRetargetingEyesMultiplierBothDecimalSlider",
                             1.0,
@@ -504,15 +524,44 @@ class FrameEdits:
                             x_s, target_eye_ratio * eye_mult, face_editor_type
                         )
 
-                    accumulated_motion += get_component_motion(
-                        eye_indices,
-                        x_d_i_info["exp"],
-                        driving_multiplier_eyes,
-                        extra_delta=eyes_retarget_delta,
-                        is_relative=flag_relative_eyes,
-                        neutral_ref=0,
-                        use_boost=True,
-                    )
+                    if (
+                        flag_stable_gaze_eyes
+                        and flag_relative_eyes
+                        and flag_retarget_eyes
+                    ):
+                        relative_eye_motion = get_component_motion(
+                            eye_indices,
+                            x_d_i_info["exp"],
+                            1.0,
+                            is_relative=True,
+                            neutral_ref=0,
+                            use_boost=True,
+                        )
+                        absolute_retarget_eye_motion = get_component_motion(
+                            eye_indices,
+                            x_d_i_info["exp"],
+                            1.0,
+                            extra_delta=eyes_retarget_delta,
+                            is_relative=False,
+                            neutral_ref=0,
+                            use_boost=True,
+                        )
+                        accumulated_motion += (
+                            merge_eye_motion_candidates(
+                                relative_eye_motion, absolute_retarget_eye_motion
+                            )
+                            * driving_multiplier_eyes
+                        )
+                    else:
+                        accumulated_motion += get_component_motion(
+                            eye_indices,
+                            x_d_i_info["exp"],
+                            driving_multiplier_eyes,
+                            extra_delta=eyes_retarget_delta,
+                            is_relative=flag_relative_eyes,
+                            neutral_ref=0,
+                            use_boost=True,
+                        )
 
                 if flag_activate_lips:
                     lips_retarget_delta = 0

--- a/app/ui/widgets/common_layout_data.py
+++ b/app/ui/widgets/common_layout_data.py
@@ -350,6 +350,16 @@ COMMON_LAYOUT_DATA: Any = {
             "requiredSelectionValue": "Advanced",
             "help": "Activate the eyes face expression restorer",
         },
+        "FaceExpressionStableGazeEyesToggle": {
+            "level": 4,
+            "label": "Relative Lids + Retargeted Gaze",
+            "default": False,
+            "parentToggle": "FaceExpressionRetargetingEyesBothEnableToggle & FaceExpressionEnableBothToggle & FaceExpressionEyesToggle & FaceExpressionRelativeEyesToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Advanced",
+            "help": "Combines Relative Position eye motion with Retargeting Eyes by preserving relative eyelid motion while using retargeted horizontal gaze. Requires Relative Position and Retargeting Eyes.",
+        },
         "FaceExpressionRelativeEyesToggle": {
             "level": 4,
             "label": "Relative Position",


### PR DESCRIPTION
### Adds `Relative Lids + Retargeted Gaze` setting

This is meant to help with the tradeoff where `Relative Position` gives better eyelid / open-close motion, but can throw off eye aiming a bit. When enabled, it keeps the relative eye motion for the lids, while borrowing the retargeted horizontal gaze from the `Retargeting Eyes` path.

### Notes

- eye-only change
- only active / visible when both `Relative Position` and `Retargeting Eyes` are enabled
- default behavior is unchanged when the new mode is off

### Validation

- `pre-commit` passed on changed files
- `python -m pytest tests/unit/ui/ -q` passed
