### PR TITLE
Fix skipped-frame audio rebuild sync issues

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -2783,17 +2783,17 @@ class VideoProcessor(QObject):
             audio_file = os.path.join(temp_audio_dir, f"audio_segment_{idx:04d}.m4a")
             audio_files.append(audio_file)
 
-            # Try a fast "copy" extraction first to avoid decoding corrupted
-            # packets.  If the input stream itself is damaged this will still
-            # produce a file and skip decoding, hopefully avoiding the error
-            # message the user observed.  We always run validation afterwards
-            # and fall back to re-encoding if needed.
+            # Always normalize skipped-frame rebuild audio to AAC-in-M4A.
+            # This keeps the concat/remux path codec-agnostic for any source
+            # audio format that FFmpeg can decode from the input media.
             media_path: str = self.media_path  # type: ignore[assignment]
             args: list[str] = [
                 "ffmpeg",
                 "-hide_banner",
                 "-loglevel",
                 "warning",
+                "-err_detect",
+                "ignore_err",
                 "-i",
                 media_path,
                 "-ss",
@@ -2803,10 +2803,12 @@ class VideoProcessor(QObject):
                 "-vn",
                 "-map",
                 "0:a:0?",
-                "-avoid_negative_ts",
-                "make_zero",
+                "-af",
+                "aresample=async=1:first_pts=0",
                 "-c:a",
-                "copy",
+                "aac",
+                "-b:a",
+                "192k",
                 "-y",
                 audio_file,
             ]
@@ -2815,33 +2817,14 @@ class VideoProcessor(QObject):
                 print(
                     f"[INFO] Extracting audio segment {idx + 1}/{len(segments)}: {start_time:.3f}s → {end_time:.3f}s"
                 )
-                result = subprocess.run(
-                    args, check=True, capture_output=True, text=True
-                )
+                subprocess.run(args, check=True, capture_output=True, text=True)
 
-                # Check for audio decoding errors in stderr (copy mode usually avoids decoding,
-                # but some containers still report warnings)
-                stderr_output = result.stderr
-                needs_rerun = False
-                if (
-                    "Error submitting packet to decoder" in stderr_output
-                    or "Invalid data found" in stderr_output
-                ):
-                    print(f"[WARN] Audio decoding errors detected in segment {idx + 1}")
-                    print(
-                        f"[WARN] FFmpeg stderr: {stderr_output[:500]}..."
-                    )  # First 500 chars
-                    needs_rerun = True
-
-                # Validate output; if it's not valid, we'll resort to re-encode
+                # Validate output; if it's not valid, retry once with the same
+                # normalized extraction settings to rule out a transient failure.
                 if not self._validate_audio_file(audio_file):
                     print(
-                        f"[WARN] Validation failed for copied segment {idx + 1}, will retry with re-encoding"
+                        f"[WARN] Validation failed for segment {idx + 1}, retrying extraction once"
                     )
-                    needs_rerun = True
-
-                if needs_rerun:
-                    # re-extract by decoding and re-encoding, ignoring errors
                     re_args: list[str] = [
                         "ffmpeg",
                         "-hide_banner",
@@ -2868,9 +2851,6 @@ class VideoProcessor(QObject):
                         audio_file,
                     ]
                     try:
-                        print(
-                            f"[INFO]   Re-extracting segment {idx + 1} with re-encode"
-                        )
                         subprocess.run(
                             re_args, check=True, capture_output=True, text=True
                         )
@@ -2885,8 +2865,18 @@ class VideoProcessor(QObject):
                             except OSError:
                                 pass
                         return False, []
-                else:
-                    print(f"[INFO]   ✓ Segment {idx + 1} extracted successfully")
+                    if not self._validate_audio_file(audio_file):
+                        print(
+                            f"[ERROR] Retried segment {idx + 1} is still invalid after validation"
+                        )
+                        for audio in audio_files:
+                            try:
+                                os.remove(audio)
+                            except OSError:
+                                pass
+                        return False, []
+
+                print(f"[INFO] Segment {idx + 1} extracted successfully")
             except subprocess.CalledProcessError as e:
                 print(f"[ERROR] Failed to extract audio segment {idx + 1}: {e}")
                 print(f"[ERROR] FFmpeg stderr: {e.stderr}")

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -186,10 +186,10 @@ class VideoProcessor(QObject):
             None  # Last frame number that was displayed/written
         )
 
-        # --- Frame Skip Tracking (for corrupted frames) ---
+        # --- Frame Skip Tracking ---
         self.skipped_frames: set[int] = (
             set()
-        )  # Track which frames were skipped due to read errors
+        )  # Track which frames were skipped during recording/segment processing
         self.consecutive_read_errors: int = 0  # Count consecutive read failures
         self.max_consecutive_errors: int = (
             MAX_CONSECUTIVE_ERRORS  # Stop after this many consecutive errors
@@ -198,6 +198,8 @@ class VideoProcessor(QObject):
         self.stopped_by_error_limit: bool = (
             False  # Track if processing stopped due to error limit
         )
+        self.manual_dropped_skip_count: int = 0
+        self.read_error_skip_count: int = 0
 
         # --- Multi-Segment Recording State ---
         self.segments_to_process: List[Tuple[int, int]] = []
@@ -685,7 +687,7 @@ class VideoProcessor(QObject):
         """
         Unified feeder logic for standard video playback AND segment recording.
         Reads frames as long as processing is active and within the limits.
-        Now supports skipping corrupted frames instead of stopping.
+        Now supports skipping unreadable or manually dropped frames instead of stopping.
         """
 
         # Determine the mode at startup
@@ -707,6 +709,8 @@ class VideoProcessor(QObject):
         self.consecutive_read_errors = 0
         self.skipped_frames.clear()
         self.total_skipped_frames = 0
+        self.manual_dropped_skip_count = 0
+        self.read_error_skip_count = 0
 
         # VP-19: Cache target input height outside the loop; only re-read on detected change.
         cached_resize_toggle = self.main_window.control.get(
@@ -751,8 +755,7 @@ class VideoProcessor(QObject):
                 if (
                     is_segment_mode or self.recording
                 ) and self.current_frame_number in self.main_window.dropped_frames:
-                    self.skipped_frames.add(self.current_frame_number)
-                    self.total_skipped_frames += 1
+                    self._mark_skipped_frame(self.current_frame_number, "manual_drop")
                     self.current_frame_number += 1
                     misc_helpers.seek_frame(
                         self.media_capture, self.current_frame_number
@@ -811,11 +814,12 @@ class VideoProcessor(QObject):
                         self.processing = False
                         break
 
-                    # 3) Standard mode: unified frame skip logic (no longer depends on potentially inaccurate max_frame_number)
-                    # Skip corrupted frames and continue, but stop if too many consecutive failures (likely reached EOF)
+                    # 3) Standard mode: unified read-failure skip logic (no longer
+                    # depends on potentially inaccurate max_frame_number). Skip the
+                    # unreadable frame and continue, but stop if too many
+                    # consecutive failures suggest we actually reached EOF.
                     self.consecutive_read_errors += 1
-                    self.skipped_frames.add(self.current_frame_number)
-                    self.total_skipped_frames += 1
+                    self._mark_skipped_frame(self.current_frame_number, "read_error")
 
                     # Check if too many consecutive errors (likely reached actual EOF)
                     if self.consecutive_read_errors > self.max_consecutive_errors:
@@ -834,7 +838,8 @@ class VideoProcessor(QObject):
 
                     # Log skip and move to next frame
                     print(
-                        f"[WARN] Feeder: Skipping corrupted frame {self.current_frame_number} (Total skipped: {self.total_skipped_frames}, Consecutive errors: {self.consecutive_read_errors})."
+                        f"[WARN] Feeder: Skipping unreadable frame {self.current_frame_number} "
+                        f"(Total skipped: {self.total_skipped_frames}, Consecutive read errors: {self.consecutive_read_errors})."
                     )
                     self.current_frame_number += 1
                     misc_helpers.seek_frame(
@@ -934,6 +939,9 @@ class VideoProcessor(QObject):
                 f"[INFO] Feeder loop finished. Total frames skipped: {self.total_skipped_frames}"
             )
             print(
+                f"[INFO] Skip reasons: manual dropped frames={self.manual_dropped_skip_count}, read errors={self.read_error_skip_count}"
+            )
+            print(
                 f"[INFO] Skipped frame numbers: {sorted(list(self.skipped_frames)[:100])}{'...' if len(self.skipped_frames) > 100 else ''}"
             )
 
@@ -985,6 +993,16 @@ class VideoProcessor(QObject):
             except Exception as e:
                 print(f"[ERROR] Error in _feed_webcam loop: {e}")
                 self.processing = False
+
+    def _mark_skipped_frame(self, frame_number: int, reason: str) -> None:
+        """Track skipped-frame reasons for later audio-rebuild diagnostics."""
+        self.skipped_frames.add(frame_number)
+        self.total_skipped_frames += 1
+
+        if reason == "manual_drop":
+            self.manual_dropped_skip_count += 1
+        elif reason == "read_error":
+            self.read_error_skip_count += 1
 
     def display_next_frame(self):
         """
@@ -1098,7 +1116,7 @@ class VideoProcessor(QObject):
             if frame_number_to_display > original_frame:
                 skipped_count = frame_number_to_display - original_frame
                 print(
-                    f"[INFO] Display: Skipping {skipped_count} corrupted frame(s), jumping to frame {frame_number_to_display}"
+                    f"[INFO] Display: Advancing past {skipped_count} skipped frame(s), jumping to frame {frame_number_to_display}"
                 )
                 self.next_frame_to_display = frame_number_to_display
 
@@ -2759,7 +2777,10 @@ class VideoProcessor(QObject):
                 )
                 continue
 
-            audio_file = os.path.join(temp_audio_dir, f"audio_segment_{idx:04d}.aac")
+            # Use a containerized AAC output rather than raw ADTS .aac.
+            # Raw AAC concatenation is brittle on some skipped-frame rebuilds,
+            # especially for MKV-derived inputs with awkward timestamps.
+            audio_file = os.path.join(temp_audio_dir, f"audio_segment_{idx:04d}.m4a")
             audio_files.append(audio_file)
 
             # Try a fast "copy" extraction first to avoid decoding corrupted
@@ -2779,6 +2800,11 @@ class VideoProcessor(QObject):
                 str(start_time),
                 "-to",
                 str(end_time),
+                "-vn",
+                "-map",
+                "0:a:0?",
+                "-avoid_negative_ts",
+                "make_zero",
                 "-c:a",
                 "copy",
                 "-y",
@@ -2829,8 +2855,15 @@ class VideoProcessor(QObject):
                         str(start_time),
                         "-to",
                         str(end_time),
-                        "-q:a",
-                        "9",
+                        "-vn",
+                        "-map",
+                        "0:a:0?",
+                        "-af",
+                        "aresample=async=1:first_pts=0",
+                        "-c:a",
+                        "aac",
+                        "-b:a",
+                        "192k",
                         "-y",
                         audio_file,
                     ]
@@ -3021,7 +3054,7 @@ class VideoProcessor(QObject):
             print(f"[ERROR] Failed to create concat manifest: {e}")
             return None
 
-        output_audio = os.path.join(temp_audio_dir, "audio_concatenated.aac")
+        output_audio = os.path.join(temp_audio_dir, "audio_concatenated.m4a")
 
         # FFmpeg concat demuxer command
         args = [
@@ -3035,8 +3068,15 @@ class VideoProcessor(QObject):
             "0",  # Allow absolute filenames
             "-i",
             concat_file,
-            "-c",
-            "copy",  # No re-encoding, just copy
+            "-vn",
+            # Re-encode once here to flatten the segment timestamps into a
+            # single monotonic audio stream before the final mux.
+            "-af",
+            "aresample=async=1:first_pts=0",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
             "-y",
             output_audio,
         ]
@@ -3186,6 +3226,10 @@ class VideoProcessor(QObject):
             self.processing_start_frame = previous_start_frame
 
         try:
+            print(
+                f"[INFO] Segment {segment_num}: rebuilding audio for skipped frames "
+                f"(manual dropped={self.manual_dropped_skip_count}, read errors={self.read_error_skip_count})."
+            )
             audio_ok, audio_files = self._extract_audio_segments(
                 keep_segments, temp_audio_dir
             )
@@ -3402,6 +3446,10 @@ class VideoProcessor(QObject):
                 print("[INFO] Adding audio (default-style merge)...")
                 try:
                     if self.total_skipped_frames > 0:
+                        print(
+                            "[INFO] Rebuilding audio because frames were skipped "
+                            f"(manual dropped={self.manual_dropped_skip_count}, read errors={self.read_error_skip_count})."
+                        )
                         temp_audio_root = os.path.join(
                             os.path.dirname(self.temp_file), "temp_audio"
                         )
@@ -3972,7 +4020,7 @@ class VideoProcessor(QObject):
                 f"[ERROR] Segment file '{self.temp_segment_files[-1]}' not found after processing segment {segment_num}."
             )
 
-        # If corrupted frames were skipped in this segment, rebuild segment audio
+        # If frames were skipped in this segment, rebuild segment audio
         # from valid frame ranges so concatenated output stays in sync.
         self._rebuild_segment_audio_if_needed(segment_num)
 

--- a/tests/unit/processors/test_video_processor_audio.py
+++ b/tests/unit/processors/test_video_processor_audio.py
@@ -30,10 +30,11 @@ def test_mark_skipped_frame_tracks_reason_counts():
     assert dummy.read_error_skip_count == 1
 
 
-def test_extract_audio_segments_reencodes_to_containerized_aac_when_validation_fails(
+def test_extract_audio_segments_always_normalizes_to_containerized_aac(
     tmp_path, monkeypatch
 ):
     calls: list[list[str]] = []
+    validation_results = iter([False, True])
 
     def fake_run(args, **kwargs):
         calls.append(list(args))
@@ -42,7 +43,7 @@ def test_extract_audio_segments_reencodes_to_containerized_aac_when_validation_f
     dummy = SimpleNamespace(
         fps=30.0,
         media_path=str(tmp_path / "input.mkv"),
-        _validate_audio_file=lambda _: False,
+        _validate_audio_file=lambda _: next(validation_results),
     )
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -59,7 +60,8 @@ def test_extract_audio_segments_reencodes_to_containerized_aac_when_validation_f
     retry_call = calls[1]
 
     assert first_call[-1].endswith(".m4a")
-    assert first_call[first_call.index("-c:a") + 1] == "copy"
+    assert first_call[first_call.index("-c:a") + 1] == "aac"
+    assert first_call[first_call.index("-af") + 1] == "aresample=async=1:first_pts=0"
     assert first_call[first_call.index("-map") + 1] == "0:a:0?"
 
     assert retry_call[-1].endswith(".m4a")

--- a/tests/unit/processors/test_video_processor_audio.py
+++ b/tests/unit/processors/test_video_processor_audio.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.processors.video_processor import VideoProcessor
+
+
+class _RunResult:
+    def __init__(self, returncode: int = 0, stderr: str = "", stdout: str = ""):
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+def test_mark_skipped_frame_tracks_reason_counts():
+    dummy = SimpleNamespace(
+        skipped_frames=set(),
+        total_skipped_frames=0,
+        manual_dropped_skip_count=0,
+        read_error_skip_count=0,
+    )
+
+    VideoProcessor._mark_skipped_frame(dummy, 10, "manual_drop")
+    VideoProcessor._mark_skipped_frame(dummy, 11, "read_error")
+
+    assert dummy.skipped_frames == {10, 11}
+    assert dummy.total_skipped_frames == 2
+    assert dummy.manual_dropped_skip_count == 1
+    assert dummy.read_error_skip_count == 1
+
+
+def test_extract_audio_segments_reencodes_to_containerized_aac_when_validation_fails(
+    tmp_path, monkeypatch
+):
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return _RunResult()
+
+    dummy = SimpleNamespace(
+        fps=30.0,
+        media_path=str(tmp_path / "input.mkv"),
+        _validate_audio_file=lambda _: False,
+    )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    ok, audio_files = VideoProcessor._extract_audio_segments(
+        dummy, [(0, 29)], str(tmp_path)
+    )
+
+    assert ok is True
+    assert len(audio_files) == 1
+    assert audio_files[0].endswith(".m4a")
+
+    first_call = calls[0]
+    retry_call = calls[1]
+
+    assert first_call[-1].endswith(".m4a")
+    assert first_call[first_call.index("-c:a") + 1] == "copy"
+    assert first_call[first_call.index("-map") + 1] == "0:a:0?"
+
+    assert retry_call[-1].endswith(".m4a")
+    assert retry_call[retry_call.index("-c:a") + 1] == "aac"
+    assert retry_call[retry_call.index("-af") + 1] == "aresample=async=1:first_pts=0"
+
+
+def test_concatenate_audio_segments_reencodes_concat_output_to_m4a(
+    tmp_path, monkeypatch
+):
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return _RunResult()
+
+    audio_files = []
+    for name in ("seg_a.m4a", "seg_b.m4a"):
+        path = tmp_path / name
+        path.write_bytes(b"stub")
+        audio_files.append(str(path))
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    output_path = VideoProcessor._concatenate_audio_segments(
+        SimpleNamespace(), audio_files, str(tmp_path)
+    )
+
+    assert output_path == str(tmp_path / "audio_concatenated.m4a")
+    assert len(calls) == 1
+
+    concat_call = calls[0]
+    manifest_path = Path(tmp_path / "concat_manifest.txt")
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+
+    assert "file '" in manifest_text
+    assert concat_call[concat_call.index("-c:a") + 1] == "aac"
+    assert concat_call[concat_call.index("-af") + 1] == "aresample=async=1:first_pts=0"
+    assert concat_call[-1].endswith(".m4a")

--- a/tests/unit/processors/test_video_processor_audio.py
+++ b/tests/unit/processors/test_video_processor_audio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import queue
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -28,6 +29,25 @@ def test_mark_skipped_frame_tracks_reason_counts():
     assert dummy.total_skipped_frames == 2
     assert dummy.manual_dropped_skip_count == 1
     assert dummy.read_error_skip_count == 1
+
+
+def test_identify_frame_segments_without_skips_uses_processing_start_frame():
+    dummy = SimpleNamespace(processing_start_frame=100, skipped_frames=set())
+
+    segments = VideoProcessor._identify_frame_segments(dummy, 120)
+
+    assert segments == [(100, 120)]
+
+
+def test_identify_frame_segments_handles_boundary_and_pre_start_skips():
+    dummy = SimpleNamespace(
+        processing_start_frame=100,
+        skipped_frames={95, 100, 101, 105, 112},
+    )
+
+    segments = VideoProcessor._identify_frame_segments(dummy, 112)
+
+    assert segments == [(102, 104), (106, 111)]
 
 
 def test_extract_audio_segments_always_normalizes_to_containerized_aac(
@@ -69,6 +89,35 @@ def test_extract_audio_segments_always_normalizes_to_containerized_aac(
     assert retry_call[retry_call.index("-af") + 1] == "aresample=async=1:first_pts=0"
 
 
+def test_extract_audio_segments_returns_failure_after_double_validation_failure(
+    tmp_path, monkeypatch
+):
+    calls: list[list[str]] = []
+    removed_paths: list[str] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return _RunResult()
+
+    dummy = SimpleNamespace(
+        fps=30.0,
+        media_path=str(tmp_path / "input.mkv"),
+        _validate_audio_file=lambda _: False,
+    )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("os.remove", lambda path: removed_paths.append(path))
+
+    ok, audio_files = VideoProcessor._extract_audio_segments(
+        dummy, [(0, 29)], str(tmp_path)
+    )
+
+    assert ok is False
+    assert audio_files == []
+    assert len(calls) == 2
+    assert removed_paths == [str(tmp_path / "audio_segment_0000.m4a")]
+
+
 def test_concatenate_audio_segments_reencodes_concat_output_to_m4a(
     tmp_path, monkeypatch
 ):
@@ -101,3 +150,103 @@ def test_concatenate_audio_segments_reencodes_concat_output_to_m4a(
     assert concat_call[concat_call.index("-c:a") + 1] == "aac"
     assert concat_call[concat_call.index("-af") + 1] == "aresample=async=1:first_pts=0"
     assert concat_call[-1].endswith(".m4a")
+
+
+def test_finalize_default_style_recording_uses_rebuilt_audio_when_frames_skipped(
+    tmp_path, monkeypatch
+):
+    temp_file = tmp_path / "temp_output.mp4"
+    temp_file.write_bytes(b"temp-video")
+    rebuilt_audio = tmp_path / "rebuilt_audio.m4a"
+    rebuilt_audio.write_bytes(b"temp-audio")
+    final_output = tmp_path / "final_output.mp4"
+
+    identify_calls: list[int] = []
+    extract_calls: list[tuple[list[tuple[int, int]], str]] = []
+    concat_calls: list[tuple[list[str], str]] = []
+    ffmpeg_calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        ffmpeg_calls.append(list(args))
+        return _RunResult()
+
+    q = queue.Queue()
+    dummy = SimpleNamespace(
+        feeder_thread=None,
+        frames_to_display=[],
+        frame_queue=q,
+        join_and_clear_threads=lambda: None,
+        gpu_memory_update_timer=SimpleNamespace(stop=lambda: None),
+        preroll_timer=SimpleNamespace(stop=lambda: None),
+        stop_live_sound=lambda: None,
+        media_capture=None,
+        recording_sp=None,
+        recording=True,
+        processing=True,
+        is_processing_segments=False,
+        next_frame_to_display=31,
+        max_frame_number=100,
+        frames_written=30,
+        fps=30.0,
+        play_start_time=0.0,
+        play_end_time=0.0,
+        total_skipped_frames=2,
+        manual_dropped_skip_count=1,
+        read_error_skip_count=1,
+        temp_file=str(temp_file),
+        media_path=str(tmp_path / "input.mkv"),
+        stopped_by_error_limit=False,
+        triggered_by_job_manager=False,
+        processing_start_frame=10,
+        last_displayed_frame=29,
+        main_window=SimpleNamespace(
+            control={
+                "OutputMediaFolder": str(tmp_path),
+                "AutoSaveWorkspaceToggle": False,
+                "OpenOutputToggle": False,
+            }
+        ),
+        _apply_job_timestamp_to_output_name=lambda *args: (None, None),
+        _identify_frame_segments=lambda actual_end_frame: (
+            identify_calls.append(actual_end_frame) or [(10, 14), (16, 29)]
+        ),
+        _extract_audio_segments=lambda segments, temp_audio_dir: (
+            extract_calls.append((segments, temp_audio_dir))
+            or (True, [str(tmp_path / "seg_0000.m4a"), str(tmp_path / "seg_0001.m4a")])
+        ),
+        _concatenate_audio_segments=lambda audio_files, temp_audio_dir: (
+            concat_calls.append((audio_files, temp_audio_dir)) or str(rebuilt_audio)
+        ),
+        _write_video_only_output=lambda *args: True,
+        _log_processing_summary=lambda *args: None,
+        disable_virtualcam=lambda: None,
+        processing_stopped_signal=SimpleNamespace(emit=lambda: None),
+        file_type="image",
+        start_time=0.0,
+    )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.get_output_file_path",
+        lambda *args, **kwargs: str(final_output),
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.layout_actions.enable_all_parameters_and_control_widget",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.video_control_actions.reset_media_buttons",
+        lambda *args, **kwargs: None,
+    )
+
+    VideoProcessor._finalize_default_style_recording(dummy)
+
+    assert identify_calls == [29]
+    assert extract_calls and extract_calls[0][0] == [(10, 14), (16, 29)]
+    assert concat_calls
+
+    final_mux_call = ffmpeg_calls[-1]
+    assert str(rebuilt_audio) in final_mux_call
+    assert str(temp_file) in final_mux_call
+    assert "-ss" not in final_mux_call
+    assert dummy.temp_file == ""


### PR DESCRIPTION
Fixes skipped-frame audio rebuild issues during recording.

- Track skip reasons separately for manual dropped frames and read-error skips
- Improve skip-related console logging
- Harden the skipped-frame audio rebuild path
- Add focused unit coverage for the rebuilt-audio path
