### PR TITLE
Fix/issue scan optimizations and fixes

### DIFF
--- a/app/helpers/miscellaneous.py
+++ b/app/helpers/miscellaneous.py
@@ -322,10 +322,11 @@ def count_issue_scan_frames(
     This keeps issue-scan progress and summary stats aligned with the frames that
     render/output will actually keep.
     """
+    normalized_ranges = normalize_issue_scan_ranges(scan_ranges)
     normalized_dropped = sorted({int(frame) for frame in dropped_frames})
     total_frames = 0
 
-    for start_frame, end_frame in scan_ranges:
+    for start_frame, end_frame in normalized_ranges:
         normalized_start = int(start_frame)
         normalized_end = int(end_frame)
         if normalized_end < normalized_start:
@@ -337,6 +338,35 @@ def count_issue_scan_frames(
         total_frames += (normalized_end - normalized_start + 1) - dropped_in_range
 
     return total_frames
+
+
+def normalize_issue_scan_ranges(
+    scan_ranges: Sequence[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    """Return chronologically sorted, overlap-merged scan ranges."""
+    normalized: list[tuple[int, int]] = []
+
+    for start_frame, end_frame in scan_ranges:
+        normalized_start = int(start_frame)
+        normalized_end = int(end_frame)
+        if normalized_end < normalized_start:
+            continue
+        normalized.append((normalized_start, normalized_end))
+
+    if not normalized:
+        return []
+
+    normalized.sort()
+    merged_ranges: list[tuple[int, int]] = [normalized[0]]
+
+    for start_frame, end_frame in normalized[1:]:
+        previous_start, previous_end = merged_ranges[-1]
+        if start_frame <= previous_end:
+            merged_ranges[-1] = (previous_start, max(previous_end, end_frame))
+        else:
+            merged_ranges.append((start_frame, end_frame))
+
+    return merged_ranges
 
 
 # --- Function Definitions ---

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -2806,7 +2806,7 @@ class VideoProcessor(QObject):
         target_faces_snapshot: IssueScanTargetSnapshot = {}
         for target_id, target_face in live_target_faces.items():
             embeddings_by_model: IssueScanTargetEmbeddings = {}
-            for recognition_model, similarity_type in required_embedding_modes:
+            for recognition_model, similarity_type in sorted(required_embedding_modes):
                 model_embeddings = embeddings_by_model.setdefault(recognition_model, {})
                 model_embeddings[similarity_type] = (
                     self._build_issue_scan_target_embedding(
@@ -2826,6 +2826,7 @@ class VideoProcessor(QObject):
     def scan_issue_frames(
         self,
         progress_callback=None,
+        issue_found_callback=None,
         is_cancelled=None,
         scan_ranges: Optional[List[Tuple[int, int]]] = None,
         target_height: Optional[int] = None,
@@ -2906,6 +2907,30 @@ class VideoProcessor(QObject):
                 if progress_callback:
                     progress_callback(total_frames_scanned, total_frames, frame_number)
 
+            def emit_issue(face_id: str, frame_number: int) -> None:
+                normalized_face_id = str(face_id)
+                face_frames = issue_frames_by_face.setdefault(normalized_face_id, set())
+                normalized_frame = int(frame_number)
+                if normalized_frame in face_frames:
+                    return
+                face_frames.add(normalized_frame)
+                if issue_found_callback:
+                    issue_found_callback(normalized_face_id, normalized_frame)
+
+            def build_result(cancelled: bool) -> dict[str, Any]:
+                faces_with_issues = sum(
+                    1 for frames in issue_frames_by_face.values() if frames
+                )
+                return {
+                    "issue_frames_by_face": {
+                        face_id: sorted(frames)
+                        for face_id, frames in issue_frames_by_face.items()
+                    },
+                    "frames_scanned": total_frames_scanned,
+                    "faces_with_issues": faces_with_issues,
+                    "cancelled": cancelled,
+                }
+
             for start_frame, end_frame, local_control, local_params in scan_segments:
                 current_segment_tracking_enabled = bool(
                     local_control.get("FaceTrackingEnableToggle", False)
@@ -2925,7 +2950,7 @@ class VideoProcessor(QObject):
 
                 while frame_number <= end_frame:
                     if is_cancelled and is_cancelled():
-                        return None
+                        return build_result(True)
                     if frame_number in dropped_frames_snapshot:
                         next_frame = frame_number + 1
                         while (
@@ -2945,7 +2970,7 @@ class VideoProcessor(QObject):
                     )
                     if not ret or not isinstance(frame_bgr, numpy.ndarray):
                         for face_id in issue_frames_by_face:
-                            issue_frames_by_face[face_id].add(frame_number)
+                            emit_issue(face_id, frame_number)
                         self.current_frame_number = frame_number + 1
                         misc_helpers.seek_frame(capture, self.current_frame_number)
                         total_frames_scanned += 1
@@ -3016,23 +3041,13 @@ class VideoProcessor(QObject):
 
                     for face_id in issue_frames_by_face:
                         if face_id not in matched_face_ids:
-                            issue_frames_by_face[face_id].add(frame_number)
+                            emit_issue(face_id, frame_number)
                     total_frames_scanned += 1
                     emit_progress(frame_number)
                     frame_number += 1
                 previous_segment_tracking_enabled = current_segment_tracking_enabled
 
-            faces_with_issues = sum(
-                1 for frames in issue_frames_by_face.values() if frames
-            )
-            return {
-                "issue_frames_by_face": {
-                    face_id: sorted(frames)
-                    for face_id, frames in issue_frames_by_face.items()
-                },
-                "frames_scanned": total_frames_scanned,
-                "faces_with_issues": faces_with_issues,
-            }
+            return build_result(False)
         finally:
             self.last_detected_faces = previous_last_detected_faces
             self._smoothed_kps = previous_smoothed_kps

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -2458,7 +2458,7 @@ class VideoProcessor(QObject):
     def _get_issue_scan_ranges(self) -> List[Tuple[int, int]]:
         """Return the frame ranges that a scan should inspect."""
         max_frame = int(self.max_frame_number)
-        complete_segments: List[Tuple[int, int]] = []
+        scan_ranges: List[Tuple[int, int]] = []
         open_start_frame: Optional[int] = None
 
         for start_frame, end_frame in self.main_window.job_marker_pairs:
@@ -2471,14 +2471,13 @@ class VideoProcessor(QObject):
 
             normalized_end = int(end_frame)
             if normalized_end >= normalized_start:
-                complete_segments.append((normalized_start, normalized_end))
+                scan_ranges.append((normalized_start, normalized_end))
 
-        scan_ranges = sorted(complete_segments)
         if open_start_frame is not None and open_start_frame <= max_frame:
             scan_ranges.append((open_start_frame, max_frame))
 
         if scan_ranges:
-            return scan_ranges
+            return misc_helpers.normalize_issue_scan_ranges(scan_ranges)
 
         return [(0, max_frame)]
 
@@ -2487,28 +2486,54 @@ class VideoProcessor(QObject):
     ) -> str:
         """Return a short human-readable description of the current scan scope."""
         scan_ranges = scan_ranges or self._get_issue_scan_ranges()
+        max_frame = int(self.max_frame_number)
+        if not getattr(self.main_window, "job_marker_pairs", []):
+            return "Scanning full clip"
+        if scan_ranges == [(0, max_frame)]:
+            return "Scanning full clip"
 
-        complete_segments = 0
-        open_start_frame: Optional[int] = None
-        for start_frame, end_frame in self.main_window.job_marker_pairs:
-            if start_frame is None:
-                continue
-            if end_frame is None:
-                open_start_frame = int(start_frame)
-            elif int(end_frame) >= int(start_frame):
-                complete_segments += 1
+        open_start_frames = [
+            int(start_frame)
+            for start_frame, end_frame in self.main_window.job_marker_pairs
+            if start_frame is not None and end_frame is None
+        ]
+        has_open_start = bool(open_start_frames)
+        open_start_frame = min(open_start_frames) if open_start_frames else None
 
-        if complete_segments and open_start_frame is not None:
-            range_label = "range" if complete_segments == 1 else "ranges"
+        if len(scan_ranges) == 1:
+            start_frame, end_frame = scan_ranges[0]
+            if (
+                has_open_start
+                and end_frame == max_frame
+                and open_start_frame is not None
+            ):
+                if start_frame < open_start_frame:
+                    return f"Scanning 1 marked range and record start frame {open_start_frame} to end"
+                if open_start_frame > 0:
+                    return f"Scanning from record start frame {open_start_frame}"
+            return "Scanning 1 marked range"
+
+        effective_complete_segments = len(scan_ranges)
+        effective_open_start_frame: Optional[int] = None
+        if (
+            has_open_start
+            and scan_ranges[-1][1] == max_frame
+            and open_start_frame is not None
+        ):
+            effective_open_start_frame = open_start_frame
+            effective_complete_segments -= 1
+
+        if effective_complete_segments and effective_open_start_frame is not None:
+            range_label = "range" if effective_complete_segments == 1 else "ranges"
             return (
-                f"Scanning {complete_segments} marked {range_label} "
-                f"and record start frame {open_start_frame} to end"
+                f"Scanning {effective_complete_segments} marked {range_label} "
+                f"and record start frame {effective_open_start_frame} to end"
             )
-        if complete_segments:
-            range_label = "range" if complete_segments == 1 else "ranges"
-            return f"Scanning {complete_segments} marked {range_label}"
-        if open_start_frame is not None:
-            return f"Scanning from record start frame {open_start_frame}"
+        if effective_complete_segments:
+            range_label = "range" if effective_complete_segments == 1 else "ranges"
+            return f"Scanning {effective_complete_segments} marked {range_label}"
+        if effective_open_start_frame is not None:
+            return f"Scanning from record start frame {effective_open_start_frame}"
         return "Scanning full clip"
 
     @staticmethod
@@ -2611,6 +2636,7 @@ class VideoProcessor(QObject):
         )
         previous_last_detected_faces = copy.deepcopy(self.last_detected_faces)
         previous_smoothed_kps = copy.deepcopy(self._smoothed_kps)
+        previous_smoothed_dense_kps = copy.deepcopy(self._smoothed_dense_kps)
         total_frames_scanned = 0
         issue_frames_by_face: dict[str, set[int]] = {
             str(face_id): set() for face_id in target_faces_snapshot.keys()
@@ -2619,6 +2645,7 @@ class VideoProcessor(QObject):
         try:
             self.last_detected_faces = []
             self._smoothed_kps = {}
+            self._smoothed_dense_kps = {}
 
             for start_frame, end_frame in scan_ranges:
                 misc_helpers.seek_frame(capture, start_frame)
@@ -2745,6 +2772,7 @@ class VideoProcessor(QObject):
         finally:
             self.last_detected_faces = previous_last_detected_faces
             self._smoothed_kps = previous_smoothed_kps
+            self._smoothed_dense_kps = previous_smoothed_dense_kps
             self.current_frame_number = (
                 reset_frame_number
                 if reset_frame_number is not None

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -38,6 +38,9 @@ from app.helpers.typing_helper import (
 if TYPE_CHECKING:
     from app.ui.main_ui import MainWindow
 
+IssueScanTargetEmbeddings = dict[str, dict[str, numpy.ndarray]]
+IssueScanTargetSnapshot = dict[str, dict[str, Any]]
+
 TAIL_TOLERANCE = 30  # BUG-07: 10 was too tight — codec trailing B-frames can cause read
 # failures in the last ~10 frames on H.264/H.265 content, dropping valid end frames.
 MAX_CONSECUTIVE_ERRORS = (
@@ -2560,6 +2563,7 @@ class VideoProcessor(QObject):
         base_control: ControlTypes,
         base_params: FacesParametersTypes,
         target_faces_snapshot: Optional[dict] = None,
+        control_defaults_snapshot: Optional[ControlTypes] = None,
     ) -> tuple[ControlTypes, FacesParametersTypes]:
         """Resolve the effective control/parameter state for a scan frame.
 
@@ -2580,9 +2584,16 @@ class VideoProcessor(QObject):
             FacesParametersTypes, copy.deepcopy(marker_data.get("parameters", {}))
         )
         local_control: ControlTypes = cast(ControlTypes, {})
-        for widget_name, widget in self.main_window.parameter_widgets.items():
-            if widget_name in self.main_window.control:
-                local_control[widget_name] = widget.default_value
+        local_control.update(
+            cast(
+                ControlTypes,
+                copy.deepcopy(
+                    control_defaults_snapshot
+                    if control_defaults_snapshot is not None
+                    else {}
+                ),
+            )
+        )
 
         control_data = marker_data.get("control")
         if isinstance(control_data, dict):
@@ -2590,7 +2601,12 @@ class VideoProcessor(QObject):
 
         # Mirror the playback helper behavior by ensuring every current target
         # face has a parameter dict, falling back to defaults when missing.
-        for face_id in (target_faces_snapshot or self.main_window.target_faces).keys():
+        active_target_faces = (
+            target_faces_snapshot
+            if target_faces_snapshot is not None
+            else self.main_window.target_faces
+        )
+        for face_id in active_target_faces.keys():
             face_id_str = str(face_id)
             if face_id_str not in local_params:
                 local_params[face_id_str] = cast(
@@ -2606,6 +2622,7 @@ class VideoProcessor(QObject):
         base_control: ControlTypes,
         base_params: FacesParametersTypes,
         target_faces_snapshot: dict,
+        control_defaults_snapshot: Optional[ControlTypes] = None,
     ) -> list[tuple[int, int, ControlTypes, FacesParametersTypes]]:
         """Group scan ranges into marker-stable segments."""
         marker_positions = sorted(
@@ -2626,6 +2643,7 @@ class VideoProcessor(QObject):
                 base_control,
                 base_params,
                 target_faces_snapshot,
+                control_defaults_snapshot,
             )
 
             for next_marker_frame in range_markers + [end_frame + 1]:
@@ -2641,33 +2659,46 @@ class VideoProcessor(QObject):
                         base_control,
                         base_params,
                         target_faces_snapshot,
+                        control_defaults_snapshot,
                     )
 
         return segments
+
+    def _reset_issue_scan_sequential_state(self) -> None:
+        """Clear scan-local sequential detection state at tracking boundaries."""
+        self.last_detected_faces = []
+        self._smoothed_kps = {}
+        self._smoothed_dense_kps = {}
 
     def _prepare_issue_scan_match_context(
         self,
         local_control: ControlTypes,
         local_params: FacesParametersTypes,
-        target_faces_snapshot: dict,
+        target_faces_snapshot: IssueScanTargetSnapshot,
     ) -> dict[str, Any]:
         """Precompute target embeddings and thresholds for a stable scan segment."""
         recognition_model = str(
             local_control.get("RecognitionModelSelection", "arcface_128")
         )
-        similarity_type = local_control.get("SimilarityTypeSelection", "Opal")
+        similarity_type = str(local_control.get("SimilarityTypeSelection", "Opal"))
         default_params = dict(self.main_window.default_parameters.data)
-        prepared_targets: list[tuple[Any, float, numpy.ndarray]] = []
+        prepared_targets: list[tuple[str, float, numpy.ndarray]] = []
 
-        for target_id, target_face in target_faces_snapshot.items():
-            face_id_str = str(getattr(target_face, "face_id", target_id))
+        for target_id, target_face_snapshot in target_faces_snapshot.items():
+            face_id_str = str(target_face_snapshot.get("face_id", target_id))
             face_specific_params = misc_helpers.copy_mapping_data(
                 local_params.get(face_id_str)
             )
             params_pd = misc_helpers.ParametersDict(
                 face_specific_params, default_params
             )
-            target_embedding = target_face.get_embedding(recognition_model)
+            target_embeddings = cast(
+                IssueScanTargetEmbeddings,
+                target_face_snapshot.get("embeddings_by_model", {}),
+            )
+            target_embedding = target_embeddings.get(recognition_model, {}).get(
+                similarity_type
+            )
             if (
                 not isinstance(target_embedding, numpy.ndarray)
                 or target_embedding.size == 0
@@ -2675,7 +2706,7 @@ class VideoProcessor(QObject):
                 continue
             prepared_targets.append(
                 (
-                    target_face,
+                    face_id_str,
                     float(params_pd["SimilarityThresholdSlider"]),
                     target_embedding,
                 )
@@ -2690,21 +2721,107 @@ class VideoProcessor(QObject):
     def _find_best_target_match_for_scan(
         self,
         detected_embedding: numpy.ndarray,
-        prepared_targets: list[tuple[Any, float, numpy.ndarray]],
-    ) -> Any | None:
+        prepared_targets: list[tuple[str, float, numpy.ndarray]],
+    ) -> str | None:
         """Return the best target face using a precomputed scan match context."""
         best_target = None
         highest_sim = -1.0
 
-        for target_face, threshold, target_embedding in prepared_targets:
+        for target_face_id, threshold, target_embedding in prepared_targets:
             sim = self.main_window.models_processor.findCosineDistance(
                 detected_embedding, target_embedding
             )
             if sim >= threshold and sim > highest_sim:
                 highest_sim = sim
-                best_target = target_face
+                best_target = target_face_id
 
         return best_target
+
+    def _build_issue_scan_target_embedding(
+        self,
+        target_face: Any,
+        recognition_model: str,
+        similarity_type: str,
+    ) -> numpy.ndarray:
+        cropped_face = getattr(target_face, "cropped_face", None)
+        if not isinstance(cropped_face, numpy.ndarray) or cropped_face.size == 0:
+            return numpy.array([])
+        image = numpy.ascontiguousarray(cropped_face)
+        image_uint8 = (
+            image if image.dtype == numpy.uint8 else image.astype("uint8", copy=False)
+        )
+        image_tensor = (
+            torch.from_numpy(image_uint8)
+            .to(self.main_window.models_processor.device, non_blocking=True)
+            .permute(2, 0, 1)
+        )
+        height, width = image_uint8.shape[:2]
+        full_face_kps = numpy.array(
+            [
+                [0.3 * width, 0.35 * height],
+                [0.7 * width, 0.35 * height],
+                [0.5 * width, 0.55 * height],
+                [0.35 * width, 0.75 * height],
+                [0.65 * width, 0.75 * height],
+            ],
+            dtype=numpy.float32,
+        )
+        face_emb, _ = self.main_window.models_processor.run_recognize_direct(
+            image_tensor,
+            full_face_kps,
+            similarity_type,
+            recognition_model,
+        )
+        return face_emb if isinstance(face_emb, numpy.ndarray) else numpy.array([])
+
+    def prepare_issue_scan_target_faces_snapshot(
+        self,
+        scan_ranges: list[tuple[int, int]],
+        base_control: ControlTypes,
+        base_params: FacesParametersTypes,
+        control_defaults_snapshot: Optional[ControlTypes] = None,
+    ) -> IssueScanTargetSnapshot:
+        """Build a worker-safe target-face snapshot for issue scans."""
+        live_target_faces = dict(self.main_window.target_faces)
+        if not live_target_faces:
+            return {}
+
+        scan_segments = self._build_issue_scan_state_segments(
+            scan_ranges,
+            base_control,
+            base_params,
+            live_target_faces,
+            control_defaults_snapshot,
+        )
+        required_embedding_modes = {
+            (
+                str(local_control.get("RecognitionModelSelection", "arcface_128")),
+                str(local_control.get("SimilarityTypeSelection", "Opal")),
+            )
+            for _start_frame, _end_frame, local_control, _local_params in scan_segments
+        }
+        if not required_embedding_modes:
+            required_embedding_modes = {("arcface_128", "Opal")}
+
+        target_faces_snapshot: IssueScanTargetSnapshot = {}
+        for target_id, target_face in live_target_faces.items():
+            embeddings_by_model: IssueScanTargetEmbeddings = {}
+            for recognition_model, similarity_type in required_embedding_modes:
+                model_embeddings = embeddings_by_model.setdefault(recognition_model, {})
+                model_embeddings[similarity_type] = (
+                    self._build_issue_scan_target_embedding(
+                        target_face,
+                        recognition_model,
+                        similarity_type,
+                    )
+                )
+
+            target_faces_snapshot[str(target_id)] = {
+                "face_id": str(getattr(target_face, "face_id", target_id)),
+                "embeddings_by_model": embeddings_by_model,
+            }
+
+        return target_faces_snapshot
 
     def scan_issue_frames(
         self,
@@ -2714,7 +2831,8 @@ class VideoProcessor(QObject):
         target_height: Optional[int] = None,
         base_control: Optional[dict] = None,
         base_params: Optional[dict] = None,
-        target_faces_snapshot: Optional[dict] = None,
+        target_faces_snapshot: Optional[IssueScanTargetSnapshot] = None,
+        control_defaults_snapshot: Optional[dict] = None,
         reset_frame_number: Optional[int] = None,
     ) -> Optional[dict]:
         """Run a full-frame detection scan and return issue-frame results."""
@@ -2735,39 +2853,69 @@ class VideoProcessor(QObject):
             else self._get_target_input_height()
         )
         base_control = cast(
-            ControlTypes, copy.deepcopy(base_control or self.main_window.control)
+            ControlTypes,
+            copy.deepcopy(
+                base_control if base_control is not None else self.main_window.control
+            ),
         )
         base_params = cast(
             FacesParametersTypes,
-            copy.deepcopy(base_params or self.main_window.parameters),
+            copy.deepcopy(
+                base_params if base_params is not None else self.main_window.parameters
+            ),
         )
-        target_faces_snapshot = dict(
-            target_faces_snapshot or self.main_window.target_faces
-        )
+        if target_faces_snapshot is None:
+            target_faces_snapshot = self.prepare_issue_scan_target_faces_snapshot(
+                scan_ranges,
+                base_control,
+                base_params,
+                cast(Optional[ControlTypes], control_defaults_snapshot),
+            )
+        else:
+            target_faces_snapshot = cast(
+                IssueScanTargetSnapshot,
+                dict(target_faces_snapshot),
+            )
         previous_last_detected_faces = copy.deepcopy(self.last_detected_faces)
         previous_smoothed_kps = copy.deepcopy(self._smoothed_kps)
         previous_smoothed_dense_kps = copy.deepcopy(self._smoothed_dense_kps)
         total_frames_scanned = 0
+        tracking_enabled = False
         issue_frames_by_face: dict[str, set[int]] = {
             str(face_id): set() for face_id in target_faces_snapshot.keys()
         }
 
         try:
-            self.last_detected_faces = []
-            self._smoothed_kps = {}
-            self._smoothed_dense_kps = {}
+            self._reset_issue_scan_sequential_state()
             scan_segments = self._build_issue_scan_state_segments(
                 scan_ranges,
                 base_control,
                 base_params,
                 target_faces_snapshot,
+                cast(Optional[ControlTypes], control_defaults_snapshot),
             )
+            tracking_enabled = any(
+                bool(local_control.get("FaceTrackingEnableToggle", False))
+                for _start_frame, _end_frame, local_control, _local_params in scan_segments
+            )
+            if tracking_enabled:
+                self.main_window.models_processor.face_detectors.reset_tracker()
+            previous_segment_tracking_enabled: Optional[bool] = None
 
             def emit_progress(frame_number: int) -> None:
                 if progress_callback:
                     progress_callback(total_frames_scanned, total_frames, frame_number)
 
             for start_frame, end_frame, local_control, local_params in scan_segments:
+                current_segment_tracking_enabled = bool(
+                    local_control.get("FaceTrackingEnableToggle", False)
+                )
+                if (
+                    current_segment_tracking_enabled
+                    and previous_segment_tracking_enabled is False
+                ):
+                    self.main_window.models_processor.face_detectors.reset_tracker()
+                    self._reset_issue_scan_sequential_state()
                 match_context = self._prepare_issue_scan_match_context(
                     local_control, local_params, target_faces_snapshot
                 )
@@ -2860,11 +3008,11 @@ class VideoProcessor(QObject):
                     matched_face_ids: set[str] = set()
                     prepared_targets = match_context["prepared_targets"]
                     for detected_embedding in detected_embeddings:
-                        best_target = self._find_best_target_match_for_scan(
+                        best_target_face_id = self._find_best_target_match_for_scan(
                             detected_embedding, prepared_targets
                         )
-                        if best_target is not None:
-                            matched_face_ids.add(str(best_target.face_id))
+                        if best_target_face_id is not None:
+                            matched_face_ids.add(best_target_face_id)
 
                     for face_id in issue_frames_by_face:
                         if face_id not in matched_face_ids:
@@ -2872,6 +3020,7 @@ class VideoProcessor(QObject):
                     total_frames_scanned += 1
                     emit_progress(frame_number)
                     frame_number += 1
+                previous_segment_tracking_enabled = current_segment_tracking_enabled
 
             faces_with_issues = sum(
                 1 for frames in issue_frames_by_face.values() if frames
@@ -2888,6 +3037,8 @@ class VideoProcessor(QObject):
             self.last_detected_faces = previous_last_detected_faces
             self._smoothed_kps = previous_smoothed_kps
             self._smoothed_dense_kps = previous_smoothed_dense_kps
+            if tracking_enabled:
+                self.main_window.models_processor.face_detectors.reset_tracker()
             self.current_frame_number = (
                 reset_frame_number
                 if reset_frame_number is not None

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -1,6 +1,6 @@
 import threading
 import queue
-from typing import TYPE_CHECKING, Dict, Tuple, Optional, cast, List
+from typing import TYPE_CHECKING, Any, Dict, Tuple, Optional, cast, List
 import time
 import subprocess
 from pathlib import Path
@@ -416,6 +416,7 @@ class VideoProcessor(QObject):
         frame_rgb: numpy.ndarray,
         local_control_for_worker: dict,
         local_params_for_worker: dict | None = None,
+        frame_tensor: torch.Tensor | None = None,
     ):
         """
         Runs face detection sequentially in the feeder thread to guarantee
@@ -494,12 +495,14 @@ class VideoProcessor(QObject):
                 previous_faces_arg = self.last_detected_faces
             device = self.main_window.models_processor.device
 
-            # OPTIMISATION PCIe : non_blocking=True frees CPU immediately
-            frame_tensor = (
-                torch.from_numpy(frame_rgb)
-                .to(device, non_blocking=True)
-                .permute(2, 0, 1)  # Convert [H, W, C] -> [C, H, W]
-            )
+            owns_frame_tensor = frame_tensor is None
+            if frame_tensor is None:
+                # OPTIMISATION PCIe : non_blocking=True frees CPU immediately
+                frame_tensor = (
+                    torch.from_numpy(frame_rgb)
+                    .to(device, non_blocking=True)
+                    .permute(2, 0, 1)  # Convert [H, W, C] -> [C, H, W]
+                )
 
             # 1. Run Detection
             bboxes, kpss_5, kpss = self.main_window.models_processor.run_detect(
@@ -524,7 +527,8 @@ class VideoProcessor(QObject):
                 previous_detections=previous_faces_arg,
             )
             # Free up VRAM immediately since the tensor is no longer needed in this thread
-            del frame_tensor
+            if owns_frame_tensor:
+                del frame_tensor
 
             # CUDA Stream Sync: Safely wait for GPU on the current stream
             if local_stream:
@@ -2596,6 +2600,112 @@ class VideoProcessor(QObject):
 
         return local_control, local_params
 
+    def _build_issue_scan_state_segments(
+        self,
+        scan_ranges: List[Tuple[int, int]],
+        base_control: ControlTypes,
+        base_params: FacesParametersTypes,
+        target_faces_snapshot: dict,
+    ) -> list[tuple[int, int, ControlTypes, FacesParametersTypes]]:
+        """Group scan ranges into marker-stable segments."""
+        marker_positions = sorted(
+            int(frame_number)
+            for frame_number in getattr(self.main_window, "markers", {}).keys()
+        )
+        segments: list[tuple[int, int, ControlTypes, FacesParametersTypes]] = []
+
+        for start_frame, end_frame in scan_ranges:
+            range_markers = [
+                marker_frame
+                for marker_frame in marker_positions
+                if start_frame < marker_frame <= end_frame
+            ]
+            segment_start = start_frame
+            local_control, local_params = self._resolve_scan_state_for_frame(
+                start_frame,
+                base_control,
+                base_params,
+                target_faces_snapshot,
+            )
+
+            for next_marker_frame in range_markers + [end_frame + 1]:
+                segment_end = next_marker_frame - 1
+                if segment_end >= segment_start:
+                    segments.append(
+                        (segment_start, segment_end, local_control, local_params)
+                    )
+                if next_marker_frame <= end_frame:
+                    segment_start = next_marker_frame
+                    local_control, local_params = self._resolve_scan_state_for_frame(
+                        next_marker_frame,
+                        base_control,
+                        base_params,
+                        target_faces_snapshot,
+                    )
+
+        return segments
+
+    def _prepare_issue_scan_match_context(
+        self,
+        local_control: ControlTypes,
+        local_params: FacesParametersTypes,
+        target_faces_snapshot: dict,
+    ) -> dict[str, Any]:
+        """Precompute target embeddings and thresholds for a stable scan segment."""
+        recognition_model = str(
+            local_control.get("RecognitionModelSelection", "arcface_128")
+        )
+        similarity_type = local_control.get("SimilarityTypeSelection", "Opal")
+        default_params = dict(self.main_window.default_parameters.data)
+        prepared_targets: list[tuple[Any, float, numpy.ndarray]] = []
+
+        for target_id, target_face in target_faces_snapshot.items():
+            face_id_str = str(getattr(target_face, "face_id", target_id))
+            face_specific_params = misc_helpers.copy_mapping_data(
+                local_params.get(face_id_str)
+            )
+            params_pd = misc_helpers.ParametersDict(
+                face_specific_params, default_params
+            )
+            target_embedding = target_face.get_embedding(recognition_model)
+            if (
+                not isinstance(target_embedding, numpy.ndarray)
+                or target_embedding.size == 0
+            ):
+                continue
+            prepared_targets.append(
+                (
+                    target_face,
+                    float(params_pd["SimilarityThresholdSlider"]),
+                    target_embedding,
+                )
+            )
+
+        return {
+            "recognition_model": recognition_model,
+            "similarity_type": similarity_type,
+            "prepared_targets": prepared_targets,
+        }
+
+    def _find_best_target_match_for_scan(
+        self,
+        detected_embedding: numpy.ndarray,
+        prepared_targets: list[tuple[Any, float, numpy.ndarray]],
+    ) -> Any | None:
+        """Return the best target face using a precomputed scan match context."""
+        best_target = None
+        highest_sim = -1.0
+
+        for target_face, threshold, target_embedding in prepared_targets:
+            sim = self.main_window.models_processor.findCosineDistance(
+                detected_embedding, target_embedding
+            )
+            if sim >= threshold and sim > highest_sim:
+                highest_sim = sim
+                best_target = target_face
+
+        return best_target
+
     def scan_issue_frames(
         self,
         progress_callback=None,
@@ -2646,18 +2756,40 @@ class VideoProcessor(QObject):
             self.last_detected_faces = []
             self._smoothed_kps = {}
             self._smoothed_dense_kps = {}
+            scan_segments = self._build_issue_scan_state_segments(
+                scan_ranges,
+                base_control,
+                base_params,
+                target_faces_snapshot,
+            )
 
-            for start_frame, end_frame in scan_ranges:
+            def emit_progress(frame_number: int) -> None:
+                if progress_callback:
+                    progress_callback(total_frames_scanned, total_frames, frame_number)
+
+            for start_frame, end_frame, local_control, local_params in scan_segments:
+                match_context = self._prepare_issue_scan_match_context(
+                    local_control, local_params, target_faces_snapshot
+                )
                 misc_helpers.seek_frame(capture, start_frame)
                 self.current_frame_number = start_frame
+                frame_number = start_frame
 
-                for frame_number in range(start_frame, end_frame + 1):
+                while frame_number <= end_frame:
                     if is_cancelled and is_cancelled():
                         return None
                     if frame_number in dropped_frames_snapshot:
-                        self.current_frame_number = frame_number + 1
+                        next_frame = frame_number + 1
+                        while (
+                            next_frame <= end_frame
+                            and next_frame in dropped_frames_snapshot
+                        ):
+                            next_frame += 1
+                        self.current_frame_number = next_frame
                         misc_helpers.seek_frame(capture, self.current_frame_number)
+                        frame_number = next_frame
                         continue
+
                     ret, frame_bgr = misc_helpers.read_frame(
                         capture,
                         self.media_rotation,
@@ -2669,22 +2801,27 @@ class VideoProcessor(QObject):
                         self.current_frame_number = frame_number + 1
                         misc_helpers.seek_frame(capture, self.current_frame_number)
                         total_frames_scanned += 1
-                        if progress_callback:
-                            progress_callback(
-                                total_frames_scanned, total_frames, frame_number
-                            )
+                        emit_progress(frame_number)
+                        frame_number += 1
                         continue
 
                     frame_rgb = numpy.ascontiguousarray(frame_bgr[..., ::-1])
-                    local_control, local_params = self._resolve_scan_state_for_frame(
-                        frame_number,
-                        base_control,
-                        base_params,
-                        target_faces_snapshot,
+                    frame_rgb_uint8 = (
+                        frame_rgb
+                        if frame_rgb.dtype == numpy.uint8
+                        else frame_rgb.astype("uint8", copy=False)
+                    )
+                    frame_tensor = (
+                        torch.from_numpy(frame_rgb_uint8)
+                        .to(self.main_window.models_processor.device, non_blocking=True)
+                        .permute(2, 0, 1)
                     )
                     self.current_frame_number = frame_number
                     bboxes, kpss_5, _ = self._run_sequential_detection(
-                        frame_rgb, local_control, local_params
+                        frame_rgb,
+                        local_control,
+                        local_params,
+                        frame_tensor=frame_tensor,
                     )
                     detected_embeddings: list[numpy.ndarray] = []
                     if (
@@ -2694,19 +2831,8 @@ class VideoProcessor(QObject):
                         and kpss_5.shape[0] > 0
                     ):
                         max_faces = min(bboxes.shape[0], kpss_5.shape[0])
-                        frame_tensor = (
-                            torch.from_numpy(frame_rgb.astype("uint8"))
-                            .to(self.main_window.models_processor.device)
-                            .permute(2, 0, 1)
-                        )
-                        recognition_model = str(
-                            local_control.get(
-                                "RecognitionModelSelection", "arcface_128"
-                            )
-                        )
-                        similarity_type = local_control.get(
-                            "SimilarityTypeSelection", "Opal"
-                        )
+                        recognition_model = match_context["recognition_model"]
+                        similarity_type = match_context["similarity_type"]
                         for face_index in range(max_faces):
                             face_kps = kpss_5[face_index]
                             face_bbox = bboxes[face_index]
@@ -2729,22 +2855,13 @@ class VideoProcessor(QObject):
                                 and face_emb.size > 0
                             ):
                                 detected_embeddings.append(face_emb)
-                        del frame_tensor
+                    del frame_tensor
 
                     matched_face_ids: set[str] = set()
-                    recognition_model = str(
-                        local_control.get("RecognitionModelSelection", "arcface_128")
-                    )
-                    default_params = dict(self.main_window.default_parameters.data)
-
+                    prepared_targets = match_context["prepared_targets"]
                     for detected_embedding in detected_embeddings:
-                        best_target, _, _ = misc_helpers.find_best_target_match(
-                            detected_embedding,
-                            self.main_window.models_processor,
-                            target_faces_snapshot,
-                            local_params,
-                            default_params,
-                            recognition_model,
+                        best_target = self._find_best_target_match_for_scan(
+                            detected_embedding, prepared_targets
                         )
                         if best_target is not None:
                             matched_face_ids.add(str(best_target.face_id))
@@ -2753,10 +2870,8 @@ class VideoProcessor(QObject):
                         if face_id not in matched_face_ids:
                             issue_frames_by_face[face_id].add(frame_number)
                     total_frames_scanned += 1
-                    if progress_callback:
-                        progress_callback(
-                            total_frames_scanned, total_frames, frame_number
-                        )
+                    emit_progress(frame_number)
+                    frame_number += 1
 
             faces_with_issues = sum(
                 1 for frames in issue_frames_by_face.values() if frames

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -604,10 +604,10 @@ def add_scan_review_controls(main_window: "MainWindow"):
         "Flags likely issue frames for the selected target face.\n"
         "Single-frame preview may differ from playback on borderline frames."
     )
-    run_scan_button.setFlat(True)
     run_scan_button.setSizePolicy(
         QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
     )
+    run_scan_button.setFlat(True)
     run_scan_button.clicked.connect(lambda: toggle_issue_scan(main_window))
     main_window.runScanButton = run_scan_button
 
@@ -1052,9 +1052,6 @@ def _handle_issue_scan_progress(
     run_button = getattr(main_window, "runScanButton", None)
     if run_button is not None:
         run_button.setText(f"Abort Scan ({processed}/{max(total, 1)})")
-        run_button.setToolTip(
-            f"{scope_text}\n{processed}/{total} processed | FPS: {scan_fps:.1f}\nAbort the active issue scan."
-        )
     QtCore.QCoreApplication.processEvents()
 
 

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -608,7 +608,7 @@ def add_scan_review_controls(main_window: "MainWindow"):
     run_scan_button.setSizePolicy(
         QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
     )
-    run_scan_button.clicked.connect(lambda: run_issue_scan(main_window))
+    run_scan_button.clicked.connect(lambda: toggle_issue_scan(main_window))
     main_window.runScanButton = run_scan_button
 
     button_specs = [
@@ -794,6 +794,20 @@ def set_issue_frames_for_face(main_window: "MainWindow", face_id, frames):
         refresh_issue_frames_for_selected_face(main_window)
 
 
+def add_issue_frame_for_face(main_window: "MainWindow", face_id, frame_number: int):
+    """Merge a single issue frame into the stored per-face mapping."""
+    if face_id is None:
+        return
+    normalized_face_id = str(face_id)
+    face_frames = main_window.issue_frames_by_face.setdefault(normalized_face_id, set())
+    normalized_frame = int(frame_number)
+    if normalized_frame in face_frames:
+        return
+    face_frames.add(normalized_frame)
+    if normalized_face_id == str(getattr(main_window, "selected_target_face_id", None)):
+        refresh_issue_frames_for_selected_face(main_window)
+
+
 def set_issue_frames_by_face(main_window: "MainWindow", frames_by_face):
     """Replaces all stored issue results and refreshes visible markers for the selected face."""
     normalized_mapping: dict[str, set[int]] = {}
@@ -889,6 +903,143 @@ def move_slider_to_previous_issue(main_window: "MainWindow"):
     _move_slider_to_nearest_issue(main_window, "previous")
 
 
+def _set_slider_frame_without_side_effects(
+    main_window: "MainWindow", frame_number: int
+) -> None:
+    slider = main_window.videoSeekSlider
+    slider.blockSignals(True)
+    slider.setValue(int(frame_number))
+    slider.blockSignals(False)
+    slider.update()
+
+
+def _get_issue_scan_ui_state(main_window: "MainWindow") -> dict:
+    state = getattr(main_window, "scan_issue_ui_state", None)
+    if state is None:
+        state = {}
+        main_window.scan_issue_ui_state = state
+    return state
+
+
+def _restore_issue_scan_display(main_window: "MainWindow") -> None:
+    video_processor = getattr(main_window, "video_processor", None)
+    process_current_frame = getattr(video_processor, "process_current_frame", None)
+    if callable(process_current_frame):
+        process_current_frame()
+
+
+def _set_issue_scan_tool_button_state(
+    main_window: "MainWindow", scan_active: bool
+) -> None:
+    run_button = getattr(main_window, "runScanButton", None)
+    if run_button is not None:
+        run_button.setEnabled(
+            True if scan_active else bool(getattr(main_window, "target_faces", {}))
+        )
+
+    for button_name in (
+        "prevIssueButton",
+        "nextIssueButton",
+        "dropFrameButton",
+        "dropAllIssueFramesButton",
+        "clearScanResultsButton",
+        "clearDroppedFramesButton",
+    ):
+        button = getattr(main_window, button_name, None)
+        if button is not None:
+            button.setEnabled(not scan_active)
+
+
+def _start_issue_scan_ui(main_window: "MainWindow", worker, scope_text: str) -> None:
+    state = _get_issue_scan_ui_state(main_window)
+    state.clear()
+    state.update(
+        {
+            "active": True,
+            "start_frame": int(main_window.videoSeekSlider.value()),
+            "scope_text": scope_text,
+            "keep_controls": bool(main_window.control.get("KeepControlsToggle", False)),
+        }
+    )
+
+    if not state["keep_controls"]:
+        layout_actions.disable_all_parameters_and_control_widget(main_window)
+
+    _set_issue_scan_tool_button_state(main_window, True)
+
+    run_button = getattr(main_window, "runScanButton", None)
+    if run_button is not None:
+        run_button.setText("Abort Scan")
+        run_button.setToolTip(
+            f"{scope_text}\nAbort the active issue scan and keep the issue frames found so far."
+        )
+
+    play_button = getattr(main_window, "buttonMediaPlay", None)
+    if play_button is not None:
+        play_button.setEnabled(False)
+
+    record_button = getattr(main_window, "buttonMediaRecord", None)
+    if record_button is not None:
+        record_button.setEnabled(False)
+
+    toggle_button = getattr(main_window, "scanToolsToggleButton", None)
+    if toggle_button is not None:
+        toggle_button.setEnabled(False)
+
+    QtCore.QCoreApplication.processEvents()
+
+
+def _restore_issue_scan_ui(main_window: "MainWindow") -> None:
+    state = _get_issue_scan_ui_state(main_window)
+    if not state.get("active"):
+        return
+
+    if not state.get("keep_controls", False):
+        layout_actions.enable_all_parameters_and_control_widget(main_window)
+
+    start_frame = int(state.get("start_frame", main_window.videoSeekSlider.value()))
+    _set_slider_frame_without_side_effects(main_window, start_frame)
+    main_window.video_processor.current_frame_number = start_frame
+
+    run_button = getattr(main_window, "runScanButton", None)
+    if run_button is not None:
+        run_button.setText("Scan for Issues")
+        run_button.setToolTip(
+            "Scans the current render range using your current settings.\n"
+            "If record markers exist, only those ranges are scanned.\n"
+            "Saved settings markers are applied during the scan.\n"
+            "Flags likely issue frames for the selected target face.\n"
+            "Single-frame preview may differ from playback on borderline frames."
+        )
+
+    play_button = getattr(main_window, "buttonMediaPlay", None)
+    if play_button is not None:
+        play_button.setEnabled(True)
+
+    record_button = getattr(main_window, "buttonMediaRecord", None)
+    if record_button is not None:
+        record_button.setEnabled(True)
+
+    toggle_button = getattr(main_window, "scanToolsToggleButton", None)
+    if toggle_button is not None:
+        toggle_button.setEnabled(True)
+
+    state.clear()
+    _set_issue_scan_tool_button_state(main_window, False)
+    update_scan_review_button_states(main_window)
+    update_drop_frame_button_label(main_window)
+    _restore_issue_scan_display(main_window)
+    QtCore.QCoreApplication.processEvents()
+
+
+def toggle_issue_scan(main_window: "MainWindow") -> None:
+    worker = getattr(main_window, "scan_issue_worker", None)
+    if worker is not None:
+        worker.cancel()
+        return
+    run_issue_scan(main_window)
+
+
 def _handle_issue_scan_progress(
     main_window: "MainWindow",
     scope_text: str,
@@ -897,13 +1048,20 @@ def _handle_issue_scan_progress(
     frame_number: int,
     scan_fps: float,
 ):
-    dialog = main_window.scan_progress_dialog
-    dialog.setMaximum(max(total, 1))
-    dialog.setValue(min(processed, max(total, 1)))
-    dialog.setLabelText(
-        f"{scope_text}\n{processed}/{total} processed | FPS: {scan_fps:.1f}"
-    )
+    _set_slider_frame_without_side_effects(main_window, frame_number)
+    run_button = getattr(main_window, "runScanButton", None)
+    if run_button is not None:
+        run_button.setText(f"Abort Scan ({processed}/{max(total, 1)})")
+        run_button.setToolTip(
+            f"{scope_text}\n{processed}/{total} processed | FPS: {scan_fps:.1f}\nAbort the active issue scan."
+        )
     QtCore.QCoreApplication.processEvents()
+
+
+def _handle_issue_scan_issue_found(
+    main_window: "MainWindow", face_id: str, frame_number: int
+) -> None:
+    add_issue_frame_for_face(main_window, face_id, frame_number)
 
 
 def _cleanup_issue_scan_worker(main_window: "MainWindow"):
@@ -913,15 +1071,6 @@ def _cleanup_issue_scan_worker(main_window: "MainWindow"):
         main_window.scan_issue_worker = None
 
 
-def _finish_issue_scan_dialog(main_window: "MainWindow"):
-    dialog = main_window.scan_progress_dialog
-    try:
-        dialog.canceled.disconnect()
-    except RuntimeError:
-        pass
-    dialog.close()
-
-
 def _handle_issue_scan_completed(
     main_window: "MainWindow",
     issue_frames_by_face: dict,
@@ -929,18 +1078,26 @@ def _handle_issue_scan_completed(
     faces_with_issues: int,
     scope_text: str,
     elapsed_seconds: float,
+    cancelled: bool = False,
 ):
     set_issue_frames_by_face(main_window, issue_frames_by_face)
-    _finish_issue_scan_dialog(main_window)
+    _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)
     total_issue_frames = sum(
         len(set(frames)) for frames in issue_frames_by_face.values()
     )
     scan_fps = (frames_scanned / elapsed_seconds) if elapsed_seconds > 0 else 0.0
     print(
-        f"[INFO] Scan: Scope: {scope_text.removeprefix('Scanning ')} | Frames: {frames_scanned} | Time: {elapsed_seconds:.1f}s | FPS: {scan_fps:.1f} | Issues: {total_issue_frames} | Faces with issues: {faces_with_issues}"
+        f"[INFO] Scan: Scope: {scope_text.removeprefix('Scanning ')} | Frames: {frames_scanned} | Time: {elapsed_seconds:.1f}s | FPS: {scan_fps:.1f} | Issues: {total_issue_frames} | Faces with issues: {faces_with_issues} | Cancelled: {cancelled}"
     )
-    if total_issue_frames:
+    if cancelled:
+        common_widget_actions.create_and_show_toast_message(
+            main_window,
+            "Scan Aborted",
+            f"Stopped after {frames_scanned} scanned frames. Kept {total_issue_frames} issue frames found so far.",
+            style_type="warning",
+        )
+    elif total_issue_frames:
         common_widget_actions.create_and_show_toast_message(
             main_window,
             "Scan Complete",
@@ -955,24 +1112,24 @@ def _handle_issue_scan_completed(
 
 
 def _handle_issue_scan_cancelled(main_window: "MainWindow"):
-    _finish_issue_scan_dialog(main_window)
+    _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)
     common_widget_actions.create_and_show_toast_message(
         main_window,
         "Scan Cancelled",
-        "Issue scan aborted. Previous scan results were kept.",
+        "Issue scan aborted before finalizing. Kept any issue frames found so far.",
         style_type="warning",
     )
 
 
 def _handle_issue_scan_failed(main_window: "MainWindow", error_message: str):
-    _finish_issue_scan_dialog(main_window)
+    _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)
     common_widget_actions.create_and_show_messagebox(
         main_window,
         "Scan Failed",
         error_message,
-        main_window.scan_progress_dialog,
+        main_window.runScanButton,
     )
 
 
@@ -1012,13 +1169,20 @@ def run_issue_scan(main_window: "MainWindow"):
     worker = ui_workers.IssueScanWorker(main_window)
     main_window.scan_issue_worker = worker
     scope_text = worker._scan_scope_text
+    set_issue_frames_by_face(main_window, {})
+    _start_issue_scan_ui(main_window, worker, scope_text)
     worker.progress.connect(
         lambda processed, total, frame_number, scan_fps: _handle_issue_scan_progress(
             main_window, scope_text, processed, total, frame_number, scan_fps
         )
     )
+    worker.issue_found.connect(
+        lambda face_id, frame_number: _handle_issue_scan_issue_found(
+            main_window, face_id, frame_number
+        )
+    )
     worker.completed.connect(
-        lambda issue_frames_by_face, frames_scanned, faces_with_issues, completed_scope_text, elapsed_seconds: (
+        lambda issue_frames_by_face, frames_scanned, faces_with_issues, completed_scope_text, elapsed_seconds, cancelled: (
             _handle_issue_scan_completed(
                 main_window,
                 issue_frames_by_face,
@@ -1026,6 +1190,7 @@ def run_issue_scan(main_window: "MainWindow"):
                 faces_with_issues,
                 completed_scope_text,
                 elapsed_seconds,
+                cancelled,
             )
         )
     )
@@ -1033,19 +1198,6 @@ def run_issue_scan(main_window: "MainWindow"):
     worker.failed.connect(
         lambda error_message: _handle_issue_scan_failed(main_window, error_message)
     )
-
-    dialog = main_window.scan_progress_dialog
-    try:
-        dialog.canceled.disconnect()
-    except RuntimeError:
-        pass
-    dialog.setWindowTitle("Scan")
-    dialog.setLabelText(f"{scope_text}\nPreparing scan...")
-    dialog.setRange(0, 1)
-    dialog.setValue(0)
-    dialog.setMinimumWidth(420)
-    dialog.canceled.connect(worker.cancel)
-    dialog.show()
     worker.start()
 
 

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -895,11 +895,14 @@ def _handle_issue_scan_progress(
     processed: int,
     total: int,
     frame_number: int,
+    scan_fps: float,
 ):
     dialog = main_window.scan_progress_dialog
     dialog.setMaximum(max(total, 1))
     dialog.setValue(min(processed, max(total, 1)))
-    dialog.setLabelText(f"{scope_text}\nScanning frame {frame_number} of {total}...")
+    dialog.setLabelText(
+        f"{scope_text}\n{processed}/{total} processed | FPS: {scan_fps:.1f}"
+    )
     QtCore.QCoreApplication.processEvents()
 
 
@@ -1010,8 +1013,8 @@ def run_issue_scan(main_window: "MainWindow"):
     main_window.scan_issue_worker = worker
     scope_text = worker._scan_scope_text
     worker.progress.connect(
-        lambda processed, total, frame_number: _handle_issue_scan_progress(
-            main_window, scope_text, processed, total, frame_number
+        lambda processed, total, frame_number, scan_fps: _handle_issue_scan_progress(
+            main_window, scope_text, processed, total, frame_number, scan_fps
         )
     )
     worker.completed.connect(

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -181,7 +181,19 @@ class IssueScanWorker(qtc.QThread):
         self._base_params = {
             face_id: params.copy() for face_id, params in main_window.parameters.items()
         }
-        self._target_faces_snapshot = dict(main_window.target_faces)
+        self._control_defaults_snapshot = {
+            widget_name: widget.default_value
+            for widget_name, widget in main_window.parameter_widgets.items()
+            if widget_name in main_window.control
+        }
+        self._target_faces_snapshot = (
+            main_window.video_processor.prepare_issue_scan_target_faces_snapshot(
+                self._scan_ranges,
+                self._base_control,
+                self._base_params,
+                self._control_defaults_snapshot,
+            )
+        )
         self._reset_frame_number = int(main_window.videoSeekSlider.value())
 
     def cancel(self):
@@ -206,6 +218,7 @@ class IssueScanWorker(qtc.QThread):
                 base_control=self._base_control,
                 base_params=self._base_params,
                 target_faces_snapshot=self._target_faces_snapshot,
+                control_defaults_snapshot=self._control_defaults_snapshot,
                 reset_frame_number=self._reset_frame_number,
             )
             if result is None:

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -164,7 +164,8 @@ class TargetMediaLoaderWorker(qtc.QThread):
 
 class IssueScanWorker(qtc.QThread):
     progress = qtc.Signal(int, int, int, float)
-    completed = qtc.Signal(object, int, int, str, float)
+    completed = qtc.Signal(object, int, int, str, float, bool)
+    issue_found = qtc.Signal(str, int)
     cancelled = qtc.Signal()
     failed = qtc.Signal(str)
 
@@ -210,8 +211,12 @@ class IssueScanWorker(qtc.QThread):
                 scan_fps = (processed / elapsed) if elapsed > 0 else 0.0
                 self.progress.emit(processed, total, frame_number, scan_fps)
 
+            def issue_found_callback(face_id: str, frame_number: int) -> None:
+                self.issue_found.emit(str(face_id), int(frame_number))
+
             result = self.main_window.video_processor.scan_issue_frames(
                 progress_callback=progress_with_fps,
+                issue_found_callback=issue_found_callback,
                 is_cancelled=self._cancel_event.is_set,
                 scan_ranges=self._scan_ranges,
                 target_height=self._target_height,
@@ -231,6 +236,7 @@ class IssueScanWorker(qtc.QThread):
                 result["faces_with_issues"],
                 self._scan_scope_text,
                 elapsed_seconds,
+                bool(result.get("cancelled", False)),
             )
         except Exception as exc:
             self.failed.emit(str(exc))

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -163,7 +163,7 @@ class TargetMediaLoaderWorker(qtc.QThread):
 
 
 class IssueScanWorker(qtc.QThread):
-    progress = qtc.Signal(int, int, int)
+    progress = qtc.Signal(int, int, int, float)
     completed = qtc.Signal(object, int, int, str, float)
     cancelled = qtc.Signal()
     failed = qtc.Signal(str)
@@ -190,8 +190,16 @@ class IssueScanWorker(qtc.QThread):
     def run(self):
         try:
             start_time = time.monotonic()
+
+            def progress_with_fps(
+                processed: int, total: int, frame_number: int
+            ) -> None:
+                elapsed = time.monotonic() - start_time
+                scan_fps = (processed / elapsed) if elapsed > 0 else 0.0
+                self.progress.emit(processed, total, frame_number, scan_fps)
+
             result = self.main_window.video_processor.scan_issue_frames(
-                progress_callback=self.progress.emit,
+                progress_callback=progress_with_fps,
                 is_cancelled=self._cancel_event.is_set,
                 scan_ranges=self._scan_ranges,
                 target_height=self._target_height,

--- a/tests/unit/helpers/test_miscellaneous.py
+++ b/tests/unit/helpers/test_miscellaneous.py
@@ -14,6 +14,7 @@ from app.helpers.miscellaneous import (
     get_file_type,
     get_scaling_transforms,
     image_extensions,
+    normalize_issue_scan_ranges,
     video_extensions,
     _transform_cache,
 )
@@ -252,6 +253,22 @@ def test_count_issue_scan_frames_returns_zero_when_all_frames_dropped():
     scan_ranges = [(10, 12)]
     dropped_frames = {10, 11, 12}
     assert count_issue_scan_frames(scan_ranges, dropped_frames) == 0
+
+
+def test_normalize_issue_scan_ranges_sorts_open_ended_style_ranges():
+    scan_ranges = [(20, 30), (5, 50)]
+    assert normalize_issue_scan_ranges(scan_ranges) == [(5, 50)]
+
+
+def test_normalize_issue_scan_ranges_merges_overlaps():
+    scan_ranges = [(20, 25), (10, 15), (12, 18), (24, 30), (40, 45)]
+    assert normalize_issue_scan_ranges(scan_ranges) == [(10, 18), (20, 30), (40, 45)]
+
+
+def test_count_issue_scan_frames_does_not_double_count_overlaps():
+    scan_ranges = [(10, 20), (15, 25)]
+    dropped_frames = {12, 18, 22}
+    assert count_issue_scan_frames(scan_ranges, dropped_frames) == 13
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -23,6 +23,15 @@ class _DummyTargetFace:
         return self._embeddings.get(recognition_model)
 
 
+def _make_target_snapshot(face_id, embeddings_by_model=None):
+    return {
+        str(face_id): {
+            "face_id": str(face_id),
+            "embeddings_by_model": embeddings_by_model or {},
+        }
+    }
+
+
 def test_scan_issue_frames_restores_dense_smoothing_state():
     processor = VideoProcessor.__new__(VideoProcessor)
     processor.media_path = "dummy.mp4"
@@ -121,6 +130,178 @@ def test_build_issue_scan_state_segments_switches_only_at_marker_boundaries():
     ]
 
 
+def test_resolve_scan_state_uses_control_defaults_snapshot_not_live_widgets():
+    processor = VideoProcessor.__new__(VideoProcessor)
+
+    class _FailingWidgets:
+        def items(self):
+            raise AssertionError(
+                "parameter_widgets should not be read in scan state resolution"
+            )
+
+    processor.main_window = SimpleNamespace(
+        markers={},
+        parameter_widgets=_FailingWidgets(),
+        control={"ControlA": "live"},
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        target_faces={},
+    )
+
+    with patch(
+        "app.processors.video_processor.video_control_actions._get_marker_data_for_position",
+        return_value={
+            "parameters": {},
+            "control": {"ControlA": "marker", "ControlB": "marker-only"},
+        },
+    ):
+        local_control, local_params = processor._resolve_scan_state_for_frame(
+            10,
+            {"ControlA": "base"},
+            {},
+            {},
+            {"ControlA": "default", "ControlC": "default-only"},
+        )
+
+    assert local_control == {
+        "ControlA": "marker",
+        "ControlB": "marker-only",
+        "ControlC": "default-only",
+    }
+    assert local_params == {}
+
+
+def test_resolve_scan_state_respects_explicitly_empty_target_faces_snapshot():
+    processor = VideoProcessor.__new__(VideoProcessor)
+
+    processor.main_window = SimpleNamespace(
+        markers={},
+        target_faces={"live-face": object()},
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+    )
+
+    with patch(
+        "app.processors.video_processor.video_control_actions._get_marker_data_for_position",
+        return_value={"parameters": {}, "control": {}},
+    ):
+        _local_control, local_params = processor._resolve_scan_state_for_frame(
+            10,
+            {},
+            {},
+            {},
+            {},
+        )
+
+    assert local_params == {}
+
+
+def test_prepare_issue_scan_match_context_uses_snapshot_embeddings_for_segment_settings():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.main_window = SimpleNamespace(
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+    )
+    target_faces_snapshot = _make_target_snapshot(
+        "face_1",
+        {
+            "arcface_128": {
+                "Opal": np.array([1.0], dtype=np.float32),
+                "Pearl": np.array([2.0], dtype=np.float32),
+            }
+        },
+    )
+
+    match_context = processor._prepare_issue_scan_match_context(
+        {
+            "RecognitionModelSelection": "arcface_128",
+            "SimilarityTypeSelection": "Pearl",
+        },
+        {"face_1": {"SimilarityThresholdSlider": 65}},
+        target_faces_snapshot,
+    )
+
+    prepared_targets = match_context["prepared_targets"]
+    assert len(prepared_targets) == 1
+    assert prepared_targets[0][0] == "face_1"
+    assert prepared_targets[0][1] == 65.0
+    np.testing.assert_array_equal(
+        prepared_targets[0][2],
+        np.array([2.0], dtype=np.float32),
+    )
+
+
+def test_prepare_issue_scan_target_faces_snapshot_uses_segment_recognition_settings():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    run_recognize_calls = []
+
+    class _TargetFaceWithoutEmbeddingAccess:
+        def __init__(self):
+            self.face_id = "face_1"
+            self.cropped_face = np.zeros((8, 8, 3), dtype=np.uint8)
+
+        def get_embedding(self, _recognition_model):
+            raise AssertionError(
+                "scan target snapshot should not call widget get_embedding"
+            )
+
+    def fake_run_recognize_direct(_img, _kps, similarity_type, recognition_model):
+        run_recognize_calls.append((recognition_model, similarity_type))
+        if similarity_type == "Pearl":
+            return np.array([2.0], dtype=np.float32), None
+        return np.array([1.0], dtype=np.float32), None
+
+    processor.main_window = SimpleNamespace(
+        target_faces={"face_1": _TargetFaceWithoutEmbeddingAccess()},
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(
+            device="cpu",
+            run_recognize_direct=fake_run_recognize_direct,
+        ),
+    )
+
+    with patch.object(
+        processor,
+        "_build_issue_scan_state_segments",
+        return_value=[
+            (
+                0,
+                0,
+                {
+                    "RecognitionModelSelection": "arcface_128",
+                    "SimilarityTypeSelection": "Opal",
+                },
+                {},
+            ),
+            (
+                1,
+                1,
+                {
+                    "RecognitionModelSelection": "arcface_128",
+                    "SimilarityTypeSelection": "Pearl",
+                },
+                {},
+            ),
+        ],
+    ):
+        snapshot = processor.prepare_issue_scan_target_faces_snapshot(
+            [(0, 1)],
+            {},
+            {},
+            {},
+        )
+
+    assert run_recognize_calls == [
+        ("arcface_128", "Opal"),
+        ("arcface_128", "Pearl"),
+    ]
+    np.testing.assert_array_equal(
+        snapshot["face_1"]["embeddings_by_model"]["arcface_128"]["Opal"],
+        np.array([1.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        snapshot["face_1"]["embeddings_by_model"]["arcface_128"]["Pearl"],
+        np.array([2.0], dtype=np.float32),
+    )
+
+
 def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
     processor = VideoProcessor.__new__(VideoProcessor)
     processor.media_path = "dummy.mp4"
@@ -194,7 +375,7 @@ def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
             scan_ranges=[(0, 24)],
             base_control={},
             base_params={},
-            target_faces_snapshot=processor.main_window.target_faces,
+            target_faces_snapshot=_make_target_snapshot("1"),
             progress_callback=lambda processed, total, frame_number: (
                 progress_updates.append((processed, total, frame_number))
             ),
@@ -231,3 +412,354 @@ def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
         (21, 21, 24),
     ]
     assert seek_calls == [0, 5, 12]
+
+
+def test_scan_issue_frames_resets_tracker_before_and_after_tracking_scan():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    reset_calls = []
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def fake_run_detect(*_args, **_kwargs):
+        return (
+            np.empty((0, 4), dtype=np.float32),
+            np.empty((0, 5, 2), dtype=np.float32),
+            np.empty((0, 68, 2), dtype=np.float32),
+        )
+
+    processor.main_window = SimpleNamespace(
+        control={
+            "FaceTrackingEnableToggle": True,
+            "DetectorModelSelection": "RetinaFace",
+            "MaxFacesToDetectSlider": 1,
+            "DetectorScoreSlider": 50,
+            "LandmarkDetectToggle": False,
+            "LandmarkDetectModelSelection": "203",
+            "LandmarkDetectScoreSlider": 50,
+            "DetectFromPointsToggle": False,
+            "AutoRotationToggle": False,
+            "LandmarkMeanEyesToggle": False,
+            "KPSSmoothingEnableToggle": False,
+            "RecognitionModelSelection": "arcface_128",
+            "SimilarityTypeSelection": "Opal",
+        },
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(
+            device="cpu",
+            run_detect=fake_run_detect,
+            face_detectors=SimpleNamespace(
+                reset_tracker=lambda: reset_calls.append("reset")
+            ),
+        ),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 0)],
+            base_control=processor.main_window.control,
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=0,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 1,
+        "faces_with_issues": 0,
+    }
+    assert reset_calls == ["reset", "reset"]
+
+
+def test_scan_issue_frames_resets_tracker_when_marker_segment_enables_tracking():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    reset_calls = []
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    processor.main_window = SimpleNamespace(
+        control={"FaceTrackingEnableToggle": False},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(
+            device="cpu",
+            face_detectors=SimpleNamespace(
+                reset_tracker=lambda: reset_calls.append("reset")
+            ),
+        ),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[
+                (0, 0, {"FaceTrackingEnableToggle": False}, {}),
+                (1, 1, {"FaceTrackingEnableToggle": True}, {}),
+            ],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            return_value={
+                "recognition_model": "arcface_128",
+                "similarity_type": "Opal",
+                "prepared_targets": [],
+            },
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=(
+                np.empty((0, 4), dtype=np.float32),
+                np.empty((0, 5, 2), dtype=np.float32),
+                np.empty((0, 68, 2), dtype=np.float32),
+            ),
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 1)],
+            base_control={"FaceTrackingEnableToggle": False},
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=0,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 2,
+        "faces_with_issues": 0,
+    }
+    assert reset_calls == ["reset", "reset", "reset"]
+
+
+def test_scan_issue_frames_resets_tracker_when_tracking_re_enters_after_disabled_segment():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    reset_calls = []
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    processor.main_window = SimpleNamespace(
+        control={"FaceTrackingEnableToggle": False},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(
+            device="cpu",
+            face_detectors=SimpleNamespace(
+                reset_tracker=lambda: reset_calls.append("reset")
+            ),
+        ),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[
+                (0, 0, {"FaceTrackingEnableToggle": True}, {}),
+                (1, 1, {"FaceTrackingEnableToggle": False}, {}),
+                (2, 2, {"FaceTrackingEnableToggle": True}, {}),
+            ],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            return_value={
+                "recognition_model": "arcface_128",
+                "similarity_type": "Opal",
+                "prepared_targets": [],
+            },
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=(
+                np.empty((0, 4), dtype=np.float32),
+                np.empty((0, 5, 2), dtype=np.float32),
+                np.empty((0, 68, 2), dtype=np.float32),
+            ),
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 2)],
+            base_control={"FaceTrackingEnableToggle": False},
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=0,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 3,
+        "faces_with_issues": 0,
+    }
+    assert reset_calls == ["reset", "reset", "reset"]
+
+
+def test_scan_issue_frames_clears_sequential_state_when_tracking_re_enters():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = [{"persisted": True}]
+    processor._smoothed_kps = {1: np.array([[1.0, 2.0]], dtype=np.float32)}
+    processor._smoothed_dense_kps = {1: np.array([[3.0, 4.0]], dtype=np.float32)}
+    reset_state_snapshots = []
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    processor.main_window = SimpleNamespace(
+        control={"FaceTrackingEnableToggle": False},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(
+            device="cpu",
+            face_detectors=SimpleNamespace(reset_tracker=lambda: None),
+        ),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    def fake_prepare_issue_scan_match_context(*_args, **_kwargs):
+        return {
+            "recognition_model": "arcface_128",
+            "similarity_type": "Opal",
+            "prepared_targets": [],
+        }
+
+    def fake_run_sequential_detection(*_args, **_kwargs):
+        reset_state_snapshots.append(
+            (
+                list(processor.last_detected_faces),
+                dict(processor._smoothed_kps),
+                dict(processor._smoothed_dense_kps),
+            )
+        )
+        processor.last_detected_faces = [
+            {"from_segment": processor.current_frame_number}
+        ]
+        processor._smoothed_kps = {
+            processor.current_frame_number: np.array([[9.0, 9.0]], dtype=np.float32)
+        }
+        processor._smoothed_dense_kps = {
+            processor.current_frame_number: np.array([[8.0, 8.0]], dtype=np.float32)
+        }
+        return (
+            np.empty((0, 4), dtype=np.float32),
+            np.empty((0, 5, 2), dtype=np.float32),
+            np.empty((0, 68, 2), dtype=np.float32),
+        )
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[
+                (0, 0, {"FaceTrackingEnableToggle": True}, {}),
+                (1, 1, {"FaceTrackingEnableToggle": False}, {}),
+                (2, 2, {"FaceTrackingEnableToggle": True}, {}),
+            ],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            side_effect=fake_prepare_issue_scan_match_context,
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            side_effect=fake_run_sequential_detection,
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 2)],
+            base_control={"FaceTrackingEnableToggle": False},
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=0,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 3,
+        "faces_with_issues": 0,
+    }
+    assert reset_state_snapshots[0] == ([], {}, {})
+    assert reset_state_snapshots[2] == ([], {}, {})

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -71,6 +71,7 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
         "issue_frames_by_face": {},
         "frames_scanned": 0,
         "faces_with_issues": 0,
+        "cancelled": False,
     }
     np.testing.assert_array_equal(
         processor._smoothed_dense_kps[1], np.array([[3.0, 4.0]], dtype=np.float32)
@@ -387,6 +388,7 @@ def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
         },
         "frames_scanned": 21,
         "faces_with_issues": 1,
+        "cancelled": False,
     }
     assert progress_updates == [
         (1, 21, 0),
@@ -412,6 +414,168 @@ def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
         (21, 21, 24),
     ]
     assert seek_calls == [0, 5, 12]
+
+
+def test_scan_issue_frames_emits_incremental_issue_callback():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    issue_updates = []
+
+    processor.main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(device="cpu"),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[(0, 0, {}, {})],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            return_value={
+                "recognition_model": "arcface_128",
+                "similarity_type": "Opal",
+                "prepared_targets": [],
+            },
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=(
+                np.empty((0, 4), dtype=np.float32),
+                np.empty((0, 5, 2), dtype=np.float32),
+                np.empty((0, 68, 2), dtype=np.float32),
+            ),
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 0)],
+            base_control={},
+            base_params={},
+            target_faces_snapshot=_make_target_snapshot("1"),
+            issue_found_callback=lambda face_id, frame_number: issue_updates.append(
+                (face_id, frame_number)
+            ),
+        )
+
+    assert result == {
+        "issue_frames_by_face": {"1": [0]},
+        "frames_scanned": 1,
+        "faces_with_issues": 1,
+        "cancelled": False,
+    }
+    assert issue_updates == [("1", 0)]
+
+
+def test_scan_issue_frames_returns_partial_results_on_cancel():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    issue_updates = []
+    cancel_state = {"count": 0}
+
+    processor.main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(device="cpu"),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    def should_cancel():
+        cancel_state["count"] += 1
+        return cancel_state["count"] > 1
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[(0, 1, {}, {})],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            return_value={
+                "recognition_model": "arcface_128",
+                "similarity_type": "Opal",
+                "prepared_targets": [],
+            },
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=(
+                np.empty((0, 4), dtype=np.float32),
+                np.empty((0, 5, 2), dtype=np.float32),
+                np.empty((0, 68, 2), dtype=np.float32),
+            ),
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 1)],
+            base_control={},
+            base_params={},
+            target_faces_snapshot=_make_target_snapshot("1"),
+            issue_found_callback=lambda face_id, frame_number: issue_updates.append(
+                (face_id, frame_number)
+            ),
+            is_cancelled=should_cancel,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {"1": [0]},
+        "frames_scanned": 1,
+        "faces_with_issues": 1,
+        "cancelled": True,
+    }
+    assert issue_updates == [("1", 0)]
 
 
 def test_scan_issue_frames_resets_tracker_before_and_after_tracking_scan():
@@ -489,6 +653,7 @@ def test_scan_issue_frames_resets_tracker_before_and_after_tracking_scan():
         "issue_frames_by_face": {},
         "frames_scanned": 1,
         "faces_with_issues": 0,
+        "cancelled": False,
     }
     assert reset_calls == ["reset", "reset"]
 
@@ -572,6 +737,7 @@ def test_scan_issue_frames_resets_tracker_when_marker_segment_enables_tracking()
         "issue_frames_by_face": {},
         "frames_scanned": 2,
         "faces_with_issues": 0,
+        "cancelled": False,
     }
     assert reset_calls == ["reset", "reset", "reset"]
 
@@ -656,6 +822,7 @@ def test_scan_issue_frames_resets_tracker_when_tracking_re_enters_after_disabled
         "issue_frames_by_face": {},
         "frames_scanned": 3,
         "faces_with_issues": 0,
+        "cancelled": False,
     }
     assert reset_calls == ["reset", "reset", "reset"]
 
@@ -760,6 +927,7 @@ def test_scan_issue_frames_clears_sequential_state_when_tracking_re_enters():
         "issue_frames_by_face": {},
         "frames_scanned": 3,
         "faces_with_issues": 0,
+        "cancelled": False,
     }
     assert reset_state_snapshots[0] == ([], {}, {})
     assert reset_state_snapshots[2] == ([], {}, {})

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from app.processors.video_processor import VideoProcessor
+
+
+class _DummyCapture:
+    def isOpened(self):
+        return True
+
+    def set(self, *_args, **_kwargs):
+        return True
+
+
+def test_scan_issue_frames_restores_dense_smoothing_state():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = [{"id": 1}]
+    processor._smoothed_kps = {1: np.array([[1.0, 2.0]], dtype=np.float32)}
+    processor._smoothed_dense_kps = {1: np.array([[3.0, 4.0]], dtype=np.float32)}
+    processor.last_detected_faces = [{"id": 1}]
+    processor.main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        videoSeekSlider=SimpleNamespace(value=lambda: 7),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(1, 0)],
+            base_control={},
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=3,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 0,
+        "faces_with_issues": 0,
+    }
+    np.testing.assert_array_equal(
+        processor._smoothed_dense_kps[1], np.array([[3.0, 4.0]], dtype=np.float32)
+    )
+    np.testing.assert_array_equal(
+        processor._smoothed_kps[1], np.array([[1.0, 2.0]], dtype=np.float32)
+    )
+    assert processor.last_detected_faces == [{"id": 1}]
+    assert processor.current_frame_number == 3
+
+
+def test_describe_issue_scan_scope_uses_normalized_effective_ranges():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.max_frame_number = 100
+    processor.main_window = SimpleNamespace(
+        job_marker_pairs=[(20, 30), (10, 25), (40, None)]
+    )
+
+    scope_text = processor.describe_issue_scan_scope([(10, 30), (40, 100)])
+
+    assert scope_text == "Scanning 1 marked range and record start frame 40 to end"
+
+
+def test_describe_issue_scan_scope_uses_raw_open_start_when_ranges_merge():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.max_frame_number = 100
+    processor.main_window = SimpleNamespace(job_marker_pairs=[(10, 30), (20, None)])
+
+    scope_text = processor.describe_issue_scan_scope([(10, 100)])
+
+    assert scope_text == "Scanning 1 marked range and record start frame 20 to end"

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -14,6 +14,15 @@ class _DummyCapture:
         return True
 
 
+class _DummyTargetFace:
+    def __init__(self, face_id, embeddings):
+        self.face_id = face_id
+        self._embeddings = embeddings
+
+    def get_embedding(self, recognition_model):
+        return self._embeddings.get(recognition_model)
+
+
 def test_scan_issue_frames_restores_dense_smoothing_state():
     processor = VideoProcessor.__new__(VideoProcessor)
     processor.media_path = "dummy.mp4"
@@ -29,6 +38,7 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
         parameters={},
         target_faces={},
         dropped_frames=set(),
+        markers={},
         videoSeekSlider=SimpleNamespace(value=lambda: 7),
     )
     processor._get_target_input_height = lambda: 256
@@ -83,3 +93,141 @@ def test_describe_issue_scan_scope_uses_raw_open_start_when_ranges_merge():
     scope_text = processor.describe_issue_scan_scope([(10, 100)])
 
     assert scope_text == "Scanning 1 marked range and record start frame 20 to end"
+
+
+def test_build_issue_scan_state_segments_switches_only_at_marker_boundaries():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.main_window = SimpleNamespace(markers={5: {"id": 5}, 8: {"id": 8}})
+    resolved_frames = []
+
+    def fake_resolve(frame_number, *_args, **_kwargs):
+        resolved_frames.append(frame_number)
+        return {"frame": frame_number}, {"params": frame_number}
+
+    processor._resolve_scan_state_for_frame = fake_resolve
+
+    segments = processor._build_issue_scan_state_segments(
+        [(3, 10)],
+        {},
+        {},
+        {},
+    )
+
+    assert resolved_frames == [3, 5, 8]
+    assert segments == [
+        (3, 4, {"frame": 3}, {"params": 3}),
+        (5, 7, {"frame": 5}, {"params": 5}),
+        (8, 10, {"frame": 8}, {"params": 8}),
+    ]
+
+
+def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor.main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={
+            "1": _DummyTargetFace(
+                "1", {"arcface_128": np.array([1.0], dtype=np.float32)}
+            )
+        },
+        dropped_frames={2, 3, 4, 11},
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(device="cpu"),
+    )
+    processor._get_target_input_height = lambda: 256
+    progress_updates = []
+    seek_calls = []
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def fake_read_frame(*_args, **_kwargs):
+        return True, frame.copy()
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            side_effect=fake_read_frame,
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.seek_frame",
+            side_effect=lambda _capture, frame_number: seek_calls.append(frame_number),
+        ),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[(0, 24, {}, {})],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            return_value={
+                "recognition_model": "arcface_128",
+                "similarity_type": "Opal",
+                "prepared_targets": [],
+            },
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=(
+                np.empty((0, 4), dtype=np.float32),
+                np.empty((0, 5, 2), dtype=np.float32),
+                np.empty((0, 68, 2), dtype=np.float32),
+            ),
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 24)],
+            base_control={},
+            base_params={},
+            target_faces_snapshot=processor.main_window.target_faces,
+            progress_callback=lambda processed, total, frame_number: (
+                progress_updates.append((processed, total, frame_number))
+            ),
+        )
+
+    assert result == {
+        "issue_frames_by_face": {
+            "1": list(range(0, 2)) + list(range(5, 11)) + list(range(12, 25))
+        },
+        "frames_scanned": 21,
+        "faces_with_issues": 1,
+    }
+    assert progress_updates == [
+        (1, 21, 0),
+        (2, 21, 1),
+        (3, 21, 5),
+        (4, 21, 6),
+        (5, 21, 7),
+        (6, 21, 8),
+        (7, 21, 9),
+        (8, 21, 10),
+        (9, 21, 12),
+        (10, 21, 13),
+        (11, 21, 14),
+        (12, 21, 15),
+        (13, 21, 16),
+        (14, 21, 17),
+        (15, 21, 18),
+        (16, 21, 19),
+        (17, 21, 20),
+        (18, 21, 21),
+        (19, 21, 22),
+        (20, 21, 23),
+        (21, 21, 24),
+    ]
+    assert seek_calls == [0, 5, 12]

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -1,11 +1,99 @@
 from types import SimpleNamespace
 
+from app.ui.widgets.actions.video_control_actions import (
+    _handle_issue_scan_cancelled,
+    _handle_issue_scan_completed,
+    _handle_issue_scan_failed,
+    _handle_issue_scan_issue_found,
+    _handle_issue_scan_progress,
+    run_issue_scan,
+    toggle_issue_scan,
+)
 from app.ui.widgets.ui_workers import IssueScanWorker
-from app.ui.widgets.actions.video_control_actions import _handle_issue_scan_progress
 
 
-def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
-    main_window = SimpleNamespace(
+class _DummySignal:
+    def __init__(self):
+        self._callbacks = []
+
+    def connect(self, callback):
+        self._callbacks.append(callback)
+
+    def emit(self, *args, **kwargs):
+        for callback in list(self._callbacks):
+            callback(*args, **kwargs)
+
+
+class _DummyButton:
+    def __init__(self, text="", checked=False):
+        self.enabled = True
+        self.text = text
+        self.tooltip = ""
+        self.checked = checked
+
+    def setEnabled(self, value):
+        self.enabled = bool(value)
+
+    def setDisabled(self, value):
+        self.enabled = not bool(value)
+
+    def setText(self, text):
+        self.text = text
+
+    def setToolTip(self, tooltip):
+        self.tooltip = tooltip
+
+    def isChecked(self):
+        return self.checked
+
+    def setChecked(self, checked):
+        self.checked = bool(checked)
+
+
+class _DummySlider:
+    def __init__(self, value=0):
+        self._value = value
+        self.block_calls = []
+        self.updated = 0
+
+    def value(self):
+        return self._value
+
+    def blockSignals(self, value):
+        self.block_calls.append(bool(value))
+
+    def setValue(self, value):
+        self._value = int(value)
+
+    def update(self):
+        self.updated += 1
+
+
+class _FakeIssueScanWorker:
+    def __init__(self, main_window):
+        self.main_window = main_window
+        self._scan_scope_text = "Scanning full clip"
+        self.progress = _DummySignal()
+        self.completed = _DummySignal()
+        self.cancelled = _DummySignal()
+        self.failed = _DummySignal()
+        self.issue_found = _DummySignal()
+        self.started = False
+        self.cancel_calls = 0
+        self.deleted = False
+
+    def start(self):
+        self.started = True
+
+    def cancel(self):
+        self.cancel_calls += 1
+
+    def deleteLater(self):
+        self.deleted = True
+
+
+def _make_worker_main_window():
+    return SimpleNamespace(
         control={},
         parameters={},
         target_faces={},
@@ -20,6 +108,54 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
         ),
     )
 
+
+def _make_scan_main_window(keep_controls=False):
+    slider = _DummySlider(24)
+    main_window = SimpleNamespace(
+        control={"KeepControlsToggle": keep_controls},
+        parameters={},
+        target_faces={"face_1": object()},
+        parameter_widgets={},
+        issue_frames_by_face={"face_1": {3, 5}, "face_2": {9}},
+        issue_frames=set(),
+        dropped_frames=set(),
+        markers={},
+        selected_target_face_id="face_1",
+        scan_issue_worker=None,
+        scan_issue_ui_state={},
+        videoSeekSlider=slider,
+        videoSeekLineEdit=SimpleNamespace(
+            text=lambda: "24", setText=lambda _text: None
+        ),
+        graphicsViewFrame=SimpleNamespace(
+            scene=lambda: SimpleNamespace(items=lambda: []),
+            setSceneRect=lambda *_args: None,
+        ),
+        runScanButton=_DummyButton("Scan for Issues"),
+        scanToolsToggleButton=_DummyButton("Scan Tools"),
+        buttonMediaPlay=_DummyButton("Play"),
+        buttonMediaRecord=_DummyButton("Record"),
+        prevIssueButton=_DummyButton("Prev Issue"),
+        nextIssueButton=_DummyButton("Next Issue"),
+        dropFrameButton=_DummyButton("Drop Frame"),
+        dropAllIssueFramesButton=_DummyButton("Drop Issue Frames"),
+        clearScanResultsButton=_DummyButton("Clear Scan Results"),
+        clearDroppedFramesButton=_DummyButton("Clear Dropped Frames"),
+    )
+    main_window.video_processor = SimpleNamespace(
+        file_type="video",
+        media_path="dummy.mp4",
+        current_frame_number=24,
+        current_frame=None,
+        stop_processing=lambda: False,
+        process_current_frame=lambda: None,
+    )
+    return main_window
+
+
+def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
+    main_window = _make_worker_main_window()
+
     def fake_scan_issue_frames(**kwargs):
         progress_callback = kwargs["progress_callback"]
         progress_callback(1, 3, 10)
@@ -29,6 +165,7 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
             "issue_frames_by_face": {},
             "frames_scanned": 3,
             "faces_with_issues": 0,
+            "cancelled": False,
         }
 
     main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
@@ -48,7 +185,7 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
         )
     )
     worker.completed.connect(
-        lambda issue_frames_by_face, frames_scanned, faces_with_issues, scope_text, elapsed_seconds: (
+        lambda issue_frames_by_face, frames_scanned, faces_with_issues, scope_text, elapsed_seconds, cancelled: (
             completed.append(
                 (
                     issue_frames_by_face,
@@ -56,6 +193,7 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
                     faces_with_issues,
                     scope_text,
                     elapsed_seconds,
+                    cancelled,
                 )
             )
         )
@@ -68,25 +206,17 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
         (2, 3, 11, 2.0),
         (3, 3, 12, 2.0),
     ]
-    assert completed == [({}, 3, 0, "Scanning 1 marked range", 2.0)]
+    assert completed == [({}, 3, 0, "Scanning 1 marked range", 2.0, False)]
 
 
 def test_issue_scan_worker_passes_control_defaults_snapshot():
     control_widget = SimpleNamespace(default_value="default-control")
-    main_window = SimpleNamespace(
-        control={"ControlA": "live-control"},
-        parameters={},
-        target_faces={},
-        parameter_widgets={"ControlA": control_widget, "IgnoredWidget": control_widget},
-        videoSeekSlider=SimpleNamespace(value=lambda: 0),
-        video_processor=SimpleNamespace(
-            _get_issue_scan_ranges=lambda: [(0, 0)],
-            describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
-            _get_target_input_height=lambda: 256,
-            prepare_issue_scan_target_faces_snapshot=lambda *_args, **_kwargs: {},
-            scan_issue_frames=None,
-        ),
-    )
+    main_window = _make_worker_main_window()
+    main_window.control = {"ControlA": "live-control"}
+    main_window.parameter_widgets = {
+        "ControlA": control_widget,
+        "IgnoredWidget": control_widget,
+    }
     captured = {}
 
     def fake_scan_issue_frames(**kwargs):
@@ -95,6 +225,7 @@ def test_issue_scan_worker_passes_control_defaults_snapshot():
             "issue_frames_by_face": {},
             "frames_scanned": 1,
             "faces_with_issues": 0,
+            "cancelled": False,
         }
 
     main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
@@ -106,20 +237,7 @@ def test_issue_scan_worker_passes_control_defaults_snapshot():
 
 
 def test_issue_scan_worker_preserves_explicitly_empty_snapshots():
-    main_window = SimpleNamespace(
-        control={},
-        parameters={},
-        target_faces={},
-        parameter_widgets={},
-        videoSeekSlider=SimpleNamespace(value=lambda: 0),
-        video_processor=SimpleNamespace(
-            _get_issue_scan_ranges=lambda: [(0, 0)],
-            describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
-            _get_target_input_height=lambda: 256,
-            prepare_issue_scan_target_faces_snapshot=lambda *_args, **_kwargs: {},
-            scan_issue_frames=None,
-        ),
-    )
+    main_window = _make_worker_main_window()
     captured = {}
 
     def fake_scan_issue_frames(**kwargs):
@@ -131,6 +249,7 @@ def test_issue_scan_worker_preserves_explicitly_empty_snapshots():
             "issue_frames_by_face": {},
             "frames_scanned": 1,
             "faces_with_issues": 0,
+            "cancelled": False,
         }
 
     main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
@@ -172,19 +291,12 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
             }
         }
 
-    main_window = SimpleNamespace(
-        control={"ControlA": "live-control"},
-        parameters={},
-        target_faces={"face_1": _TargetFaceWithoutEmbeddingAccess()},
-        parameter_widgets={"ControlA": control_widget},
-        videoSeekSlider=SimpleNamespace(value=lambda: 0),
-        video_processor=SimpleNamespace(
-            _get_issue_scan_ranges=lambda: [(0, 0)],
-            describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
-            _get_target_input_height=lambda: 256,
-            prepare_issue_scan_target_faces_snapshot=fake_prepare_issue_scan_target_faces_snapshot,
-            scan_issue_frames=None,
-        ),
+    main_window = _make_worker_main_window()
+    main_window.control = {"ControlA": "live-control"}
+    main_window.target_faces = {"face_1": _TargetFaceWithoutEmbeddingAccess()}
+    main_window.parameter_widgets = {"ControlA": control_widget}
+    main_window.video_processor.prepare_issue_scan_target_faces_snapshot = (
+        fake_prepare_issue_scan_target_faces_snapshot
     )
 
     def fake_scan_issue_frames(**kwargs):
@@ -193,6 +305,7 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
             "issue_frames_by_face": {},
             "frames_scanned": 1,
             "faces_with_issues": 0,
+            "cancelled": False,
         }
 
     main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
@@ -212,14 +325,12 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
     }
 
 
-def test_handle_issue_scan_progress_updates_dialog_label_with_fps():
-    captured = {}
-    dialog = SimpleNamespace(
-        setMaximum=lambda value: captured.setdefault("maximum", value),
-        setValue=lambda value: captured.setdefault("value", value),
-        setLabelText=lambda text: captured.setdefault("label", text),
+def test_handle_issue_scan_progress_moves_slider_and_updates_abort_button(monkeypatch):
+    main_window = _make_scan_main_window()
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
     )
-    main_window = SimpleNamespace(scan_progress_dialog=dialog)
 
     _handle_issue_scan_progress(
         main_window,
@@ -230,6 +341,335 @@ def test_handle_issue_scan_progress_updates_dialog_label_with_fps():
         7.25,
     )
 
-    assert captured["maximum"] == 40
-    assert captured["value"] == 12
-    assert captured["label"] == "Scanning 2 marked ranges\n12/40 processed | FPS: 7.2"
+    assert main_window.videoSeekSlider.value() == 345
+    assert main_window.videoSeekSlider.block_calls == [True, False]
+    assert main_window.runScanButton.text == "Abort Scan (12/40)"
+    assert "FPS: 7.2" in main_window.runScanButton.tooltip
+
+
+def test_handle_issue_scan_issue_found_merges_and_refreshes_selected_face(monkeypatch):
+    main_window = _make_scan_main_window()
+    main_window.issue_frames_by_face = {}
+    refreshed = []
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.refresh_issue_frames_for_selected_face",
+        lambda _main_window: refreshed.append(dict(_main_window.issue_frames_by_face)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+
+    _handle_issue_scan_issue_found(main_window, "face_1", 12)
+    _handle_issue_scan_issue_found(main_window, "face_1", 12)
+    _handle_issue_scan_issue_found(main_window, "face_2", 8)
+
+    assert main_window.issue_frames_by_face == {"face_1": {12}, "face_2": {8}}
+    assert refreshed == [
+        {"face_1": {12}},
+    ]
+
+
+def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window(keep_controls=False)
+    fake_worker = _FakeIssueScanWorker(main_window)
+    disabled_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.ui_workers.IssueScanWorker",
+        lambda _main_window: fake_worker,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.Path.is_file",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.layout_actions.disable_all_parameters_and_control_widget",
+        lambda _main_window: disabled_calls.append("disabled"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+
+    run_issue_scan(main_window)
+
+    assert fake_worker.started is True
+    assert disabled_calls == ["disabled"]
+    assert main_window.scan_issue_worker is fake_worker
+    assert main_window.runScanButton.enabled is True
+    assert main_window.runScanButton.text == "Abort Scan"
+    assert main_window.issue_frames_by_face == {}
+    assert main_window.buttonMediaPlay.enabled is False
+    assert main_window.buttonMediaRecord.enabled is False
+    assert main_window.scanToolsToggleButton.enabled is False
+    assert main_window.prevIssueButton.enabled is False
+    assert main_window.nextIssueButton.enabled is False
+    assert main_window.dropFrameButton.enabled is False
+    assert main_window.dropAllIssueFramesButton.enabled is False
+    assert main_window.clearScanResultsButton.enabled is False
+    assert main_window.clearDroppedFramesButton.enabled is False
+
+
+def test_run_issue_scan_respects_keep_controls_toggle(monkeypatch):
+    main_window = _make_scan_main_window(keep_controls=True)
+    fake_worker = _FakeIssueScanWorker(main_window)
+    disabled_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.ui_workers.IssueScanWorker",
+        lambda _main_window: fake_worker,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.Path.is_file",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.layout_actions.disable_all_parameters_and_control_widget",
+        lambda _main_window: disabled_calls.append("disabled"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+
+    run_issue_scan(main_window)
+
+    assert fake_worker.started is True
+    assert disabled_calls == []
+    assert main_window.runScanButton.enabled is True
+    assert main_window.runScanButton.text == "Abort Scan"
+    assert main_window.issue_frames_by_face == {}
+    assert main_window.prevIssueButton.enabled is False
+    assert main_window.nextIssueButton.enabled is False
+    assert main_window.dropFrameButton.enabled is False
+    assert main_window.dropAllIssueFramesButton.enabled is False
+    assert main_window.clearScanResultsButton.enabled is False
+    assert main_window.clearDroppedFramesButton.enabled is False
+
+
+def test_run_issue_scan_does_not_start_twice(monkeypatch):
+    main_window = _make_scan_main_window()
+    existing_worker = _FakeIssueScanWorker(main_window)
+    main_window.scan_issue_worker = existing_worker
+    worker_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.ui_workers.IssueScanWorker",
+        lambda _main_window: worker_calls.append("created"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.Path.is_file",
+        lambda self: True,
+    )
+
+    run_issue_scan(main_window)
+
+    assert worker_calls == []
+    assert main_window.scan_issue_worker is existing_worker
+
+
+def test_toggle_issue_scan_cancels_active_worker():
+    main_window = _make_scan_main_window()
+    active_worker = _FakeIssueScanWorker(main_window)
+    main_window.scan_issue_worker = active_worker
+
+    toggle_issue_scan(main_window)
+
+    assert active_worker.cancel_calls == 1
+
+
+def test_issue_scan_completion_restores_slider_and_ui(monkeypatch):
+    main_window = _make_scan_main_window(keep_controls=False)
+    fake_worker = _FakeIssueScanWorker(main_window)
+    enabled_calls = []
+    toast_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.layout_actions.enable_all_parameters_and_control_widget",
+        lambda _main_window: enabled_calls.append("enabled"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": False,
+    }
+    main_window.videoSeekSlider.setValue(90)
+    main_window.video_processor.current_frame_number = 90
+
+    _handle_issue_scan_completed(
+        main_window,
+        {"face_1": [1, 2]},
+        50,
+        1,
+        "Scanning full clip",
+        5.0,
+        False,
+    )
+
+    assert enabled_calls == ["enabled"]
+    assert main_window.videoSeekSlider.value() == 24
+    assert main_window.video_processor.current_frame_number == 24
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert main_window.runScanButton.text == "Scan for Issues"
+    assert main_window.buttonMediaPlay.enabled is True
+    assert main_window.prevIssueButton.enabled is True
+    assert main_window.nextIssueButton.enabled is True
+    assert main_window.dropFrameButton.enabled is True
+    assert main_window.dropAllIssueFramesButton.enabled is True
+    assert main_window.clearScanResultsButton.enabled is True
+    assert main_window.clearDroppedFramesButton.enabled is True
+    assert restore_calls == ["restored"]
+    assert toast_calls
+
+
+def test_issue_scan_partial_completion_keeps_partial_results(monkeypatch):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    toast_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+    }
+    main_window.videoSeekSlider.setValue(91)
+
+    _handle_issue_scan_completed(
+        main_window,
+        {"face_1": [8, 9]},
+        12,
+        1,
+        "Scanning full clip",
+        2.0,
+        True,
+    )
+
+    assert main_window.videoSeekSlider.value() == 24
+    assert main_window.issue_frames_by_face == {"face_1": {8, 9}}
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert main_window.prevIssueButton.enabled is True
+    assert main_window.nextIssueButton.enabled is True
+    assert main_window.dropFrameButton.enabled is True
+    assert main_window.dropAllIssueFramesButton.enabled is True
+    assert main_window.clearScanResultsButton.enabled is True
+    assert main_window.clearDroppedFramesButton.enabled is True
+    assert restore_calls == ["restored"]
+    assert toast_calls[0][0][1] == "Scan Aborted"
+
+
+def test_issue_scan_failed_restores_ui_and_shows_message(monkeypatch):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    messagebox_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_messagebox",
+        lambda *_args, **_kwargs: messagebox_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+    }
+    main_window.videoSeekSlider.setValue(101)
+
+    _handle_issue_scan_failed(main_window, "boom")
+
+    assert main_window.videoSeekSlider.value() == 24
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert main_window.prevIssueButton.enabled is True
+    assert main_window.nextIssueButton.enabled is True
+    assert main_window.dropFrameButton.enabled is True
+    assert main_window.dropAllIssueFramesButton.enabled is True
+    assert main_window.clearScanResultsButton.enabled is True
+    assert main_window.clearDroppedFramesButton.enabled is True
+    assert restore_calls == ["restored"]
+    assert messagebox_calls[0][0][1] == "Scan Failed"
+    assert messagebox_calls[0][0][2] == "boom"
+
+
+def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    toast_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.issue_frames_by_face = {"face_1": {8}}
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+    }
+
+    _handle_issue_scan_cancelled(main_window)
+
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert restore_calls == ["restored"]
+    assert toast_calls[0][0][1] == "Scan Cancelled"
+    assert "Kept any issue frames found so far." in toast_calls[0][0][2]

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -327,6 +327,9 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
 
 def test_handle_issue_scan_progress_moves_slider_and_updates_abort_button(monkeypatch):
     main_window = _make_scan_main_window()
+    main_window.runScanButton.tooltip = (
+        "Scanning 2 marked ranges\nAbort the active issue scan."
+    )
     monkeypatch.setattr(
         "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
         lambda: None,
@@ -344,7 +347,9 @@ def test_handle_issue_scan_progress_moves_slider_and_updates_abort_button(monkey
     assert main_window.videoSeekSlider.value() == 345
     assert main_window.videoSeekSlider.block_calls == [True, False]
     assert main_window.runScanButton.text == "Abort Scan (12/40)"
-    assert "FPS: 7.2" in main_window.runScanButton.tooltip
+    assert main_window.runScanButton.tooltip == (
+        "Scanning 2 marked ranges\nAbort the active issue scan."
+    )
 
 
 def test_handle_issue_scan_issue_found_merges_and_refreshes_selected_face(monkeypatch):
@@ -401,6 +406,8 @@ def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
     assert main_window.scan_issue_worker is fake_worker
     assert main_window.runScanButton.enabled is True
     assert main_window.runScanButton.text == "Abort Scan"
+    assert "processed" not in main_window.runScanButton.tooltip
+    assert "FPS" not in main_window.runScanButton.tooltip
     assert main_window.issue_frames_by_face == {}
     assert main_window.buttonMediaPlay.enabled is False
     assert main_window.buttonMediaRecord.enabled is False
@@ -441,6 +448,8 @@ def test_run_issue_scan_respects_keep_controls_toggle(monkeypatch):
     assert disabled_calls == []
     assert main_window.runScanButton.enabled is True
     assert main_window.runScanButton.text == "Abort Scan"
+    assert "processed" not in main_window.runScanButton.tooltip
+    assert "FPS" not in main_window.runScanButton.tooltip
     assert main_window.issue_frames_by_face == {}
     assert main_window.prevIssueButton.enabled is False
     assert main_window.nextIssueButton.enabled is False

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -9,11 +9,13 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
         control={},
         parameters={},
         target_faces={},
+        parameter_widgets={},
         videoSeekSlider=SimpleNamespace(value=lambda: 0),
         video_processor=SimpleNamespace(
             _get_issue_scan_ranges=lambda: [(0, 2)],
             describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
             _get_target_input_height=lambda: 256,
+            prepare_issue_scan_target_faces_snapshot=lambda *_args, **_kwargs: {},
             scan_issue_frames=None,
         ),
     )
@@ -67,6 +69,147 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
         (3, 3, 12, 2.0),
     ]
     assert completed == [({}, 3, 0, "Scanning 1 marked range", 2.0)]
+
+
+def test_issue_scan_worker_passes_control_defaults_snapshot():
+    control_widget = SimpleNamespace(default_value="default-control")
+    main_window = SimpleNamespace(
+        control={"ControlA": "live-control"},
+        parameters={},
+        target_faces={},
+        parameter_widgets={"ControlA": control_widget, "IgnoredWidget": control_widget},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        video_processor=SimpleNamespace(
+            _get_issue_scan_ranges=lambda: [(0, 0)],
+            describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
+            _get_target_input_height=lambda: 256,
+            prepare_issue_scan_target_faces_snapshot=lambda *_args, **_kwargs: {},
+            scan_issue_frames=None,
+        ),
+    )
+    captured = {}
+
+    def fake_scan_issue_frames(**kwargs):
+        captured["control_defaults_snapshot"] = kwargs["control_defaults_snapshot"]
+        return {
+            "issue_frames_by_face": {},
+            "frames_scanned": 1,
+            "faces_with_issues": 0,
+        }
+
+    main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
+
+    worker = IssueScanWorker(main_window)
+    worker.run()
+
+    assert captured["control_defaults_snapshot"] == {"ControlA": "default-control"}
+
+
+def test_issue_scan_worker_preserves_explicitly_empty_snapshots():
+    main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        parameter_widgets={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        video_processor=SimpleNamespace(
+            _get_issue_scan_ranges=lambda: [(0, 0)],
+            describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
+            _get_target_input_height=lambda: 256,
+            prepare_issue_scan_target_faces_snapshot=lambda *_args, **_kwargs: {},
+            scan_issue_frames=None,
+        ),
+    )
+    captured = {}
+
+    def fake_scan_issue_frames(**kwargs):
+        captured["base_control"] = kwargs["base_control"]
+        captured["base_params"] = kwargs["base_params"]
+        captured["target_faces_snapshot"] = kwargs["target_faces_snapshot"]
+        captured["control_defaults_snapshot"] = kwargs["control_defaults_snapshot"]
+        return {
+            "issue_frames_by_face": {},
+            "frames_scanned": 1,
+            "faces_with_issues": 0,
+        }
+
+    main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
+
+    worker = IssueScanWorker(main_window)
+    worker.run()
+
+    assert captured == {
+        "base_control": {},
+        "base_params": {},
+        "target_faces_snapshot": {},
+        "control_defaults_snapshot": {},
+    }
+
+
+def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_methods():
+    control_widget = SimpleNamespace(default_value="default-control")
+    captured = {}
+
+    class _TargetFaceWithoutEmbeddingAccess:
+        def __init__(self):
+            self.face_id = "face_1"
+            self.cropped_face = None
+
+        def get_embedding(self, _recognition_model):
+            raise AssertionError(
+                "IssueScanWorker should not call target-face widget methods"
+            )
+
+    def fake_prepare_issue_scan_target_faces_snapshot(*_args, **_kwargs):
+        return {
+            "face_1": {
+                "face_id": "face_1",
+                "embeddings_by_model": {
+                    "arcface_128": {
+                        "Opal": "prepared-embedding",
+                    }
+                },
+            }
+        }
+
+    main_window = SimpleNamespace(
+        control={"ControlA": "live-control"},
+        parameters={},
+        target_faces={"face_1": _TargetFaceWithoutEmbeddingAccess()},
+        parameter_widgets={"ControlA": control_widget},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        video_processor=SimpleNamespace(
+            _get_issue_scan_ranges=lambda: [(0, 0)],
+            describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
+            _get_target_input_height=lambda: 256,
+            prepare_issue_scan_target_faces_snapshot=fake_prepare_issue_scan_target_faces_snapshot,
+            scan_issue_frames=None,
+        ),
+    )
+
+    def fake_scan_issue_frames(**kwargs):
+        captured["target_faces_snapshot"] = kwargs["target_faces_snapshot"]
+        return {
+            "issue_frames_by_face": {},
+            "frames_scanned": 1,
+            "faces_with_issues": 0,
+        }
+
+    main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
+
+    worker = IssueScanWorker(main_window)
+    worker.run()
+
+    assert captured["target_faces_snapshot"] == {
+        "face_1": {
+            "face_id": "face_1",
+            "embeddings_by_model": {
+                "arcface_128": {
+                    "Opal": "prepared-embedding",
+                }
+            },
+        }
+    }
 
 
 def test_handle_issue_scan_progress_updates_dialog_label_with_fps():

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+from app.ui.widgets.ui_workers import IssueScanWorker
+from app.ui.widgets.actions.video_control_actions import _handle_issue_scan_progress
+
+
+def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
+    main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        video_processor=SimpleNamespace(
+            _get_issue_scan_ranges=lambda: [(0, 2)],
+            describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
+            _get_target_input_height=lambda: 256,
+            scan_issue_frames=None,
+        ),
+    )
+
+    def fake_scan_issue_frames(**kwargs):
+        progress_callback = kwargs["progress_callback"]
+        progress_callback(1, 3, 10)
+        progress_callback(2, 3, 11)
+        progress_callback(3, 3, 12)
+        return {
+            "issue_frames_by_face": {},
+            "frames_scanned": 3,
+            "faces_with_issues": 0,
+        }
+
+    main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
+    worker = IssueScanWorker(main_window)
+    emitted = []
+    completed = []
+    monotonic_values = iter([10.0, 10.5, 11.0, 11.5, 12.0])
+
+    monkeypatch.setattr(
+        "app.ui.widgets.ui_workers.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    worker.progress.connect(
+        lambda processed, total, frame_number, scan_fps: emitted.append(
+            (processed, total, frame_number, scan_fps)
+        )
+    )
+    worker.completed.connect(
+        lambda issue_frames_by_face, frames_scanned, faces_with_issues, scope_text, elapsed_seconds: (
+            completed.append(
+                (
+                    issue_frames_by_face,
+                    frames_scanned,
+                    faces_with_issues,
+                    scope_text,
+                    elapsed_seconds,
+                )
+            )
+        )
+    )
+
+    worker.run()
+
+    assert emitted == [
+        (1, 3, 10, 2.0),
+        (2, 3, 11, 2.0),
+        (3, 3, 12, 2.0),
+    ]
+    assert completed == [({}, 3, 0, "Scanning 1 marked range", 2.0)]
+
+
+def test_handle_issue_scan_progress_updates_dialog_label_with_fps():
+    captured = {}
+    dialog = SimpleNamespace(
+        setMaximum=lambda value: captured.setdefault("maximum", value),
+        setValue=lambda value: captured.setdefault("value", value),
+        setLabelText=lambda text: captured.setdefault("label", text),
+    )
+    main_window = SimpleNamespace(scan_progress_dialog=dialog)
+
+    _handle_issue_scan_progress(
+        main_window,
+        "Scanning 2 marked ranges",
+        12,
+        40,
+        345,
+        7.25,
+    )
+
+    assert captured["maximum"] == 40
+    assert captured["value"] == 12
+    assert captured["label"] == "Scanning 2 marked ranges\n12/40 processed | FPS: 7.2"


### PR DESCRIPTION
## Summary

- Refines the issue scan follow-up work with performance, UX, and state-handling fixes
- Normalizes scan ranges and scope reporting
- Moves scan progress into the main UI with playhead-based feedback
- Adds incremental issue marker updates and keeps partial results on abort
- Keeps `Abort Scan` active while disabling the other scan-review controls
- Clears old scan results when starting a new scan
- Improves scan behavior around worker, marker, and tracker state
- Makes marker-based scan matching use stable worker-side snapshots

## Tests

- Added/expanded:
  - `tests/unit/processors/test_video_processor_scan.py`
  - `tests/unit/ui/test_issue_scan_progress.py`
  - `tests/unit/helpers/test_miscellaneous.py`

## Validation

- `pre-commit` passed
- Focused unit tests passed
- Manual scan workflow checks passed