### PR TITLE
stabilize fullscreen transitions while theatre mode is active

### DIFF
--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -777,7 +777,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             case QtCore.Qt.Key_Escape:
                 if getattr(self, "is_theatre_mode", False):
                     video_control_actions.toggle_theatre_mode(self)
-                elif self.isFullScreen() or getattr(self, "is_full_screen", False):
+                elif self.isFullScreen():
                     video_control_actions.view_fullscreen(self)
             case QtCore.Qt.Key_F11:
                 video_control_actions.view_fullscreen(self)

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -1312,17 +1312,40 @@ def delete_all_markers(main_window: "MainWindow"):
 
 
 def view_fullscreen(main_window: "MainWindow"):
-    """Toggle fullscreen or update the remembered fullscreen base while theatre mode is active."""
-    if getattr(main_window, "is_theatre_mode", False):
-        main_window._was_custom_fullscreen = not bool(
-            getattr(main_window, "_was_custom_fullscreen", False)
-        )
-    elif main_window.isFullScreen():
-        main_window.showNormal()  # Exit full-screen mode
-    else:
-        main_window.showFullScreen()  # Enter full-screen mode
+    """Toggle fullscreen, briefly exiting/re-entering theatre mode when needed."""
+
+    def _apply_fullscreen_toggle():
+        if main_window.isFullScreen():
+            main_window.showNormal()  # Exit full-screen mode
+            main_window.is_full_screen = False
+        else:
+            main_window.showFullScreen()  # Enter full-screen mode
+            main_window.is_full_screen = True
 
     sync_actions = getattr(main_window, "_sync_viewer_menu_actions", None)
+
+    if getattr(main_window, "_fullscreen_theatre_transition_in_progress", False):
+        return
+
+    if getattr(main_window, "is_theatre_mode", False):
+        main_window._fullscreen_theatre_transition_in_progress = True
+        toggle_theatre_mode(main_window)
+        _apply_fullscreen_toggle()
+
+        def _reenter_theatre():
+            try:
+                if not getattr(main_window, "is_theatre_mode", False):
+                    toggle_theatre_mode(main_window)
+            finally:
+                main_window._fullscreen_theatre_transition_in_progress = False
+                if callable(sync_actions):
+                    sync_actions()
+
+        QtCore.QTimer.singleShot(0, _reenter_theatre)
+        return
+
+    _apply_fullscreen_toggle()
+
     if callable(sync_actions):
         sync_actions()
 
@@ -2751,6 +2774,7 @@ def toggle_theatre_mode(main_window: "MainWindow"):
     Role: Activates Theatre Mode by safely detaching UI elements and preventing layout crushing.
     Impact: Solves the "squashed text" bug and preserves exact QDockWidget sizes using saveState/restoreState.
     """
+
     is_theatre = getattr(main_window, "is_theatre_mode", False)
     if not is_theatre:
         # --- ENTER THEATRE MODE ---
@@ -2759,9 +2783,7 @@ def toggle_theatre_mode(main_window: "MainWindow"):
         # 0. Save the exact state of all docks and toolbars (sizes, proportions, splitters)
         main_window._saved_window_state = main_window.saveState()
         main_window._was_maximized = main_window.isMaximized()
-        main_window._was_custom_fullscreen = getattr(
-            main_window, "is_full_screen", False
-        )
+        main_window._was_custom_fullscreen = main_window.isFullScreen()
         if main_window.isMaximized() or main_window.isFullScreen():
             main_window._was_normal_geometry = main_window.normalGeometry()
         else:
@@ -2841,8 +2863,14 @@ def toggle_theatre_mode(main_window: "MainWindow"):
             QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
         )
 
-        # 6. Switch to Fullscreen
-        main_window.showFullScreen()
+        # 6. Preserve the base window mode; only remain fullscreen if already fullscreen.
+        if main_window._was_custom_fullscreen:
+            main_window.setWindowState(QtCore.Qt.WindowState.WindowFullScreen)
+            main_window.showFullScreen()
+            QtWidgets.QApplication.processEvents()
+            main_window.is_full_screen = True
+        else:
+            main_window.is_full_screen = False
 
         # 7. Activate Hover Timer for media controls overlay
         if not hasattr(main_window, "theatre_hover_timer"):
@@ -2936,13 +2964,19 @@ def toggle_theatre_mode(main_window: "MainWindow"):
         # Exit Fullscreen mode
         was_custom_fullscreen = getattr(main_window, "_was_custom_fullscreen", False)
         was_maximized = getattr(main_window, "_was_maximized", False)
+        saved_normal_geometry = getattr(main_window, "_was_normal_geometry", None)
 
         if was_custom_fullscreen:
             main_window.showFullScreen()
+            main_window.is_full_screen = True
         elif was_maximized:
             main_window.showMaximized()
+            main_window.is_full_screen = False
         else:
             main_window.showNormal()
+            if saved_normal_geometry is not None:
+                main_window.setGeometry(saved_normal_geometry)
+            main_window.is_full_screen = False
 
         # Restores the exact layout state of docks (fixes the Input Faces / Target Video sizing)
         if hasattr(main_window, "_saved_window_state"):

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -32,28 +32,54 @@ for _s in _STUBS:
 
 
 from app.ui.widgets.actions import common_actions as common_widget_actions  # noqa: E402
+from app.ui.widgets.actions import video_control_actions  # noqa: E402
 from app.ui.widgets.actions.video_control_actions import (  # noqa: E402
     _disable_compare_preview_modes_for_recording,
+    toggle_theatre_mode,
     view_fullscreen,
 )
 
 
-def test_view_fullscreen_flips_theatre_base_without_window_transition():
+def test_view_fullscreen_temporarily_exits_and_reenters_theatre(monkeypatch):
     synced = []
+    theatre_calls = []
+    single_shot_calls = []
+
+    def fake_toggle_theatre_mode(window):
+        theatre_calls.append(window.is_theatre_mode)
+        window.is_theatre_mode = not window.is_theatre_mode
+
+    monkeypatch.setattr(
+        video_control_actions, "toggle_theatre_mode", fake_toggle_theatre_mode
+    )
+    monkeypatch.setattr(
+        video_control_actions.QtCore.QTimer,
+        "singleShot",
+        lambda delay, callback: (
+            single_shot_calls.append(delay),
+            callback(),
+        )[-1],
+    )
+
     main_window = SimpleNamespace(
         is_theatre_mode=True,
-        _was_custom_fullscreen=False,
+        is_full_screen=False,
+        _fullscreen_theatre_transition_in_progress=False,
         showFullScreen=MagicMock(),
         showNormal=MagicMock(),
-        isFullScreen=lambda: True,
+        isFullScreen=lambda: False,
         _sync_viewer_menu_actions=lambda: synced.append(True),
     )
 
     view_fullscreen(main_window)
 
-    assert main_window._was_custom_fullscreen is True
-    main_window.showFullScreen.assert_not_called()
+    assert theatre_calls == [True, False]
+    main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
+    assert main_window.is_theatre_mode is True
+    assert main_window.is_full_screen is True
+    assert main_window._fullscreen_theatre_transition_in_progress is False
+    assert single_shot_calls == [0]
     assert synced == [True]
 
 
@@ -61,6 +87,7 @@ def test_view_fullscreen_uses_real_window_transition_outside_theatre():
     synced = []
     main_window = SimpleNamespace(
         is_theatre_mode=False,
+        is_full_screen=True,
         showFullScreen=MagicMock(),
         showNormal=MagicMock(),
         isFullScreen=lambda: False,
@@ -72,6 +99,218 @@ def test_view_fullscreen_uses_real_window_transition_outside_theatre():
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
     assert synced == [True]
+
+
+class _FakeWidget:
+    def __init__(self, visible: bool = True):
+        self._visible = visible
+        self._minimum_height = None
+
+    def isVisible(self):
+        return self._visible
+
+    def hide(self):
+        self._visible = False
+
+    def show(self):
+        self._visible = True
+
+    def sizeHint(self):
+        return SimpleNamespace(height=lambda: 42)
+
+    def setMinimumHeight(self, value):
+        self._minimum_height = value
+
+
+class _FakeMenuBar(_FakeWidget):
+    pass
+
+
+class _FakeLayout:
+    def count(self):
+        return 0
+
+    def itemAt(self, _index):
+        raise IndexError
+
+    def takeAt(self, _index):
+        raise IndexError
+
+    def setContentsMargins(self, *_args):
+        return None
+
+    def contentsMargins(self):
+        return (0, 0, 0, 0)
+
+    def setSpacing(self, *_args):
+        return None
+
+    def spacing(self):
+        return 0
+
+    def insertItem(self, *_args):
+        return None
+
+    def invalidate(self):
+        return None
+
+
+class _FakeGraphicsViewFrame:
+    def frameShape(self):
+        return "box"
+
+    def setFrameShape(self, *_args):
+        return None
+
+    def setStyleSheet(self, *_args):
+        return None
+
+    def setVerticalScrollBarPolicy(self, *_args):
+        return None
+
+    def setHorizontalScrollBarPolicy(self, *_args):
+        return None
+
+
+def _make_theatre_entry_window(*, is_fullscreen: bool, is_maximized: bool = False):
+    menu_bar = _FakeMenuBar()
+    return SimpleNamespace(
+        is_theatre_mode=False,
+        is_full_screen=False,
+        _saved_window_state=None,
+        input_Target_DockWidget=_FakeWidget(),
+        input_Faces_DockWidget=_FakeWidget(),
+        jobManagerDockWidget=_FakeWidget(),
+        controlOptionsDockWidget=_FakeWidget(),
+        facesPanelGroupBox=_FakeWidget(),
+        menuBar=lambda: menu_bar,
+        horizontalLayout=_FakeLayout(),
+        verticalLayout=_FakeLayout(),
+        verticalLayoutMediaControls=_FakeLayout(),
+        panelVisibilityCheckBoxLayout=_FakeLayout(),
+        graphicsViewFrame=_FakeGraphicsViewFrame(),
+        saveState=lambda: "window-state",
+        isMaximized=lambda: is_maximized,
+        isFullScreen=lambda: is_fullscreen,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
+        setWindowState=MagicMock(),
+        showFullScreen=MagicMock(),
+    )
+
+
+def test_toggle_theatre_mode_keeps_fullscreen_when_base_mode_is_fullscreen(monkeypatch):
+    monkeypatch.setattr(
+        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(is_fullscreen=True)
+
+    toggle_theatre_mode(main_window)
+
+    assert main_window._was_custom_fullscreen is True
+    assert main_window._was_normal_geometry == "normal-geometry"
+    main_window.setWindowState.assert_called_once_with(
+        video_control_actions.QtCore.Qt.WindowState.WindowFullScreen
+    )
+    main_window.showFullScreen.assert_called_once()
+    assert main_window.is_full_screen is True
+
+
+def test_toggle_theatre_mode_keeps_normal_window_when_base_mode_is_windowed(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(is_fullscreen=False, is_maximized=False)
+
+    toggle_theatre_mode(main_window)
+
+    assert main_window._was_custom_fullscreen is False
+    main_window.setWindowState.assert_not_called()
+    main_window.showFullScreen.assert_not_called()
+    assert main_window.is_full_screen is False
+
+
+def test_toggle_theatre_mode_keeps_maximized_window_when_base_mode_is_maximized(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(is_fullscreen=False, is_maximized=True)
+
+    toggle_theatre_mode(main_window)
+
+    assert main_window._was_custom_fullscreen is False
+    assert main_window._was_maximized is True
+    main_window.setWindowState.assert_not_called()
+    main_window.showFullScreen.assert_not_called()
+    assert main_window.is_full_screen is False
+
+
+def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(monkeypatch):
+    monkeypatch.setattr(
+        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+
+    menu_bar = _FakeMenuBar()
+    saved_geometry = SimpleNamespace(
+        x=lambda: 100,
+        y=lambda: 200,
+        width=lambda: 900,
+        height=lambda: 600,
+    )
+    set_geometry_calls = []
+    main_window = SimpleNamespace(
+        is_theatre_mode=True,
+        _was_custom_fullscreen=False,
+        _was_maximized=False,
+        _was_normal_geometry=saved_geometry,
+        _saved_window_state="window-state",
+        _saved_dock_states={},
+        _saved_layout_props={},
+        _main_v_spacers=[],
+        _top_bar_spacers=[],
+        _top_bar_widgets_state={},
+        input_Target_DockWidget=_FakeWidget(False),
+        input_Faces_DockWidget=_FakeWidget(False),
+        jobManagerDockWidget=_FakeWidget(False),
+        controlOptionsDockWidget=_FakeWidget(False),
+        facesPanelGroupBox=_FakeWidget(False),
+        menuBar=lambda: menu_bar,
+        horizontalLayout=_FakeLayout(),
+        verticalLayout=_FakeLayout(),
+        verticalLayoutMediaControls=_FakeLayout(),
+        panelVisibilityCheckBoxLayout=_FakeLayout(),
+        graphicsViewFrame=_FakeGraphicsViewFrame(),
+        isFullScreen=lambda: False,
+        normalGeometry=lambda: saved_geometry,
+        geometry=lambda: saved_geometry,
+        showFullScreen=MagicMock(),
+        showMaximized=MagicMock(),
+        showNormal=MagicMock(),
+        setGeometry=lambda geometry: set_geometry_calls.append(geometry),
+        restoreState=MagicMock(),
+        setUpdatesEnabled=MagicMock(),
+    )
+
+    toggle_theatre_mode(main_window)
+
+    main_window.showNormal.assert_called_once()
+    main_window.showFullScreen.assert_not_called()
+    main_window.showMaximized.assert_not_called()
+    assert set_geometry_calls == [saved_geometry]
+    main_window.restoreState.assert_called_once_with("window-state")
+    assert [call.args for call in main_window.setUpdatesEnabled.call_args_list] == [
+        (False,),
+        (True,),
+    ]
+    assert main_window.is_full_screen is False
 
 
 def test_disable_compare_preview_modes_for_recording_disables_both_and_toasts():


### PR DESCRIPTION
## Summary

This PR improves fullscreen toggling while theatre mode is active.

Rather than trying to change fullscreen state in-place during theatre mode, it now exits theatre, applies the fullscreen toggle, and then re-enters theatre. This avoids the broken window-state behavior seen on some Windows scaling setups.

## Changes

- Updated fullscreen handling while theatre mode is active so it now:
  - exits theatre
  - toggles fullscreen or windowed mode
  - re-enters theatre
- Preserved the expected base window behavior:
  - windowed stays windowed
  - maximized stays maximized
  - fullscreen stays fullscreen
- Added regression coverage for the theatre/fullscreen transition flow

## Validation

- `pre-commit run --all-files` passed
- Targeted tests passed:
  - `tests/unit/ui/test_video_control_actions.py`
  - `tests/unit/ui/test_save_load_actions.py`