### PR TITLE
Fix/theatre fullscreen restore

### DIFF
--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -114,6 +114,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self._rightFacesStripVisible = False
         self._theatre_normal_panel_states: dict[str, bool] | None = None
         self._theatre_mode_panel_states: dict[str, bool] | None = None
+        self._fullscreen_restore_was_maximized = False
+        self._fullscreen_restore_geometry = None
         self.panel_visibility_state: dict[str, bool] = {
             "target_media": True,
             "input_faces": True,
@@ -775,10 +777,10 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def keyPressEvent(self, event):
         match event.key():
             case QtCore.Qt.Key_Escape:
-                if getattr(self, "is_theatre_mode", False):
-                    video_control_actions.toggle_theatre_mode(self)
-                elif self.isFullScreen():
+                if self.isFullScreen():
                     video_control_actions.view_fullscreen(self)
+                elif getattr(self, "is_theatre_mode", False):
+                    video_control_actions.toggle_theatre_mode(self)
             case QtCore.Qt.Key_F11:
                 video_control_actions.view_fullscreen(self)
             case QtCore.Qt.Key_T:
@@ -1319,8 +1321,6 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         return context_labels.get(value, self._mask_show_option_label(value))
 
     def _is_fullscreen_menu_active(self) -> bool:
-        if getattr(self, "is_theatre_mode", False):
-            return bool(getattr(self, "_was_custom_fullscreen", False))
         return self.isFullScreen()
 
     def _handle_viewer_mask_action(self, value: str, checked: bool):

--- a/app/ui/widgets/actions/save_load_actions.py
+++ b/app/ui/widgets/actions/save_load_actions.py
@@ -698,13 +698,9 @@ def save_current_workspace(
     saved_geometry = main_window.geometry()
     dock_state_source = None
     if is_theatre_mode:
-        saved_is_fullscreen = bool(
-            getattr(main_window, "_was_custom_fullscreen", False)
-        )
+        saved_is_fullscreen = bool(main_window.is_full_screen)
         saved_is_maximized = (
-            bool(getattr(main_window, "_was_maximized", False))
-            if not saved_is_fullscreen
-            else False
+            bool(main_window.isMaximized()) if not saved_is_fullscreen else False
         )
         saved_geometry = getattr(main_window, "_was_normal_geometry", saved_geometry)
         dock_state_source = getattr(main_window, "_saved_window_state", None)

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -1311,40 +1311,56 @@ def delete_all_markers(main_window: "MainWindow"):
     update_drop_frame_button_label(main_window)
 
 
-def view_fullscreen(main_window: "MainWindow"):
-    """Toggle fullscreen, briefly exiting/re-entering theatre mode when needed."""
+def _restore_window_base_mode(
+    main_window: "MainWindow",
+    *,
+    restore_to_fullscreen: bool,
+    restore_to_maximized: bool,
+    restore_geometry=None,
+):
+    if restore_to_fullscreen:
+        try:
+            main_window.setWindowState(QtCore.Qt.WindowState.WindowFullScreen)
+        except Exception:
+            main_window.showFullScreen()
+        main_window.is_full_screen = True
+        return
 
-    def _apply_fullscreen_toggle():
-        if main_window.isFullScreen():
-            main_window.showNormal()  # Exit full-screen mode
-            main_window.is_full_screen = False
-        else:
-            main_window.showFullScreen()  # Enter full-screen mode
-            main_window.is_full_screen = True
+    if restore_to_maximized:
+        main_window.showMaximized()
+    else:
+        main_window.showNormal()
+        if restore_geometry is not None:
+            main_window.setGeometry(restore_geometry)
+    main_window.is_full_screen = False
+
+
+def view_fullscreen(main_window: "MainWindow"):
+    """Toggle fullscreen without changing theatre mode."""
+
+    if main_window.isFullScreen():
+        restore_to_maximized = bool(
+            getattr(main_window, "_fullscreen_restore_was_maximized", False)
+        )
+        restore_geometry = getattr(main_window, "_fullscreen_restore_geometry", None)
+        _restore_window_base_mode(
+            main_window,
+            restore_to_fullscreen=False,
+            restore_to_maximized=restore_to_maximized,
+            restore_geometry=restore_geometry,
+        )
+        main_window._fullscreen_restore_was_maximized = False
+        main_window._fullscreen_restore_geometry = None
+    else:
+        was_maximized = main_window.isMaximized()
+        main_window._fullscreen_restore_was_maximized = was_maximized
+        main_window._fullscreen_restore_geometry = (
+            main_window.normalGeometry() if was_maximized else main_window.geometry()
+        )
+        main_window.showFullScreen()  # Enter full-screen mode
+        main_window.is_full_screen = True
 
     sync_actions = getattr(main_window, "_sync_viewer_menu_actions", None)
-
-    if getattr(main_window, "_fullscreen_theatre_transition_in_progress", False):
-        return
-
-    if getattr(main_window, "is_theatre_mode", False):
-        main_window._fullscreen_theatre_transition_in_progress = True
-        toggle_theatre_mode(main_window)
-        _apply_fullscreen_toggle()
-
-        def _reenter_theatre():
-            try:
-                if not getattr(main_window, "is_theatre_mode", False):
-                    toggle_theatre_mode(main_window)
-            finally:
-                main_window._fullscreen_theatre_transition_in_progress = False
-                if callable(sync_actions):
-                    sync_actions()
-
-        QtCore.QTimer.singleShot(0, _reenter_theatre)
-        return
-
-    _apply_fullscreen_toggle()
 
     if callable(sync_actions):
         sync_actions()
@@ -2966,17 +2982,12 @@ def toggle_theatre_mode(main_window: "MainWindow"):
         was_maximized = getattr(main_window, "_was_maximized", False)
         saved_normal_geometry = getattr(main_window, "_was_normal_geometry", None)
 
-        if was_custom_fullscreen:
-            main_window.showFullScreen()
-            main_window.is_full_screen = True
-        elif was_maximized:
-            main_window.showMaximized()
-            main_window.is_full_screen = False
-        else:
-            main_window.showNormal()
-            if saved_normal_geometry is not None:
-                main_window.setGeometry(saved_normal_geometry)
-            main_window.is_full_screen = False
+        _restore_window_base_mode(
+            main_window,
+            restore_to_fullscreen=was_custom_fullscreen,
+            restore_to_maximized=was_maximized and not was_custom_fullscreen,
+            restore_geometry=saved_normal_geometry,
+        )
 
         # Restores the exact layout state of docks (fixes the Input Faces / Target Video sizing)
         if hasattr(main_window, "_saved_window_state"):

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -430,7 +430,7 @@ def test_save_workspace_non_theatre_uses_live_window_state(tmp_path):
     assert (saved["x"], saved["y"], saved["width"], saved["height"]) == (5, 6, 700, 500)
 
 
-def test_save_workspace_theatre_from_fullscreen_uses_base_snapshot(tmp_path):
+def test_save_workspace_theatre_from_fullscreen_uses_live_window_state(tmp_path):
     save_path = tmp_path / "workspace.json"
     base_geometry = _FakeGeometry(100, 200, 900, 600)
     main_window = _make_workspace_main_window(
@@ -459,14 +459,14 @@ def test_save_workspace_theatre_from_fullscreen_uses_base_snapshot(tmp_path):
     )
 
 
-def test_save_workspace_theatre_from_maximized_uses_base_snapshot(tmp_path):
+def test_save_workspace_theatre_from_maximized_uses_live_window_state(tmp_path):
     save_path = tmp_path / "workspace.json"
     base_geometry = _FakeGeometry(111, 222, 1000, 700)
     main_window = _make_workspace_main_window(
         tmp_path,
         is_theatre_mode=True,
-        is_full_screen=True,
-        is_maximized=False,
+        is_full_screen=False,
+        is_maximized=True,
         geometry=_FakeGeometry(0, 0, 1920, 1080),
         normal_geometry=base_geometry,
         saved_window_state="pre-theatre-layout",
@@ -488,13 +488,13 @@ def test_save_workspace_theatre_from_maximized_uses_base_snapshot(tmp_path):
     )
 
 
-def test_save_workspace_theatre_from_normal_uses_base_snapshot(tmp_path):
+def test_save_workspace_theatre_from_normal_uses_live_window_state(tmp_path):
     save_path = tmp_path / "workspace.json"
     base_geometry = _FakeGeometry(123, 234, 1010, 710)
     main_window = _make_workspace_main_window(
         tmp_path,
         is_theatre_mode=True,
-        is_full_screen=True,
+        is_full_screen=False,
         is_maximized=False,
         geometry=_FakeGeometry(0, 0, 1920, 1080),
         normal_geometry=base_geometry,
@@ -531,11 +531,30 @@ def test_save_workspace_theatre_uses_latest_fullscreen_base_toggle(tmp_path):
 
     save_current_workspace(main_window, str(save_path))
     saved = _read_saved_workspace(save_path)["window_state_data"]
-    assert saved["isFullScreen"] is False
-    assert saved["isMaximized"] is True
+    assert saved["isFullScreen"] is True
+    assert saved["isMaximized"] is False
 
+    main_window.is_full_screen = False
+    main_window.isMaximized = lambda: True
     main_window._was_custom_fullscreen = True
     save_current_workspace(main_window, str(save_path))
     saved = _read_saved_workspace(save_path)["window_state_data"]
-    assert saved["isFullScreen"] is True
-    assert saved["isMaximized"] is False
+    assert saved["isFullScreen"] is False
+    assert saved["isMaximized"] is True
+
+
+def test_save_workspace_theatre_does_not_serialize_theatre_active_flag(tmp_path):
+    save_path = tmp_path / "workspace.json"
+    main_window = _make_workspace_main_window(
+        tmp_path,
+        is_theatre_mode=True,
+        is_full_screen=False,
+        is_maximized=False,
+        saved_window_state="pre-theatre-layout",
+    )
+
+    save_current_workspace(main_window, str(save_path))
+
+    saved = _read_saved_workspace(save_path)
+    assert "is_theatre_mode" not in saved
+    assert "is_theatre_mode" not in saved["window_state_data"]

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -19,6 +19,13 @@ _STUBS = [
     "PySide6.QtWidgets",
     "PySide6.QtCore",
     "PySide6.QtGui",
+    "cv2",
+    "numpy",
+    "PIL",
+    "PIL.Image",
+    "app.helpers",
+    "app.helpers.typing_helper",
+    "app.helpers.miscellaneous",
     "app.ui.widgets.widget_components",
     "app.ui.widgets.ui_workers",
     "app.ui.widgets.actions.common_actions",
@@ -40,46 +47,29 @@ from app.ui.widgets.actions.video_control_actions import (  # noqa: E402
 )
 
 
-def test_view_fullscreen_temporarily_exits_and_reenters_theatre(monkeypatch):
+def test_view_fullscreen_keeps_theatre_mode_active():
     synced = []
-    theatre_calls = []
-    single_shot_calls = []
-
-    def fake_toggle_theatre_mode(window):
-        theatre_calls.append(window.is_theatre_mode)
-        window.is_theatre_mode = not window.is_theatre_mode
-
-    monkeypatch.setattr(
-        video_control_actions, "toggle_theatre_mode", fake_toggle_theatre_mode
-    )
-    monkeypatch.setattr(
-        video_control_actions.QtCore.QTimer,
-        "singleShot",
-        lambda delay, callback: (
-            single_shot_calls.append(delay),
-            callback(),
-        )[-1],
-    )
-
     main_window = SimpleNamespace(
         is_theatre_mode=True,
         is_full_screen=False,
-        _fullscreen_theatre_transition_in_progress=False,
+        _fullscreen_restore_was_maximized=False,
+        _fullscreen_restore_geometry=None,
         showFullScreen=MagicMock(),
         showNormal=MagicMock(),
+        isMaximized=lambda: False,
         isFullScreen=lambda: False,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
         _sync_viewer_menu_actions=lambda: synced.append(True),
     )
 
     view_fullscreen(main_window)
 
-    assert theatre_calls == [True, False]
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
     assert main_window.is_theatre_mode is True
     assert main_window.is_full_screen is True
-    assert main_window._fullscreen_theatre_transition_in_progress is False
-    assert single_shot_calls == [0]
+    assert main_window._fullscreen_restore_geometry == "live-geometry"
     assert synced == [True]
 
 
@@ -90,7 +80,10 @@ def test_view_fullscreen_uses_real_window_transition_outside_theatre():
         is_full_screen=True,
         showFullScreen=MagicMock(),
         showNormal=MagicMock(),
+        isMaximized=lambda: False,
         isFullScreen=lambda: False,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
         _sync_viewer_menu_actions=lambda: synced.append(True),
     )
 
@@ -99,6 +92,185 @@ def test_view_fullscreen_uses_real_window_transition_outside_theatre():
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
     assert synced == [True]
+
+
+class _FakeGeometry:
+    def __init__(
+        self,
+        x: int = 100,
+        y: int = 200,
+        width: int = 900,
+        height: int = 600,
+    ):
+        self._x = x
+        self._y = y
+        self._width = width
+        self._height = height
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+    def width(self):
+        return self._width
+
+    def height(self):
+        return self._height
+
+
+class _StatefulFullscreenWindow:
+    def __init__(
+        self,
+        *,
+        state: str = "normal",
+        geometry: _FakeGeometry | None = None,
+        is_theatre_mode: bool = False,
+    ):
+        self._state = state
+        self._geometry = geometry or _FakeGeometry()
+        self._normal_geometry = self._geometry
+        self.is_theatre_mode = is_theatre_mode
+        self.is_full_screen = state == "fullscreen"
+        self._fullscreen_restore_was_maximized = False
+        self._fullscreen_restore_geometry = None
+        self._was_maximized = state == "maximized"
+        self._was_custom_fullscreen = False
+        self._was_normal_geometry = self._normal_geometry
+        self._sync_calls: list[bool] = []
+        self.showFullScreen = MagicMock(side_effect=self._show_fullscreen)
+        self.showNormal = MagicMock(side_effect=self._show_normal)
+        self.showMaximized = MagicMock(side_effect=self._show_maximized)
+        self.setGeometry = MagicMock(side_effect=self._set_geometry)
+
+    def _show_fullscreen(self):
+        self._state = "fullscreen"
+        self.is_full_screen = True
+
+    def _show_normal(self):
+        self._state = "normal"
+        self.is_full_screen = False
+
+    def _show_maximized(self):
+        self._state = "maximized"
+        self.is_full_screen = False
+
+    def _set_geometry(self, geometry):
+        self._geometry = geometry
+        self._normal_geometry = geometry
+
+    def isFullScreen(self):
+        return self._state == "fullscreen"
+
+    def isMaximized(self):
+        return self._state == "maximized"
+
+    def normalGeometry(self):
+        return self._normal_geometry
+
+    def geometry(self):
+        return self._geometry
+
+    def _sync_viewer_menu_actions(self):
+        self._sync_calls.append(True)
+
+
+def test_view_fullscreen_restores_saved_geometry_after_round_trip():
+    geometry = _FakeGeometry()
+    main_window = _StatefulFullscreenWindow(state="normal", geometry=geometry)
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    main_window.showFullScreen.assert_called_once()
+    main_window.showNormal.assert_called_once()
+    assert main_window.setGeometry.call_args_list[-1].args == (geometry,)
+    assert main_window.isFullScreen() is False
+    assert main_window.isMaximized() is False
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is None
+    assert main_window._sync_calls == [True, True]
+
+
+def test_view_fullscreen_restores_maximized_state_after_round_trip():
+    main_window = _StatefulFullscreenWindow(state="maximized")
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    main_window.showFullScreen.assert_called_once()
+    main_window.showMaximized.assert_called_once()
+    main_window.showNormal.assert_not_called()
+    main_window.setGeometry.assert_not_called()
+    assert main_window.isMaximized() is True
+    assert main_window.isFullScreen() is False
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is None
+    assert main_window._sync_calls == [True, True]
+
+
+def test_view_fullscreen_preserves_maximized_base_state_in_theatre():
+    main_window = _StatefulFullscreenWindow(state="maximized", is_theatre_mode=True)
+    main_window._was_maximized = True
+    main_window._was_custom_fullscreen = False
+    main_window._was_normal_geometry = main_window.normalGeometry()
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isMaximized() is True
+    assert main_window.isFullScreen() is False
+    assert main_window.showMaximized.call_count == 1
+    assert main_window._was_maximized is True
+    assert main_window._was_custom_fullscreen is False
+    assert main_window._was_normal_geometry == main_window.normalGeometry()
+    assert main_window._fullscreen_restore_geometry is None
+
+
+def test_view_fullscreen_preserves_normal_geometry_in_theatre():
+    geometry = _FakeGeometry()
+    main_window = _StatefulFullscreenWindow(
+        state="normal",
+        geometry=geometry,
+        is_theatre_mode=True,
+    )
+    main_window._was_maximized = False
+    main_window._was_custom_fullscreen = False
+    main_window._was_normal_geometry = geometry
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isMaximized() is False
+    assert main_window.isFullScreen() is False
+    assert main_window.showNormal.call_count == 1
+    assert main_window.setGeometry.call_args_list[-1].args == (geometry,)
+    assert main_window._was_maximized is False
+    assert main_window._was_custom_fullscreen is False
+    assert main_window._was_normal_geometry is geometry
+
+
+def test_view_fullscreen_keeps_theatre_layout_active_during_round_trip():
+    main_window = _StatefulFullscreenWindow(state="normal", is_theatre_mode=True)
+    base_geometry = main_window.geometry()
+    main_window._was_maximized = False
+    main_window._was_custom_fullscreen = False
+    main_window._was_normal_geometry = base_geometry
+
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isFullScreen() is True
+    assert main_window._was_normal_geometry is base_geometry
+
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isFullScreen() is False
+    assert main_window.geometry() is base_geometry
 
 
 class _FakeWidget:
@@ -305,6 +477,61 @@ def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(monkeypatch)
     main_window.showFullScreen.assert_not_called()
     main_window.showMaximized.assert_not_called()
     assert set_geometry_calls == [saved_geometry]
+    main_window.restoreState.assert_called_once_with("window-state")
+    assert [call.args for call in main_window.setUpdatesEnabled.call_args_list] == [
+        (False,),
+        (True,),
+    ]
+    assert main_window.is_full_screen is False
+
+
+def test_toggle_theatre_mode_restores_maximized_state_on_exit(monkeypatch):
+    monkeypatch.setattr(
+        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+
+    menu_bar = _FakeMenuBar()
+    main_window = SimpleNamespace(
+        is_theatre_mode=True,
+        _was_custom_fullscreen=False,
+        _was_maximized=True,
+        _was_normal_geometry="normal-geometry",
+        _saved_window_state="window-state",
+        _saved_dock_states={},
+        _saved_layout_props={},
+        _main_v_spacers=[],
+        _top_bar_spacers=[],
+        _top_bar_widgets_state={},
+        input_Target_DockWidget=_FakeWidget(False),
+        input_Faces_DockWidget=_FakeWidget(False),
+        jobManagerDockWidget=_FakeWidget(False),
+        controlOptionsDockWidget=_FakeWidget(False),
+        facesPanelGroupBox=_FakeWidget(False),
+        menuBar=lambda: menu_bar,
+        horizontalLayout=_FakeLayout(),
+        verticalLayout=_FakeLayout(),
+        verticalLayoutMediaControls=_FakeLayout(),
+        panelVisibilityCheckBoxLayout=_FakeLayout(),
+        graphicsViewFrame=_FakeGraphicsViewFrame(),
+        isFullScreen=lambda: False,
+        isMaximized=lambda: False,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
+        showFullScreen=MagicMock(),
+        showMaximized=MagicMock(),
+        showNormal=MagicMock(),
+        setGeometry=MagicMock(),
+        restoreState=MagicMock(),
+        setUpdatesEnabled=MagicMock(),
+    )
+
+    toggle_theatre_mode(main_window)
+
+    main_window.showFullScreen.assert_not_called()
+    main_window.showMaximized.assert_called_once()
+    main_window.showNormal.assert_not_called()
+    main_window.setGeometry.assert_not_called()
     main_window.restoreState.assert_called_once_with("window-state")
     assert [call.args for call in main_window.setUpdatesEnabled.call_args_list] == [
         (False,),


### PR DESCRIPTION
## Summary

This fixes the remaining `F11` fullscreen and theatre mode state issues.

Theatre mode is now independent from fullscreen, so pressing `F11` no longer exits and re-enters theatre mode just to change window state. It can now stay active in normal, maximized, or fullscreen modes.

Workspace saving was also corrected. When saving while theatre mode is active, the current window state is preserved, but theatre mode itself is still not persisted.

## Changes

- Keep theatre mode active during `F11` fullscreen toggles
- Restore fullscreen back to the correct base window state
- Make `Esc` exit fullscreen before theatre mode
- Keep the fullscreen menu state in sync with the live window state
- Save the live fullscreen/maximized state while theatre mode is active
- Restore the normal dock/layout state from the pre-theatre snapshot
- Do not persist theatre mode in saved workspaces

## Notes

- On Windows, leaving native fullscreen to maximized may still cause a brief visual hop. The restored state is still correct.
- The app will not reopen in theatre mode after loading a workspace.

## Testing

Ran:

```bash
.venv\Scripts\python.exe -m pytest --noconftest tests\unit\ui\test_video_control_actions.py -q
.venv\Scripts\python.exe -m pytest --noconftest tests\unit\ui\test_save_load_actions.py -q
pre-commit run --all-files