### PR TITLE
KPS and Landmarks Fixes + added separate 203 kps

### DIFF
--- a/app/helpers/miscellaneous.py
+++ b/app/helpers/miscellaneous.py
@@ -159,6 +159,7 @@ class ThumbnailManager:
             media_width=width, media_height=height, max_height=140, max_width=140
         )
 
+        width, height = max(1, width), max(1, height)
         resized_frame = cv2.resize(
             frame, (width, height), interpolation=cv2.INTER_LANCZOS4
         )
@@ -623,10 +624,10 @@ def get_scaled_resolution(
         scaled_width = media_width * scale
         scaled_height = media_height * scale
 
-        return int(scaled_width), int(scaled_height)
+        return max(1, int(scaled_width)), max(1, int(scaled_height))
 
     # If the media is already within bounds, return its original dimensions.
-    return int(media_width), int(media_height)
+    return max(1, int(media_width)), max(1, int(media_height))
 
 
 def get_video_rotation(media_path: str) -> int:
@@ -1254,27 +1255,31 @@ def draw_bounding_boxes_on_detected_faces(
 
 def paint_landmarks_on_image(img: torch.Tensor, landmarks_data: list) -> torch.Tensor:
     """
-    OPTIMIZED: Replaced deeply nested loops and per-pixel tensor allocations
-    with tensor slicing and pre-allocated colors to eliminate CPU bottlenecks.
+    OPTIMIZED: Pre-allocates color tensor to avoid GPU memory overhead in the inner loop.
+    NOTE: This function expects the input tensor 'img' to be in (H, W, C) format.
     """
     img_out_hwc = img.clone()
     p = 2
+
+    # Extract dimensions correctly based on (H, W, C) format
+    h = img_out_hwc.shape[0]
+    w = img_out_hwc.shape[1]
 
     for item in landmarks_data:
         keypoints = item["kps"]
         kcolor = item["color"]
         if keypoints is not None:
-            # OPTIMIZATION: Allocate the color tensor ONCE per face, not per pixel
+            # Create color tensor once per face (shape: [3]).
+            # PyTorch will automatically broadcast this across the [y, x] slice in the (H, W, C) tensor.
             kcolor_tensor = torch.tensor(kcolor, device=img.device, dtype=img.dtype)
 
             for kpoint in keypoints:
                 kx, ky = int(kpoint[0]), int(kpoint[1])
 
-                # OPTIMIZATION: Use direct slicing instead of nested loops
                 y_min = max(0, ky - p // 2)
-                y_max = min(img_out_hwc.shape[0], ky + p // 2 + 1)
+                y_max = min(h, ky + p // 2 + 1)
                 x_min = max(0, kx - p // 2)
-                x_max = min(img_out_hwc.shape[1], kx + p // 2 + 1)
+                x_max = min(w, kx + p // 2 + 1)
 
                 if y_min < y_max and x_min < x_max:
                     img_out_hwc[y_min:y_max, x_min:x_max] = kcolor_tensor

--- a/app/processors/frame_edits.py
+++ b/app/processors/frame_edits.py
@@ -946,26 +946,16 @@ class FrameEdits:
         Returns:
             torch.Tensor: Image with makeup applied.
         """
-        use_mean_eyes = parameters.get("LandmarkMeanEyesToggle", False)
-
         if (
             parameters["FaceMakeupEnableToggle"]
             or parameters["HairMakeupEnableToggle"]
             or parameters["EyeBrowsMakeupEnableToggle"]
             or parameters["LipsMakeupEnableToggle"]
         ):
-            if kps is not None and len(kps) > 5:
+            if kps is not None and len(kps) >= 5:
                 lmk_crop = kps
             else:
-                _, lmk_crop, _ = self.models_processor.run_detect_landmark(
-                    img,
-                    bbox=[],
-                    det_kpss=kps,
-                    detect_mode="203",
-                    score=0.5,
-                    from_points=False,
-                    use_mean_eyes=use_mean_eyes,
-                )
+                return img
 
             # Use the interpolation mode passed from FrameWorker, or default to BILINEAR
             interp_mode = (

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -143,6 +143,7 @@ class VideoProcessor(QObject):
         self.last_detected_faces: list[dict] = []
         self._smoothed_kps: dict[int, numpy.ndarray] = {}
         self._smoothed_dense_kps: dict[int, numpy.ndarray] = {}
+        self._smoothed_dense_kps_203: dict[int, numpy.ndarray] = {}
 
         # --- Processing State Flags ---
         self.processing = False  # MASTER flag: True if playback, recording, or webcam stream is active
@@ -483,42 +484,41 @@ class VideoProcessor(QObject):
             )
             from_points = local_control_for_worker.get("DetectFromPointsToggle", False)
 
-            # Check if LivePortrait or Makeup features are enabled (they strictly require 203 landmarks)
+            # Check if LivePortrait features are enabled (they strictly require 203 landmarks)
+            master_edit_button = self.main_window.editFacesButton.isChecked()
+
             requires_203 = False
+            if local_params_for_worker:
+                from collections.abc import Mapping
 
-            # 1. Check global control fallback
-            if local_control_for_worker.get(
-                "FaceEditorEnableToggle", False
-            ) or local_control_for_worker.get("FaceExpressionEnableBothToggle", False):
-                requires_203 = True
-
-            # 2. Check per-face parameters (where these settings actually live)
-            if not requires_203 and local_params_for_worker:
                 for face_id, face_params in local_params_for_worker.items():
-                    if isinstance(face_params, dict):
-                        if (
-                            face_params.get("FaceEditorEnableToggle", False)
-                            or face_params.get("FaceExpressionEnableBothToggle", False)
-                            or face_params.get("AutoMouthExpressionEnableToggle", False)
-                            or face_params.get("FaceMakeupEnableToggle", False)
+                    if isinstance(face_params, Mapping):
+                        is_face_editor_active = master_edit_button and face_params.get(
+                            "FaceEditorEnableToggle", False
+                        )
+                        is_expression_active = face_params.get(
+                            "FaceExpressionEnableBothToggle", False
+                        )
+                        is_auto_mouth_active = face_params.get(
+                            "AutoMouthExpressionEnableToggle", False
+                        )
+                        is_makeup_active = master_edit_button and (
+                            face_params.get("FaceMakeupEnableToggle", False)
                             or face_params.get("HairMakeupEnableToggle", False)
                             or face_params.get("EyeBrowsMakeupEnableToggle", False)
                             or face_params.get("LipsMakeupEnableToggle", False)
+                        )
+
+                        if (
+                            is_face_editor_active
+                            or is_expression_active
+                            or is_auto_mouth_active
+                            or is_makeup_active
                         ):
                             requires_203 = True
                             break
 
-            if requires_203:
-                # Force 203 and from_points to ensure LivePortrait does not crash
-                use_landmark = True
-                landmark_mode = "203"
-                from_points = True
-            elif local_control_for_worker.get(
-                "edit_enabled", True
-            ) or local_control_for_worker.get("swap_enabled", True):
-                # Standard swap/edit still needs landmarks for basic face alignment,
-                # but we respect the user's choice for the landmark model and from_points.
-                use_landmark = True
+            # DO NOT override user choice! We preserve use_landmark and landmark_mode.
 
             detection_interval = int(
                 local_control_for_worker.get("FaceDetectionIntervalSlider", 1)
@@ -534,14 +534,13 @@ class VideoProcessor(QObject):
 
             owns_frame_tensor = frame_tensor is None
             if frame_tensor is None:
-                # OPTIMISATION PCIe : non_blocking=True frees CPU immediately
                 frame_tensor = (
                     torch.from_numpy(frame_rgb)
                     .to(device, non_blocking=True)
                     .permute(2, 0, 1)  # Convert [H, W, C] -> [C, H, W]
                 )
 
-            # 1. Run Detection
+            # 1. Primary Detection (respecting User's UI choice)
             bboxes, kpss_5, kpss = self.main_window.models_processor.run_detect(
                 frame_tensor,
                 local_control_for_worker.get("DetectorModelSelection", "RetinaFace"),
@@ -563,6 +562,43 @@ class VideoProcessor(QObject):
                 ),
                 previous_detections=previous_faces_arg,
             )
+
+            # 2. Smart Double-Scan for 203 points
+            kpss_203 = None
+            if requires_203:
+                if use_landmark and landmark_mode == "203":
+                    # OPTIMIZATION: User already selected 203. Duplicate reference. Zero CUDA cost.
+                    kpss_203 = kpss
+                else:
+                    # Execute second pass specifically for advanced features
+                    _, _, kpss_203 = self.main_window.models_processor.run_detect(
+                        frame_tensor,
+                        local_control_for_worker.get(
+                            "DetectorModelSelection", "RetinaFace"
+                        ),
+                        max_num=int(
+                            local_control_for_worker.get("MaxFacesToDetectSlider", 20)
+                        ),
+                        score=local_control_for_worker.get("DetectorScoreSlider", 50)
+                        / 100.0,
+                        input_size=(512, 512),
+                        use_landmark_detection=True,
+                        landmark_detect_mode="203",
+                        landmark_score=local_control_for_worker.get(
+                            "LandmarkDetectScoreSlider", 50
+                        )
+                        / 100.0,
+                        from_points=True,  # Force from_points for feature stability
+                        rotation_angles=[0]
+                        if not local_control_for_worker.get("AutoRotationToggle", False)
+                        else [0, 90, 180, 270],
+                        use_mean_eyes=local_control_for_worker.get(
+                            "LandmarkMeanEyesToggle", False
+                        ),
+                        previous_detections=previous_faces_arg,
+                        bypass_bytetrack=True,  # Prevent double-incrementing the object tracker
+                    )
+
             # Free up VRAM immediately since the tensor is no longer needed in this thread
             if owns_frame_tensor:
                 del frame_tensor
@@ -580,6 +616,9 @@ class VideoProcessor(QObject):
             kpss_5 = kpss_5.copy()
         if isinstance(kpss, numpy.ndarray):
             kpss = kpss.copy()
+        if isinstance(kpss_203, numpy.ndarray):
+            kpss_203 = kpss_203.copy()
+
         # Ensure 'bboxes' and keypoints are strictly valid float32 arrays and not 'object'.
         if isinstance(bboxes, numpy.ndarray):
             if bboxes.dtype == object:
@@ -606,17 +645,25 @@ class VideoProcessor(QObject):
                         valid_mask
                     ):
                         kpss = kpss[valid_mask]
+                    # Safely align dense kpss_203 if dimensions match
+                    if isinstance(kpss_203, numpy.ndarray) and kpss_203.shape[0] == len(
+                        valid_mask
+                    ):
+                        kpss_203 = kpss_203[valid_mask]
             else:
                 bboxes = numpy.empty((0, 4), dtype=numpy.float32)
         else:
             bboxes = numpy.empty((0, 4), dtype=numpy.float32)
+
         # If the sanitization purged the bboxes, we MUST purge the keypoints too.
         # Otherwise, the FrameWorker receives mismatched arrays and skips the face.
         if bboxes.shape[0] == 0:
             if isinstance(kpss_5, numpy.ndarray):
                 kpss_5 = numpy.empty((0, 5, 2), dtype=numpy.float32)
             if isinstance(kpss, numpy.ndarray):
-                kpss = numpy.empty((0, 68, 2), dtype=numpy.float32)
+                kpss = numpy.empty((0, 68, 2), dtype=numpy.float32)  # Fallback shape
+            if isinstance(kpss_203, numpy.ndarray):
+                kpss_203 = numpy.empty((0, 203, 2), dtype=numpy.float32)
 
         # 2. Update tracking state for the next sequential frame
         detected_for_state = []
@@ -640,10 +687,22 @@ class VideoProcessor(QObject):
                 n_faces = kpss_5.shape[0]
                 new_smoothed_kps = {}
                 new_smoothed_dense_kps = {}
+                new_smoothed_dense_kps_203 = {}
+
+                valid_kpss = cast(numpy.ndarray, kpss)
+                valid_kpss_203 = cast(numpy.ndarray, kpss_203)
 
                 has_dense_kps = isinstance(kpss, numpy.ndarray) and kpss.shape[0] > 0
                 if has_dense_kps:
-                    kpss = kpss.copy()
+                    valid_kpss = valid_kpss.copy()
+                    kpss = valid_kpss
+
+                has_dense_kps_203 = (
+                    isinstance(kpss_203, numpy.ndarray) and kpss_203.shape[0] > 0
+                )
+                if has_dense_kps_203:
+                    valid_kpss_203 = valid_kpss_203.copy()
+                    kpss_203 = valid_kpss_203
 
                 for _i in range(n_faces):
                     _raw = kpss_5[_i]
@@ -699,30 +758,50 @@ class VideoProcessor(QObject):
                         if has_dense_kps:
                             if _best_match_key in self._smoothed_dense_kps:
                                 new_smoothed_dense_kps[_i] = (
-                                    dynamic_alpha * kpss[_i]
+                                    dynamic_alpha * valid_kpss[_i]
                                     + (1.0 - dynamic_alpha)
                                     * self._smoothed_dense_kps[_best_match_key]
                                 )
                                 del self._smoothed_dense_kps[_best_match_key]
                             else:
-                                new_smoothed_dense_kps[_i] = kpss[_i].copy()
+                                new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
+
+                        # Smoothing on Dense KPS 203
+                        if has_dense_kps_203:
+                            if _best_match_key in self._smoothed_dense_kps_203:
+                                new_smoothed_dense_kps_203[_i] = (
+                                    dynamic_alpha * valid_kpss_203[_i]
+                                    + (1.0 - dynamic_alpha)
+                                    * self._smoothed_dense_kps_203[_best_match_key]
+                                )
+                                del self._smoothed_dense_kps_203[_best_match_key]
+                            else:
+                                new_smoothed_dense_kps_203[_i] = valid_kpss_203[
+                                    _i
+                                ].copy()
                     else:
                         new_smoothed_kps[_i] = _raw.copy()
                         if has_dense_kps:
-                            new_smoothed_dense_kps[_i] = kpss[_i].copy()
+                            new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
+                        if has_dense_kps_203:
+                            new_smoothed_dense_kps_203[_i] = valid_kpss_203[_i].copy()
 
                     kpss_5[_i] = new_smoothed_kps[_i]
                     if has_dense_kps:
-                        kpss[_i] = new_smoothed_dense_kps[_i]
+                        valid_kpss[_i] = new_smoothed_dense_kps[_i]
+                    if has_dense_kps_203:
+                        valid_kpss_203[_i] = new_smoothed_dense_kps_203[_i]
 
                 self._smoothed_kps = new_smoothed_kps
                 self._smoothed_dense_kps = new_smoothed_dense_kps
+                self._smoothed_dense_kps_203 = new_smoothed_dense_kps_203
         else:
             # Safe Clear if disabled
             self._smoothed_kps.clear()
             self._smoothed_dense_kps.clear()
+            self._smoothed_dense_kps_203.clear()
 
-        return bboxes, kpss_5, kpss
+        return bboxes, kpss_5, kpss, kpss_203
 
     def _feed_video_loop(self):
         """
@@ -937,7 +1016,7 @@ class VideoProcessor(QObject):
                 frame_rgb = numpy.ascontiguousarray(frame_bgr[..., ::-1])
 
                 # --- Inject Sequential Detection ---
-                bboxes, kpss_5, kpss = self._run_sequential_detection(
+                bboxes, kpss_5, kpss, kpss_203 = self._run_sequential_detection(
                     frame_rgb, local_control_for_worker, local_params_for_worker
                 )
 
@@ -950,6 +1029,7 @@ class VideoProcessor(QObject):
                     bboxes,
                     kpss_5,
                     kpss,
+                    kpss_203,
                 )
 
                 # Put the task in the queue for the worker pool
@@ -1013,11 +1093,11 @@ class VideoProcessor(QObject):
                     local_control_for_worker = self.main_window.control.copy()
 
                 # --- Inject Sequential Detection ---
-                bboxes, kpss_5, kpss = self._run_sequential_detection(
+                bboxes, kpss_5, kpss, kpss_203 = self._run_sequential_detection(
                     frame_rgb, local_control_for_worker, local_params_for_worker
                 )
 
-                # Create the 7-tuple task
+                # Create the 8-tuple task
                 task = (
                     0,  # frame_number is always 0 for webcam
                     frame_rgb,
@@ -1026,6 +1106,7 @@ class VideoProcessor(QObject):
                     bboxes,
                     kpss_5,
                     kpss,
+                    kpss_203,
                 )
 
                 # Put the task in the queue for the worker pool
@@ -2830,6 +2911,7 @@ class VideoProcessor(QObject):
         self.last_detected_faces = []
         self._smoothed_kps = {}
         self._smoothed_dense_kps = {}
+        self._smoothed_dense_kps_203 = {}
 
     def _prepare_issue_scan_match_context(
         self,
@@ -3151,7 +3233,7 @@ class VideoProcessor(QObject):
                         .permute(2, 0, 1)
                     )
                     self.current_frame_number = frame_number
-                    bboxes, kpss_5, _ = self._run_sequential_detection(
+                    bboxes, kpss_5, _, _ = self._run_sequential_detection(
                         frame_rgb,
                         local_control,
                         local_params,

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -223,6 +223,7 @@ class FrameWorker(threading.Thread):
         self.precomputed_bboxes: Optional[list] = None
         self.precomputed_kpss_5: Optional[list] = None
         self.precomputed_kpss: Optional[list] = None
+        self.precomputed_kpss_203: Optional[list] = None
 
         # --- OPTIMIZATION: Cached Convolution Kernels (VRAM) ---
         # Pre-allocating mathematical filters prevents massive CPU-to-GPU
@@ -306,6 +307,7 @@ class FrameWorker(threading.Thread):
                         self.precomputed_bboxes,
                         self.precomputed_kpss_5,
                         self.precomputed_kpss,
+                        self.precomputed_kpss_203,
                     ) = task
 
                     # Store them locally in the worker
@@ -1125,12 +1127,8 @@ class FrameWorker(threading.Thread):
         - Stitching back
         """
         # FW-RACE-02: read from snapshotted feeder state instead of live Qt button
-        swap_button_is_checked_global = self.local_control_state_from_feeder.get(
-            "swap_enabled", True
-        )
-        edit_button_is_checked_global = self.local_control_state_from_feeder.get(
-            "edit_enabled", True
-        )
+        swap_button_is_checked_global = self.main_window.swapfacesButton.isChecked()
+        edit_button_is_checked_global = self.main_window.editFacesButton.isChecked()
 
         # VR-08: cache the EquirectangularConverter instance at worker level.
         # When the frame size is unchanged (common for video), reuse the cached
@@ -1922,12 +1920,8 @@ class FrameWorker(threading.Thread):
         - Overlays (BBox, Landmarks, Comparison)
         """
         # FW-RACE-02: read button state from snapshotted feeder dict, not live Qt buttons
-        swap_button_is_checked_global = self.local_control_state_from_feeder.get(
-            "swap_enabled", True
-        )
-        edit_button_is_checked_global = self.local_control_state_from_feeder.get(
-            "edit_enabled", True
-        )
+        swap_button_is_checked_global = self.main_window.swapfacesButton.isChecked()
+        edit_button_is_checked_global = self.main_window.editFacesButton.isChecked()
 
         # FW-RACE-01: snapshot target_faces under lock so the worker thread never
         # iterates the live dict while the UI thread may be modifying it.
@@ -2012,6 +2006,7 @@ class FrameWorker(threading.Thread):
             bboxes = self.precomputed_bboxes
             kpss_5 = self.precomputed_kpss_5
             kpss = self.precomputed_kpss
+            kpss_203 = self.precomputed_kpss_203
         else:
             # 2. Fallback Path (Single-Frame Mode / Static Images)
             use_landmark, landmark_mode, from_points = (
@@ -2019,10 +2014,40 @@ class FrameWorker(threading.Thread):
                 control.get("LandmarkDetectModelSelection", "203"),
                 control.get("DetectFromPointsToggle", False),
             )
-            if edit_button_is_checked_global:
-                use_landmark, landmark_mode, from_points = True, "203", True
 
-            # Run detection strictly for this single image
+            # Identify if 203 points are strictly required by an advanced feature
+            requires_203 = False
+            from collections.abc import Mapping
+
+            for face_params in self.parameters.values():
+                if isinstance(face_params, Mapping):
+                    is_face_editor_active = (
+                        edit_button_is_checked_global
+                        and face_params.get("FaceEditorEnableToggle", False)
+                    )
+                    is_expression_active = face_params.get(
+                        "FaceExpressionEnableBothToggle", False
+                    )
+                    is_auto_mouth_active = face_params.get(
+                        "AutoMouthExpressionEnableToggle", False
+                    )
+                    is_makeup_active = edit_button_is_checked_global and (
+                        face_params.get("FaceMakeupEnableToggle", False)
+                        or face_params.get("HairMakeupEnableToggle", False)
+                        or face_params.get("EyeBrowsMakeupEnableToggle", False)
+                        or face_params.get("LipsMakeupEnableToggle", False)
+                    )
+
+                    if (
+                        is_face_editor_active
+                        or is_expression_active
+                        or is_auto_mouth_active
+                        or is_makeup_active
+                    ):
+                        requires_203 = True
+                        break
+
+            # STEP 1: Standard detection respecting User's choice
             bboxes, kpss_5, kpss = self.models_processor.run_detect(
                 img,
                 control.get("DetectorModelSelection", "RetinaFace"),
@@ -2037,9 +2062,36 @@ class FrameWorker(threading.Thread):
                 if not control.get("AutoRotationToggle", False)
                 else [0, 90, 180, 270],
                 use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
-                previous_detections=None,  # No historical tracking for single images
-                bypass_bytetrack=True,  # Bypassing ByteTrack to avoid corrupting the global Kalman filter state
+                previous_detections=None,
+                bypass_bytetrack=True,
             )
+
+            # STEP 2: Smart Double-Scan for 203 points
+            kpss_203 = None
+            if requires_203:
+                if use_landmark and landmark_mode == "203":
+                    # OPTIMIZATION: 203 was already extracted by the user's choice. Zero CUDA cost.
+                    kpss_203 = kpss
+                else:
+                    # Extract 203 specifically for advanced features
+                    _, _, kpss_203 = self.models_processor.run_detect(
+                        img,
+                        control.get("DetectorModelSelection", "RetinaFace"),
+                        max_num=control.get("MaxFacesToDetectSlider", 1),
+                        score=control.get("DetectorScoreSlider", 50) / 100.0,
+                        input_size=(512, 512),
+                        use_landmark_detection=True,
+                        landmark_detect_mode="203",
+                        landmark_score=control.get("LandmarkDetectScoreSlider", 50)
+                        / 100.0,
+                        from_points=from_points,
+                        rotation_angles=[0]
+                        if not control.get("AutoRotationToggle", False)
+                        else [0, 90, 180, 270],
+                        use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
+                        previous_detections=None,
+                        bypass_bytetrack=True,
+                    )
 
         if (
             isinstance(kpss_5, np.ndarray)
@@ -2059,12 +2111,18 @@ class FrameWorker(threading.Thread):
                     control["SimilarityTypeSelection"],
                     control["RecognitionModelSelection"],
                 )
-                # FW-BUG-01: bounds check before indexing kpss
+
                 kps_all_i = kpss[i] if kpss is not None and i < len(kpss) else None
+                # NEW: Extract the 203 points specifically
+                kps_203_i = (
+                    kpss_203[i] if kpss_203 is not None and i < len(kpss_203) else None
+                )
+
                 det_faces_data_for_display.append(
                     {
                         "kps_5": kpss_5[i],
                         "kps_all": kps_all_i,
+                        "kps_203": kps_203_i,
                         "embedding": face_emb,
                         "bbox": bboxes[i],
                         "original_face": None,
@@ -2184,6 +2242,7 @@ class FrameWorker(threading.Thread):
                                 img,
                                 best_fface["kps_5"],
                                 best_fface["kps_all"],
+                                kps_203=best_fface.get("kps_203"),
                                 s_e=s_e,
                                 t_e=target_face.get_embedding(arcface_model),
                                 parameters=_params_for_swap_a,
@@ -2200,8 +2259,13 @@ class FrameWorker(threading.Thread):
                                     "LipsMakeupEnableToggle",
                                 )
                             ):
+                                kps_for_makeup_best = (
+                                    best_fface.get("kps_203")
+                                    if best_fface.get("kps_203") is not None
+                                    else best_fface.get("kps_5")
+                                )
                                 img = self.frame_edits.swap_edit_face_core_makeup(
-                                    img, best_fface["kps_all"], params.data, control
+                                    img, kps_for_makeup_best, params.data, control
                                 )
                         except Exception as e:
                             print(
@@ -2295,6 +2359,7 @@ class FrameWorker(threading.Thread):
                                     img,
                                     fface["kps_5"],
                                     fface["kps_all"],
+                                    kps_203=fface.get("kps_203"),
                                     s_e=s_e,
                                     t_e=best_target.get_embedding(arcface_model),
                                     parameters=_params_for_swap_b,
@@ -2312,8 +2377,13 @@ class FrameWorker(threading.Thread):
                                     "LipsMakeupEnableToggle",
                                 )
                             ):
+                                kps_for_makeup = (
+                                    fface.get("kps_203")
+                                    if fface.get("kps_203") is not None
+                                    else fface.get("kps_5")
+                                )
                                 img = self.frame_edits.swap_edit_face_core_makeup(
-                                    img, fface["kps_all"], params.data, control
+                                    img, kps_for_makeup, params.data, control
                                 )
                         except Exception as e:
                             print(
@@ -2391,7 +2461,7 @@ class FrameWorker(threading.Thread):
                 _face_id_1 = getattr(cached_tgt, "face_id", None)
                 face_specific: dict = cast(
                     dict,
-                    self.parameters.get(_face_id_1, {})  # type: ignore[arg-type]
+                    self.parameters.get(str(_face_id_1), {})  # type: ignore[arg-type]
                     if _face_id_1 is not None
                     else {},
                 )
@@ -2401,11 +2471,36 @@ class FrameWorker(threading.Thread):
                     fface_data["embedding"], control
                 )
             if matched_params:
-                use_adj = matched_params["LandmarksPositionAdjEnableToggle"]
-                keypoints = (
-                    fface_data.get("kps_5") if use_adj else fface_data.get("kps_all")
-                )
-                kcolor = (255, 0, 0) if use_adj else (0, 255, 255)
+                # Use .get() safely in case the key doesn't exist yet
+                use_adj = matched_params.get("LandmarksPositionAdjEnableToggle", False)
+
+                kps_203 = fface_data.get("kps_203")
+                kps_all = fface_data.get("kps_all")
+                kps_5 = fface_data.get("kps_5")
+
+                if use_adj:
+                    # Manual Adjustment Mode: always force 5 points
+                    keypoints = kps_5
+                    kcolor = (255, 0, 0)  # BGR: Blue
+                else:
+                    # Smart Cascade: From most detailed to least detailed
+                    if kps_all is not None and len(kps_all) > 5:
+                        keypoints = kps_all
+                        kcolor = (
+                            0,
+                            255,
+                            255,
+                        )  # BGR: Yellow (Standard dense model chosen in UI)
+                    elif kps_203 is not None and len(kps_203) == 203:
+                        keypoints = kps_203
+                        kcolor = (
+                            0,
+                            165,
+                            255,
+                        )  # BGR: Orange (Indicates advanced tools triggered the 203 points)
+                    else:
+                        keypoints = kps_5
+                        kcolor = (0, 255, 0)  # BGR: Green (Base 5 points model)
 
                 if keypoints is not None:
                     landmarks_to_draw.append({"kps": keypoints, "color": kcolor})
@@ -2433,7 +2528,7 @@ class FrameWorker(threading.Thread):
                 _face_id_2 = getattr(cached_tgt, "face_id", None)
                 face_specific: dict = cast(
                     dict,
-                    self.parameters.get(_face_id_2, {})  # type: ignore[arg-type]
+                    self.parameters.get(str(_face_id_2), {})  # type: ignore[arg-type]
                     if _face_id_2 is not None
                     else {},
                 )
@@ -3958,6 +4053,7 @@ class FrameWorker(threading.Thread):
         img: torch.Tensor,
         kps_5: np.ndarray,
         kps: np.ndarray | None = None,  # FW-ROBUST-06: changed default False -> None
+        kps_203: np.ndarray | None = None,  # NEW: Dedicated 203 points
         s_e: np.ndarray | None = None,
         t_e: np.ndarray | None = None,
         parameters: dict | None = None,
@@ -3993,8 +4089,10 @@ class FrameWorker(threading.Thread):
 
         # OPTIMIZATION: Transform full-frame smoothed keypoints to the 512x512 crop space
         kps_all_crop = None
-        if kps is not None and len(kps) == 203:
-            raw_kps_crop = tform(kps)
+        if (
+            kps_203 is not None and len(kps_203) == 203
+        ):  # Use the dedicated 203 variable
+            raw_kps_crop = tform(kps_203)
             kps_all_crop = np.array(raw_kps_crop, dtype=np.float32)
 
         # STATE TRACKER: Suit si le tenseur 'swap' a subi une modification géométrique

--- a/app/ui/widgets/actions/common_actions.py
+++ b/app/ui/widgets/actions/common_actions.py
@@ -499,6 +499,7 @@ def show_hide_related_widgets(
 
 # @misc_helpers.benchmark
 def get_pixmap_from_frame(main_window: "MainWindow", frame: np.ndarray):
+    frame = np.ascontiguousarray(frame)
     height, width, channel = frame.shape
     # BUG-04: Grayscale check should be channel==1, not 2
     if channel == 1:
@@ -605,6 +606,7 @@ def extract_frame_as_image(
 
     # This helper function converts a numpy frame to a scaled QImage safely.
     def convert_frame_to_image(frame):
+        frame = np.ascontiguousarray(frame)
         height, width, _ = frame.shape
         bytes_per_line = 3 * width
 

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -451,7 +451,7 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
         "KPSSmoothingEnableToggle": {
             "level": 1,
             "label": "Enable KPS Smoothing",
-            "default": True,  # Activé par défaut pour garder la stabilité
+            "default": False,
             "help": "Enable temporal smoothing for facial keypoints (KPS) to reduce jittering and stabilize the face.",
         },
         "KPSEmaAlphaSlider": {


### PR DESCRIPTION
## Summary of Changes

**Landmark Detection & Processing:**
- Added smart double-scan for 203-point detection (zero cost if user already selected 203)
- Full temporal smoothing for 203-point landmarks (`_smoothed_dense_kps_203`)
- Smart landmark cascade for display: 203 → 68 → 5 points (color-coded)

**Robustness Fixes:**
- Enforce minimum 1px dimensions in `create_thumbnail()` and `get_scaled_resolution()`
- Fixed bounds checking before keypoint indexing
- Safer dictionary access with `.get()` methods
- Removed fallback re-detection in makeup (changed `> 5` to `>= 5`)

**GPU Optimization:**
- Simplified makeup detection logic
- Added `np.ascontiguousarray()` to frame conversion for memory safety
- Fixed button state reads (use live UI state instead of stale dicts)

**Configuration:**
- Set `KPSSmoothingEnableToggle` default to `False`

**Files Modified:** 7 core files across detection, processing, and UI layers.