### PR TITLE
Fix/theatre fullscreen restore

### DIFF
--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -740,11 +740,40 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             scene_rect = pixmap_item.boundingRect()
             self.graphicsViewFrame.setSceneRect(scene_rect)
             graphics_view_actions.fit_image_to_view(self, pixmap_item, scene_rect)
+        self._sync_theatre_base_window_snapshot()
+
+    def moveEvent(self, event: QtGui.QMoveEvent):
+        super().moveEvent(event)
+        self._sync_theatre_base_window_snapshot()
 
     def changeEvent(self, event: QtCore.QEvent):
         super().changeEvent(event)
         if event.type() == QtCore.QEvent.Type.WindowStateChange:
             self.is_full_screen = self.isFullScreen()
+            self._sync_theatre_base_window_snapshot()
+
+    def _sync_theatre_base_window_snapshot(self):
+        if not getattr(self, "is_theatre_mode", False):
+            return
+
+        if self.isFullScreen():
+            restore_geometry = getattr(self, "_fullscreen_restore_geometry", None)
+            self._was_custom_fullscreen = True
+            self._was_maximized = False
+            self._was_normal_geometry = (
+                restore_geometry
+                if restore_geometry is not None
+                else self.normalGeometry()
+            )
+            return
+
+        self._was_custom_fullscreen = False
+        if self.isMaximized():
+            self._was_maximized = True
+            self._was_normal_geometry = self.normalGeometry()
+        else:
+            self._was_maximized = False
+            self._was_normal_geometry = self.geometry()
 
     def eventFilter(self, watched, event):
         viewport_widget = getattr(self, "mediaControlsViewportWidget", None)

--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -114,6 +114,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self._rightFacesStripVisible = False
         self._theatre_normal_panel_states: dict[str, bool] | None = None
         self._theatre_mode_panel_states: dict[str, bool] | None = None
+        self._fullscreen_restore_was_maximized = False
+        self._fullscreen_restore_geometry = None
         self.panel_visibility_state: dict[str, bool] = {
             "target_media": True,
             "input_faces": True,
@@ -775,10 +777,10 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def keyPressEvent(self, event):
         match event.key():
             case QtCore.Qt.Key_Escape:
-                if getattr(self, "is_theatre_mode", False):
-                    video_control_actions.toggle_theatre_mode(self)
-                elif self.isFullScreen():
+                if self.isFullScreen():
                     video_control_actions.view_fullscreen(self)
+                elif getattr(self, "is_theatre_mode", False):
+                    video_control_actions.toggle_theatre_mode(self)
             case QtCore.Qt.Key_F11:
                 video_control_actions.view_fullscreen(self)
             case QtCore.Qt.Key_T:
@@ -1319,8 +1321,6 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         return context_labels.get(value, self._mask_show_option_label(value))
 
     def _is_fullscreen_menu_active(self) -> bool:
-        if getattr(self, "is_theatre_mode", False):
-            return bool(getattr(self, "_was_custom_fullscreen", False))
         return self.isFullScreen()
 
     def _handle_viewer_mask_action(self, value: str, checked: bool):

--- a/app/ui/widgets/actions/save_load_actions.py
+++ b/app/ui/widgets/actions/save_load_actions.py
@@ -698,13 +698,9 @@ def save_current_workspace(
     saved_geometry = main_window.geometry()
     dock_state_source = None
     if is_theatre_mode:
-        saved_is_fullscreen = bool(
-            getattr(main_window, "_was_custom_fullscreen", False)
-        )
+        saved_is_fullscreen = bool(main_window.is_full_screen)
         saved_is_maximized = (
-            bool(getattr(main_window, "_was_maximized", False))
-            if not saved_is_fullscreen
-            else False
+            bool(main_window.isMaximized()) if not saved_is_fullscreen else False
         )
         saved_geometry = getattr(main_window, "_was_normal_geometry", saved_geometry)
         dock_state_source = getattr(main_window, "_saved_window_state", None)

--- a/app/ui/widgets/actions/save_load_actions.py
+++ b/app/ui/widgets/actions/save_load_actions.py
@@ -101,6 +101,44 @@ def _clamp_window_frame_to_available_geometry(main_window: "MainWindow"):
         main_window.move(clamped_x, clamped_y)
 
 
+def _apply_workspace_window_state(
+    main_window: "MainWindow", window_state: dict
+) -> bool:
+    is_maximized = window_state.get("isMaximized", False)
+    is_fullscreen = window_state.get("isFullScreen", False)
+
+    main_window._fullscreen_restore_was_maximized = False
+    main_window._fullscreen_restore_geometry = None
+
+    if is_maximized:
+        main_window.resize(main_window.sizeHint())
+        main_window.showMaximized()
+        main_window.menuBar().show()
+        main_window.is_full_screen = False
+        return False
+
+    restored_rect = _get_clamped_window_geometry(
+        main_window,
+        window_state.get("x", main_window.x()),
+        window_state.get("y", main_window.y()),
+        window_state.get("width", main_window.width()),
+        window_state.get("height", main_window.height()),
+    )
+
+    if is_fullscreen:
+        main_window._fullscreen_restore_was_maximized = False
+        main_window._fullscreen_restore_geometry = restored_rect
+        main_window.resize(main_window.sizeHint())
+        main_window.showFullScreen()
+        main_window.is_full_screen = True
+        return False
+
+    main_window.setGeometry(restored_rect)
+    main_window.menuBar().show()
+    main_window.is_full_screen = False
+    return True
+
+
 def open_embeddings_from_file(main_window: "MainWindow"):
     embedding_filename, _ = QtWidgets.QFileDialog.getOpenFileName(
         main_window,
@@ -595,31 +633,9 @@ def load_saved_workspace(
 
             # Restore Window State
             window_state = data.get("window_state_data", {})
-            is_maximized = window_state.get("isMaximized", False)
-            is_fullScreen = window_state.get("isFullScreen", False)
-            needs_post_restore_frame_clamp = False
-
-            if is_maximized:
-                main_window.resize(main_window.sizeHint())
-                main_window.showMaximized()
-                main_window.menuBar().show()
-                main_window.is_full_screen = False
-            elif is_fullScreen:
-                main_window.resize(main_window.sizeHint())
-                main_window.showFullScreen()
-                main_window.is_full_screen = True
-            else:
-                restored_rect = _get_clamped_window_geometry(
-                    main_window,
-                    window_state.get("x", main_window.x()),
-                    window_state.get("y", main_window.y()),
-                    window_state.get("width", main_window.width()),
-                    window_state.get("height", main_window.height()),
-                )
-                main_window.setGeometry(restored_rect)
-                main_window.menuBar().show()
-                main_window.is_full_screen = False
-                needs_post_restore_frame_clamp = True
+            needs_post_restore_frame_clamp = _apply_workspace_window_state(
+                main_window, window_state
+            )
             panel_state_map = {
                 "target_media": window_state.get(
                     "target_media",
@@ -693,17 +709,27 @@ def save_current_workspace(
     # --- Save Window State ---
     # --- Save dock layout / panel sizes ---
     is_theatre_mode = bool(getattr(main_window, "is_theatre_mode", False))
-    saved_is_fullscreen = main_window.is_full_screen
-    saved_is_maximized = main_window.isMaximized()
+    saved_is_fullscreen = bool(main_window.is_full_screen)
+    saved_is_maximized = (
+        bool(main_window.isMaximized()) if not saved_is_fullscreen else False
+    )
     saved_geometry = main_window.geometry()
     dock_state_source = None
     if is_theatre_mode:
-        saved_is_fullscreen = bool(main_window.is_full_screen)
+        saved_is_fullscreen = bool(
+            getattr(main_window, "_was_custom_fullscreen", main_window.is_full_screen)
+        )
         saved_is_maximized = (
-            bool(main_window.isMaximized()) if not saved_is_fullscreen else False
+            bool(getattr(main_window, "_was_maximized", main_window.isMaximized()))
+            if not saved_is_fullscreen
+            else False
         )
         saved_geometry = getattr(main_window, "_was_normal_geometry", saved_geometry)
         dock_state_source = getattr(main_window, "_saved_window_state", None)
+    elif saved_is_fullscreen:
+        restore_geometry = getattr(main_window, "_fullscreen_restore_geometry", None)
+        if restore_geometry is not None:
+            saved_geometry = restore_geometry
 
     try:
         # saveState returns QByteArray; convert to base64 string for json compatibility

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -1360,6 +1360,12 @@ def view_fullscreen(main_window: "MainWindow"):
         main_window.showFullScreen()  # Enter full-screen mode
         main_window.is_full_screen = True
 
+    sync_theatre_snapshot = getattr(
+        main_window, "_sync_theatre_base_window_snapshot", None
+    )
+    if callable(sync_theatre_snapshot):
+        sync_theatre_snapshot()
+
     sync_actions = getattr(main_window, "_sync_viewer_menu_actions", None)
 
     if callable(sync_actions):

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -1311,40 +1311,56 @@ def delete_all_markers(main_window: "MainWindow"):
     update_drop_frame_button_label(main_window)
 
 
-def view_fullscreen(main_window: "MainWindow"):
-    """Toggle fullscreen, briefly exiting/re-entering theatre mode when needed."""
+def _restore_window_base_mode(
+    main_window: "MainWindow",
+    *,
+    restore_to_fullscreen: bool,
+    restore_to_maximized: bool,
+    restore_geometry=None,
+):
+    if restore_to_fullscreen:
+        try:
+            main_window.setWindowState(QtCore.Qt.WindowState.WindowFullScreen)
+        except Exception:
+            main_window.showFullScreen()
+        main_window.is_full_screen = True
+        return
 
-    def _apply_fullscreen_toggle():
-        if main_window.isFullScreen():
-            main_window.showNormal()  # Exit full-screen mode
-            main_window.is_full_screen = False
-        else:
-            main_window.showFullScreen()  # Enter full-screen mode
-            main_window.is_full_screen = True
+    if restore_to_maximized:
+        main_window.showMaximized()
+    else:
+        main_window.showNormal()
+        if restore_geometry is not None:
+            main_window.setGeometry(restore_geometry)
+    main_window.is_full_screen = False
+
+
+def view_fullscreen(main_window: "MainWindow"):
+    """Toggle fullscreen without changing theatre mode."""
+
+    if main_window.isFullScreen():
+        restore_to_maximized = bool(
+            getattr(main_window, "_fullscreen_restore_was_maximized", False)
+        )
+        restore_geometry = getattr(main_window, "_fullscreen_restore_geometry", None)
+        _restore_window_base_mode(
+            main_window,
+            restore_to_fullscreen=False,
+            restore_to_maximized=restore_to_maximized,
+            restore_geometry=restore_geometry,
+        )
+        main_window._fullscreen_restore_was_maximized = False
+        main_window._fullscreen_restore_geometry = None
+    else:
+        was_maximized = main_window.isMaximized()
+        main_window._fullscreen_restore_was_maximized = was_maximized
+        main_window._fullscreen_restore_geometry = (
+            main_window.normalGeometry() if was_maximized else main_window.geometry()
+        )
+        main_window.showFullScreen()  # Enter full-screen mode
+        main_window.is_full_screen = True
 
     sync_actions = getattr(main_window, "_sync_viewer_menu_actions", None)
-
-    if getattr(main_window, "_fullscreen_theatre_transition_in_progress", False):
-        return
-
-    if getattr(main_window, "is_theatre_mode", False):
-        main_window._fullscreen_theatre_transition_in_progress = True
-        toggle_theatre_mode(main_window)
-        _apply_fullscreen_toggle()
-
-        def _reenter_theatre():
-            try:
-                if not getattr(main_window, "is_theatre_mode", False):
-                    toggle_theatre_mode(main_window)
-            finally:
-                main_window._fullscreen_theatre_transition_in_progress = False
-                if callable(sync_actions):
-                    sync_actions()
-
-        QtCore.QTimer.singleShot(0, _reenter_theatre)
-        return
-
-    _apply_fullscreen_toggle()
 
     if callable(sync_actions):
         sync_actions()
@@ -2966,17 +2982,12 @@ def toggle_theatre_mode(main_window: "MainWindow"):
         was_maximized = getattr(main_window, "_was_maximized", False)
         saved_normal_geometry = getattr(main_window, "_was_normal_geometry", None)
 
-        if was_custom_fullscreen:
-            main_window.showFullScreen()
-            main_window.is_full_screen = True
-        elif was_maximized:
-            main_window.showMaximized()
-            main_window.is_full_screen = False
-        else:
-            main_window.showNormal()
-            if saved_normal_geometry is not None:
-                main_window.setGeometry(saved_normal_geometry)
-            main_window.is_full_screen = False
+        _restore_window_base_mode(
+            main_window,
+            restore_to_fullscreen=was_custom_fullscreen,
+            restore_to_maximized=was_maximized and not was_custom_fullscreen,
+            restore_geometry=saved_normal_geometry,
+        )
 
         # Restores the exact layout state of docks (fixes the Input Faces / Target Video sizing)
         if hasattr(main_window, "_saved_window_state"):

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -67,6 +67,7 @@ from app.helpers.miscellaneous import ParametersDict  # noqa: E402
 
 # Now import the module under test
 from app.ui.widgets.actions.save_load_actions import (  # noqa: E402
+    _apply_workspace_window_state,
     convert_parameters_to_supported_type,
     convert_markers_to_supported_type,
     save_current_workspace,
@@ -360,6 +361,7 @@ def _make_workspace_main_window(
     saved_window_state: str = "live-window-state",
     was_custom_fullscreen: bool = False,
     was_maximized: bool = False,
+    fullscreen_restore_geometry: _FakeGeometry | None = None,
 ):
     default_params_data = {"brightness": 1.0, "contrast": 0.8}
     geometry = geometry or _FakeGeometry(10, 20, 1280, 720)
@@ -372,6 +374,8 @@ def _make_workspace_main_window(
     mw._was_custom_fullscreen = was_custom_fullscreen
     mw._was_maximized = was_maximized
     mw._was_normal_geometry = normal_geometry
+    mw._fullscreen_restore_was_maximized = False
+    mw._fullscreen_restore_geometry = fullscreen_restore_geometry
     mw._saved_window_state = _FakeByteArray(saved_window_state)
     mw.control = {}
     mw.target_videos = {}
@@ -401,6 +405,7 @@ def _make_workspace_main_window(
     mw.scan_tools_expanded = False
     mw.project_root_path = tmp_path
     mw.geometry = lambda: geometry
+    mw.normalGeometry = lambda: normal_geometry
     mw.isMaximized = lambda: is_maximized
     mw.saveState = lambda: _FakeByteArray("live-window-state")
     return mw
@@ -428,6 +433,33 @@ def test_save_workspace_non_theatre_uses_live_window_state(tmp_path):
     assert saved["isMaximized"] is False
     assert saved["dock_state"] == "live-window-state"
     assert (saved["x"], saved["y"], saved["width"], saved["height"]) == (5, 6, 700, 500)
+
+
+def test_save_workspace_non_theatre_fullscreen_uses_restore_geometry(tmp_path):
+    save_path = tmp_path / "workspace.json"
+    geometry = _FakeGeometry(0, 0, 1920, 1080)
+    restore_geometry = _FakeGeometry(50, 60, 800, 500)
+    main_window = _make_workspace_main_window(
+        tmp_path,
+        is_theatre_mode=False,
+        is_full_screen=True,
+        is_maximized=False,
+        geometry=geometry,
+        normal_geometry=_FakeGeometry(5, 6, 700, 500),
+        fullscreen_restore_geometry=restore_geometry,
+    )
+
+    save_current_workspace(main_window, str(save_path))
+
+    saved = _read_saved_workspace(save_path)["window_state_data"]
+    assert saved["isFullScreen"] is True
+    assert saved["isMaximized"] is False
+    assert (saved["x"], saved["y"], saved["width"], saved["height"]) == (
+        50,
+        60,
+        800,
+        500,
+    )
 
 
 def test_save_workspace_theatre_from_fullscreen_uses_live_window_state(tmp_path):
@@ -524,23 +556,130 @@ def test_save_workspace_theatre_uses_latest_fullscreen_base_toggle(tmp_path):
         is_theatre_mode=True,
         is_full_screen=True,
         is_maximized=False,
+        normal_geometry=_FakeGeometry(150, 250, 950, 650),
         saved_window_state="pre-theatre-layout",
-        was_custom_fullscreen=False,
-        was_maximized=True,
+        was_custom_fullscreen=True,
+        was_maximized=False,
     )
 
     save_current_workspace(main_window, str(save_path))
     saved = _read_saved_workspace(save_path)["window_state_data"]
     assert saved["isFullScreen"] is True
     assert saved["isMaximized"] is False
+    assert (saved["x"], saved["y"], saved["width"], saved["height"]) == (
+        150,
+        250,
+        950,
+        650,
+    )
 
     main_window.is_full_screen = False
-    main_window.isMaximized = lambda: True
-    main_window._was_custom_fullscreen = True
+    main_window.isMaximized = lambda: False
+    main_window._was_custom_fullscreen = False
+    main_window._was_maximized = False
+    main_window._was_normal_geometry = _FakeGeometry(220, 330, 1110, 720)
     save_current_workspace(main_window, str(save_path))
     saved = _read_saved_workspace(save_path)["window_state_data"]
     assert saved["isFullScreen"] is False
-    assert saved["isMaximized"] is True
+    assert saved["isMaximized"] is False
+    assert (saved["x"], saved["y"], saved["width"], saved["height"]) == (
+        220,
+        330,
+        1110,
+        720,
+    )
+
+
+def test_apply_workspace_window_state_fullscreen_seeds_restore_geometry(monkeypatch):
+    restored_rect = _FakeGeometry(140, 150, 910, 610)
+    main_window = SimpleNamespace(
+        _fullscreen_restore_was_maximized=True,
+        _fullscreen_restore_geometry="stale-geometry",
+        resize=MagicMock(),
+        sizeHint=lambda: "size-hint",
+        showFullScreen=MagicMock(),
+        showMaximized=MagicMock(),
+        setGeometry=MagicMock(),
+        menuBar=lambda: SimpleNamespace(show=MagicMock()),
+        is_full_screen=False,
+        x=lambda: 0,
+        y=lambda: 0,
+        width=lambda: 1920,
+        height=lambda: 1080,
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.save_load_actions._get_clamped_window_geometry",
+        lambda *_args, **_kwargs: restored_rect,
+    )
+
+    needs_clamp = _apply_workspace_window_state(
+        main_window,
+        {
+            "isMaximized": False,
+            "isFullScreen": True,
+            "x": 1,
+            "y": 2,
+            "width": 3,
+            "height": 4,
+        },
+    )
+
+    assert needs_clamp is False
+    main_window.resize.assert_called_once_with("size-hint")
+    main_window.showFullScreen.assert_called_once()
+    main_window.showMaximized.assert_not_called()
+    main_window.setGeometry.assert_not_called()
+    assert main_window.is_full_screen is True
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is restored_rect
+
+
+def test_apply_workspace_window_state_normal_clears_fullscreen_restore_state(
+    monkeypatch,
+):
+    restored_rect = _FakeGeometry(240, 250, 920, 620)
+    menu_bar = SimpleNamespace(show=MagicMock())
+    main_window = SimpleNamespace(
+        _fullscreen_restore_was_maximized=True,
+        _fullscreen_restore_geometry="stale-geometry",
+        resize=MagicMock(),
+        sizeHint=lambda: "size-hint",
+        showFullScreen=MagicMock(),
+        showMaximized=MagicMock(),
+        setGeometry=MagicMock(),
+        menuBar=lambda: menu_bar,
+        is_full_screen=True,
+        x=lambda: 0,
+        y=lambda: 0,
+        width=lambda: 1920,
+        height=lambda: 1080,
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.save_load_actions._get_clamped_window_geometry",
+        lambda *_args, **_kwargs: restored_rect,
+    )
+
+    needs_clamp = _apply_workspace_window_state(
+        main_window,
+        {
+            "isMaximized": False,
+            "isFullScreen": False,
+            "x": 1,
+            "y": 2,
+            "width": 3,
+            "height": 4,
+        },
+    )
+
+    assert needs_clamp is True
+    main_window.setGeometry.assert_called_once_with(restored_rect)
+    menu_bar.show.assert_called_once()
+    main_window.showFullScreen.assert_not_called()
+    assert main_window.is_full_screen is False
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is None
 
 
 def test_save_workspace_theatre_does_not_serialize_theatre_active_flag(tmp_path):

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -430,7 +430,7 @@ def test_save_workspace_non_theatre_uses_live_window_state(tmp_path):
     assert (saved["x"], saved["y"], saved["width"], saved["height"]) == (5, 6, 700, 500)
 
 
-def test_save_workspace_theatre_from_fullscreen_uses_base_snapshot(tmp_path):
+def test_save_workspace_theatre_from_fullscreen_uses_live_window_state(tmp_path):
     save_path = tmp_path / "workspace.json"
     base_geometry = _FakeGeometry(100, 200, 900, 600)
     main_window = _make_workspace_main_window(
@@ -459,14 +459,14 @@ def test_save_workspace_theatre_from_fullscreen_uses_base_snapshot(tmp_path):
     )
 
 
-def test_save_workspace_theatre_from_maximized_uses_base_snapshot(tmp_path):
+def test_save_workspace_theatre_from_maximized_uses_live_window_state(tmp_path):
     save_path = tmp_path / "workspace.json"
     base_geometry = _FakeGeometry(111, 222, 1000, 700)
     main_window = _make_workspace_main_window(
         tmp_path,
         is_theatre_mode=True,
-        is_full_screen=True,
-        is_maximized=False,
+        is_full_screen=False,
+        is_maximized=True,
         geometry=_FakeGeometry(0, 0, 1920, 1080),
         normal_geometry=base_geometry,
         saved_window_state="pre-theatre-layout",
@@ -488,13 +488,13 @@ def test_save_workspace_theatre_from_maximized_uses_base_snapshot(tmp_path):
     )
 
 
-def test_save_workspace_theatre_from_normal_uses_base_snapshot(tmp_path):
+def test_save_workspace_theatre_from_normal_uses_live_window_state(tmp_path):
     save_path = tmp_path / "workspace.json"
     base_geometry = _FakeGeometry(123, 234, 1010, 710)
     main_window = _make_workspace_main_window(
         tmp_path,
         is_theatre_mode=True,
-        is_full_screen=True,
+        is_full_screen=False,
         is_maximized=False,
         geometry=_FakeGeometry(0, 0, 1920, 1080),
         normal_geometry=base_geometry,
@@ -531,11 +531,30 @@ def test_save_workspace_theatre_uses_latest_fullscreen_base_toggle(tmp_path):
 
     save_current_workspace(main_window, str(save_path))
     saved = _read_saved_workspace(save_path)["window_state_data"]
-    assert saved["isFullScreen"] is False
-    assert saved["isMaximized"] is True
+    assert saved["isFullScreen"] is True
+    assert saved["isMaximized"] is False
 
+    main_window.is_full_screen = False
+    main_window.isMaximized = lambda: True
     main_window._was_custom_fullscreen = True
     save_current_workspace(main_window, str(save_path))
     saved = _read_saved_workspace(save_path)["window_state_data"]
-    assert saved["isFullScreen"] is True
-    assert saved["isMaximized"] is False
+    assert saved["isFullScreen"] is False
+    assert saved["isMaximized"] is True
+
+
+def test_save_workspace_theatre_does_not_serialize_theatre_active_flag(tmp_path):
+    save_path = tmp_path / "workspace.json"
+    main_window = _make_workspace_main_window(
+        tmp_path,
+        is_theatre_mode=True,
+        is_full_screen=False,
+        is_maximized=False,
+        saved_window_state="pre-theatre-layout",
+    )
+
+    save_current_workspace(main_window, str(save_path))
+
+    saved = _read_saved_workspace(save_path)
+    assert "is_theatre_mode" not in saved
+    assert "is_theatre_mode" not in saved["window_state_data"]

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import importlib
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-sys.modules.pop("app.ui.widgets.actions.video_control_actions", None)
+import pytest
 
 
 def _stub(name: str) -> MagicMock:
@@ -14,40 +15,117 @@ def _stub(name: str) -> MagicMock:
     return m
 
 
-_STUBS = [
-    "PySide6",
-    "PySide6.QtWidgets",
-    "PySide6.QtCore",
-    "PySide6.QtGui",
-    "cv2",
-    "numpy",
-    "PIL",
-    "PIL.Image",
-    "app.helpers",
-    "app.helpers.typing_helper",
-    "app.helpers.miscellaneous",
-    "app.ui.widgets.widget_components",
-    "app.ui.widgets.ui_workers",
-    "app.ui.widgets.actions.common_actions",
-    "app.ui.widgets.actions.card_actions",
-    "app.ui.widgets.actions.graphics_view_actions",
-    "app.ui.widgets.actions.layout_actions",
-]
-for _s in _STUBS:
-    if _s not in sys.modules:
-        sys.modules[_s] = _stub(_s)
+@pytest.fixture(scope="module")
+def video_actions_env():
+    stubbed_modules = {
+        "PySide6": _stub("PySide6"),
+        "PySide6.QtWidgets": _stub("PySide6.QtWidgets"),
+        "PySide6.QtCore": _stub("PySide6.QtCore"),
+        "PySide6.QtGui": _stub("PySide6.QtGui"),
+        "cv2": _stub("cv2"),
+        "numpy": _stub("numpy"),
+        "PIL": _stub("PIL"),
+        "PIL.Image": _stub("PIL.Image"),
+        "app.helpers": _stub("app.helpers"),
+        "app.helpers.typing_helper": _stub("app.helpers.typing_helper"),
+        "app.helpers.miscellaneous": _stub("app.helpers.miscellaneous"),
+        "app.ui.widgets.widget_components": _stub("app.ui.widgets.widget_components"),
+        "app.ui.widgets.ui_workers": _stub("app.ui.widgets.ui_workers"),
+        "app.ui.widgets.actions.common_actions": _stub(
+            "app.ui.widgets.actions.common_actions"
+        ),
+        "app.ui.widgets.actions.card_actions": _stub(
+            "app.ui.widgets.actions.card_actions"
+        ),
+        "app.ui.widgets.actions.graphics_view_actions": _stub(
+            "app.ui.widgets.actions.graphics_view_actions"
+        ),
+        "app.ui.widgets.actions.layout_actions": _stub(
+            "app.ui.widgets.actions.layout_actions"
+        ),
+    }
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in [
+            *stubbed_modules,
+            "app.ui.widgets.actions.video_control_actions",
+        ]
+    }
+    saved_package_attrs: dict[tuple[str, str], tuple[bool, object | None]] = {}
+
+    for module_name in [
+        *stubbed_modules,
+        "app.ui.widgets.actions.video_control_actions",
+    ]:
+        parent_name, _, attr_name = module_name.rpartition(".")
+        if not parent_name:
+            continue
+        parent_module = sys.modules.get(parent_name)
+        had_attr = parent_module is not None and hasattr(parent_module, attr_name)
+        saved_package_attrs[(parent_name, attr_name)] = (
+            had_attr,
+            getattr(parent_module, attr_name) if had_attr else None,
+        )
+
+    try:
+        for name, module in stubbed_modules.items():
+            sys.modules[name] = module
+
+        stubbed_modules["PySide6"].QtWidgets = stubbed_modules["PySide6.QtWidgets"]
+        stubbed_modules["PySide6"].QtCore = stubbed_modules["PySide6.QtCore"]
+        stubbed_modules["PySide6"].QtGui = stubbed_modules["PySide6.QtGui"]
+        stubbed_modules["PIL"].Image = stubbed_modules["PIL.Image"]
+        stubbed_modules["app.helpers"].typing_helper = stubbed_modules[
+            "app.helpers.typing_helper"
+        ]
+        stubbed_modules["app.helpers"].miscellaneous = stubbed_modules[
+            "app.helpers.miscellaneous"
+        ]
+        for module_name, module in stubbed_modules.items():
+            parent_name, _, attr_name = module_name.rpartition(".")
+            parent_module = sys.modules.get(parent_name)
+            if parent_module is not None and attr_name:
+                setattr(parent_module, attr_name, module)
+
+        sys.modules.pop("app.ui.widgets.actions.video_control_actions", None)
+
+        common_widget_actions = importlib.import_module(
+            "app.ui.widgets.actions.common_actions"
+        )
+        video_control_actions = importlib.import_module(
+            "app.ui.widgets.actions.video_control_actions"
+        )
+
+        yield SimpleNamespace(
+            module=video_control_actions,
+            common_widget_actions=common_widget_actions,
+            view_fullscreen=video_control_actions.view_fullscreen,
+            toggle_theatre_mode=video_control_actions.toggle_theatre_mode,
+            disable_compare_preview_modes_for_recording=(
+                video_control_actions._disable_compare_preview_modes_for_recording
+            ),
+        )
+    finally:
+        for name, original_module in saved_modules.items():
+            if original_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original_module
+
+        for (parent_name, attr_name), (
+            had_attr,
+            original_value,
+        ) in saved_package_attrs.items():
+            parent_module = sys.modules.get(parent_name)
+            if parent_module is None:
+                continue
+            if had_attr:
+                setattr(parent_module, attr_name, original_value)
+            elif hasattr(parent_module, attr_name):
+                delattr(parent_module, attr_name)
 
 
-from app.ui.widgets.actions import common_actions as common_widget_actions  # noqa: E402
-from app.ui.widgets.actions import video_control_actions  # noqa: E402
-from app.ui.widgets.actions.video_control_actions import (  # noqa: E402
-    _disable_compare_preview_modes_for_recording,
-    toggle_theatre_mode,
-    view_fullscreen,
-)
-
-
-def test_view_fullscreen_keeps_theatre_mode_active():
+def test_view_fullscreen_keeps_theatre_mode_active(video_actions_env):
     synced = []
     main_window = SimpleNamespace(
         is_theatre_mode=True,
@@ -63,7 +141,7 @@ def test_view_fullscreen_keeps_theatre_mode_active():
         _sync_viewer_menu_actions=lambda: synced.append(True),
     )
 
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
@@ -73,7 +151,7 @@ def test_view_fullscreen_keeps_theatre_mode_active():
     assert synced == [True]
 
 
-def test_view_fullscreen_uses_real_window_transition_outside_theatre():
+def test_view_fullscreen_uses_real_window_transition_outside_theatre(video_actions_env):
     synced = []
     main_window = SimpleNamespace(
         is_theatre_mode=False,
@@ -87,7 +165,7 @@ def test_view_fullscreen_uses_real_window_transition_outside_theatre():
         _sync_viewer_menu_actions=lambda: synced.append(True),
     )
 
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
@@ -176,12 +254,12 @@ class _StatefulFullscreenWindow:
         self._sync_calls.append(True)
 
 
-def test_view_fullscreen_restores_saved_geometry_after_round_trip():
+def test_view_fullscreen_restores_saved_geometry_after_round_trip(video_actions_env):
     geometry = _FakeGeometry()
     main_window = _StatefulFullscreenWindow(state="normal", geometry=geometry)
 
-    view_fullscreen(main_window)
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_called_once()
@@ -193,11 +271,11 @@ def test_view_fullscreen_restores_saved_geometry_after_round_trip():
     assert main_window._sync_calls == [True, True]
 
 
-def test_view_fullscreen_restores_maximized_state_after_round_trip():
+def test_view_fullscreen_restores_maximized_state_after_round_trip(video_actions_env):
     main_window = _StatefulFullscreenWindow(state="maximized")
 
-    view_fullscreen(main_window)
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     main_window.showFullScreen.assert_called_once()
     main_window.showMaximized.assert_called_once()
@@ -210,14 +288,14 @@ def test_view_fullscreen_restores_maximized_state_after_round_trip():
     assert main_window._sync_calls == [True, True]
 
 
-def test_view_fullscreen_preserves_maximized_base_state_in_theatre():
+def test_view_fullscreen_preserves_maximized_base_state_in_theatre(video_actions_env):
     main_window = _StatefulFullscreenWindow(state="maximized", is_theatre_mode=True)
     main_window._was_maximized = True
     main_window._was_custom_fullscreen = False
     main_window._was_normal_geometry = main_window.normalGeometry()
 
-    view_fullscreen(main_window)
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     assert main_window.is_theatre_mode is True
     assert main_window.isMaximized() is True
@@ -229,7 +307,7 @@ def test_view_fullscreen_preserves_maximized_base_state_in_theatre():
     assert main_window._fullscreen_restore_geometry is None
 
 
-def test_view_fullscreen_preserves_normal_geometry_in_theatre():
+def test_view_fullscreen_preserves_normal_geometry_in_theatre(video_actions_env):
     geometry = _FakeGeometry()
     main_window = _StatefulFullscreenWindow(
         state="normal",
@@ -240,8 +318,8 @@ def test_view_fullscreen_preserves_normal_geometry_in_theatre():
     main_window._was_custom_fullscreen = False
     main_window._was_normal_geometry = geometry
 
-    view_fullscreen(main_window)
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     assert main_window.is_theatre_mode is True
     assert main_window.isMaximized() is False
@@ -253,20 +331,22 @@ def test_view_fullscreen_preserves_normal_geometry_in_theatre():
     assert main_window._was_normal_geometry is geometry
 
 
-def test_view_fullscreen_keeps_theatre_layout_active_during_round_trip():
+def test_view_fullscreen_keeps_theatre_layout_active_during_round_trip(
+    video_actions_env,
+):
     main_window = _StatefulFullscreenWindow(state="normal", is_theatre_mode=True)
     base_geometry = main_window.geometry()
     main_window._was_maximized = False
     main_window._was_custom_fullscreen = False
     main_window._was_normal_geometry = base_geometry
 
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     assert main_window.is_theatre_mode is True
     assert main_window.isFullScreen() is True
     assert main_window._was_normal_geometry is base_geometry
 
-    view_fullscreen(main_window)
+    video_actions_env.view_fullscreen(main_window)
 
     assert main_window.is_theatre_mode is True
     assert main_window.isFullScreen() is False
@@ -371,34 +451,36 @@ def _make_theatre_entry_window(*, is_fullscreen: bool, is_maximized: bool = Fals
     )
 
 
-def test_toggle_theatre_mode_keeps_fullscreen_when_base_mode_is_fullscreen(monkeypatch):
+def test_toggle_theatre_mode_keeps_fullscreen_when_base_mode_is_fullscreen(
+    monkeypatch, video_actions_env
+):
     monkeypatch.setattr(
-        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
     )
-    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
     main_window = _make_theatre_entry_window(is_fullscreen=True)
 
-    toggle_theatre_mode(main_window)
+    video_actions_env.toggle_theatre_mode(main_window)
 
     assert main_window._was_custom_fullscreen is True
     assert main_window._was_normal_geometry == "normal-geometry"
     main_window.setWindowState.assert_called_once_with(
-        video_control_actions.QtCore.Qt.WindowState.WindowFullScreen
+        video_actions_env.module.QtCore.Qt.WindowState.WindowFullScreen
     )
     main_window.showFullScreen.assert_called_once()
     assert main_window.is_full_screen is True
 
 
 def test_toggle_theatre_mode_keeps_normal_window_when_base_mode_is_windowed(
-    monkeypatch,
+    monkeypatch, video_actions_env
 ):
     monkeypatch.setattr(
-        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
     )
-    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
     main_window = _make_theatre_entry_window(is_fullscreen=False, is_maximized=False)
 
-    toggle_theatre_mode(main_window)
+    video_actions_env.toggle_theatre_mode(main_window)
 
     assert main_window._was_custom_fullscreen is False
     main_window.setWindowState.assert_not_called()
@@ -407,15 +489,15 @@ def test_toggle_theatre_mode_keeps_normal_window_when_base_mode_is_windowed(
 
 
 def test_toggle_theatre_mode_keeps_maximized_window_when_base_mode_is_maximized(
-    monkeypatch,
+    monkeypatch, video_actions_env
 ):
     monkeypatch.setattr(
-        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
     )
-    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
     main_window = _make_theatre_entry_window(is_fullscreen=False, is_maximized=True)
 
-    toggle_theatre_mode(main_window)
+    video_actions_env.toggle_theatre_mode(main_window)
 
     assert main_window._was_custom_fullscreen is False
     assert main_window._was_maximized is True
@@ -424,11 +506,13 @@ def test_toggle_theatre_mode_keeps_maximized_window_when_base_mode_is_maximized(
     assert main_window.is_full_screen is False
 
 
-def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(monkeypatch):
+def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(
+    monkeypatch, video_actions_env
+):
     monkeypatch.setattr(
-        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
     )
-    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
 
     menu_bar = _FakeMenuBar()
     saved_geometry = SimpleNamespace(
@@ -471,7 +555,7 @@ def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(monkeypatch)
         setUpdatesEnabled=MagicMock(),
     )
 
-    toggle_theatre_mode(main_window)
+    video_actions_env.toggle_theatre_mode(main_window)
 
     main_window.showNormal.assert_called_once()
     main_window.showFullScreen.assert_not_called()
@@ -485,11 +569,13 @@ def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(monkeypatch)
     assert main_window.is_full_screen is False
 
 
-def test_toggle_theatre_mode_restores_maximized_state_on_exit(monkeypatch):
+def test_toggle_theatre_mode_restores_maximized_state_on_exit(
+    monkeypatch, video_actions_env
+):
     monkeypatch.setattr(
-        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
     )
-    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
 
     menu_bar = _FakeMenuBar()
     main_window = SimpleNamespace(
@@ -526,7 +612,7 @@ def test_toggle_theatre_mode_restores_maximized_state_on_exit(monkeypatch):
         setUpdatesEnabled=MagicMock(),
     )
 
-    toggle_theatre_mode(main_window)
+    video_actions_env.toggle_theatre_mode(main_window)
 
     main_window.showFullScreen.assert_not_called()
     main_window.showMaximized.assert_called_once()
@@ -540,31 +626,35 @@ def test_toggle_theatre_mode_restores_maximized_state_on_exit(monkeypatch):
     assert main_window.is_full_screen is False
 
 
-def test_disable_compare_preview_modes_for_recording_disables_both_and_toasts():
+def test_disable_compare_preview_modes_for_recording_disables_both_and_toasts(
+    video_actions_env,
+):
     calls = []
     main_window = SimpleNamespace(
         view_face_compare_enabled=True,
         view_face_mask_enabled=True,
         _set_compare_mode=lambda mode, checked: calls.append((mode, checked)),
     )
-    common_widget_actions.create_and_show_toast_message.reset_mock()
+    video_actions_env.common_widget_actions.create_and_show_toast_message.reset_mock()
 
-    _disable_compare_preview_modes_for_recording(main_window)
+    video_actions_env.disable_compare_preview_modes_for_recording(main_window)
 
     assert calls == [("compare", False), ("mask", False)]
-    common_widget_actions.create_and_show_toast_message.assert_called_once()
+    video_actions_env.common_widget_actions.create_and_show_toast_message.assert_called_once()
 
 
-def test_disable_compare_preview_modes_for_recording_is_noop_when_already_off():
+def test_disable_compare_preview_modes_for_recording_is_noop_when_already_off(
+    video_actions_env,
+):
     calls = []
     main_window = SimpleNamespace(
         view_face_compare_enabled=False,
         view_face_mask_enabled=False,
         _set_compare_mode=lambda mode, checked: calls.append((mode, checked)),
     )
-    common_widget_actions.create_and_show_toast_message.reset_mock()
+    video_actions_env.common_widget_actions.create_and_show_toast_message.reset_mock()
 
-    _disable_compare_preview_modes_for_recording(main_window)
+    video_actions_env.disable_compare_preview_modes_for_recording(main_window)
 
     assert calls == []
-    common_widget_actions.create_and_show_toast_message.assert_not_called()
+    video_actions_env.common_widget_actions.create_and_show_toast_message.assert_not_called()

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -19,6 +19,13 @@ _STUBS = [
     "PySide6.QtWidgets",
     "PySide6.QtCore",
     "PySide6.QtGui",
+    "cv2",
+    "numpy",
+    "PIL",
+    "PIL.Image",
+    "app.helpers",
+    "app.helpers.typing_helper",
+    "app.helpers.miscellaneous",
     "app.ui.widgets.widget_components",
     "app.ui.widgets.ui_workers",
     "app.ui.widgets.actions.common_actions",
@@ -40,46 +47,29 @@ from app.ui.widgets.actions.video_control_actions import (  # noqa: E402
 )
 
 
-def test_view_fullscreen_temporarily_exits_and_reenters_theatre(monkeypatch):
+def test_view_fullscreen_keeps_theatre_mode_active():
     synced = []
-    theatre_calls = []
-    single_shot_calls = []
-
-    def fake_toggle_theatre_mode(window):
-        theatre_calls.append(window.is_theatre_mode)
-        window.is_theatre_mode = not window.is_theatre_mode
-
-    monkeypatch.setattr(
-        video_control_actions, "toggle_theatre_mode", fake_toggle_theatre_mode
-    )
-    monkeypatch.setattr(
-        video_control_actions.QtCore.QTimer,
-        "singleShot",
-        lambda delay, callback: (
-            single_shot_calls.append(delay),
-            callback(),
-        )[-1],
-    )
-
     main_window = SimpleNamespace(
         is_theatre_mode=True,
         is_full_screen=False,
-        _fullscreen_theatre_transition_in_progress=False,
+        _fullscreen_restore_was_maximized=False,
+        _fullscreen_restore_geometry=None,
         showFullScreen=MagicMock(),
         showNormal=MagicMock(),
+        isMaximized=lambda: False,
         isFullScreen=lambda: False,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
         _sync_viewer_menu_actions=lambda: synced.append(True),
     )
 
     view_fullscreen(main_window)
 
-    assert theatre_calls == [True, False]
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
     assert main_window.is_theatre_mode is True
     assert main_window.is_full_screen is True
-    assert main_window._fullscreen_theatre_transition_in_progress is False
-    assert single_shot_calls == [0]
+    assert main_window._fullscreen_restore_geometry == "live-geometry"
     assert synced == [True]
 
 
@@ -90,7 +80,10 @@ def test_view_fullscreen_uses_real_window_transition_outside_theatre():
         is_full_screen=True,
         showFullScreen=MagicMock(),
         showNormal=MagicMock(),
+        isMaximized=lambda: False,
         isFullScreen=lambda: False,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
         _sync_viewer_menu_actions=lambda: synced.append(True),
     )
 
@@ -99,6 +92,185 @@ def test_view_fullscreen_uses_real_window_transition_outside_theatre():
     main_window.showFullScreen.assert_called_once()
     main_window.showNormal.assert_not_called()
     assert synced == [True]
+
+
+class _FakeGeometry:
+    def __init__(
+        self,
+        x: int = 100,
+        y: int = 200,
+        width: int = 900,
+        height: int = 600,
+    ):
+        self._x = x
+        self._y = y
+        self._width = width
+        self._height = height
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+    def width(self):
+        return self._width
+
+    def height(self):
+        return self._height
+
+
+class _StatefulFullscreenWindow:
+    def __init__(
+        self,
+        *,
+        state: str = "normal",
+        geometry: _FakeGeometry | None = None,
+        is_theatre_mode: bool = False,
+    ):
+        self._state = state
+        self._geometry = geometry or _FakeGeometry()
+        self._normal_geometry = self._geometry
+        self.is_theatre_mode = is_theatre_mode
+        self.is_full_screen = state == "fullscreen"
+        self._fullscreen_restore_was_maximized = False
+        self._fullscreen_restore_geometry = None
+        self._was_maximized = state == "maximized"
+        self._was_custom_fullscreen = False
+        self._was_normal_geometry = self._normal_geometry
+        self._sync_calls: list[bool] = []
+        self.showFullScreen = MagicMock(side_effect=self._show_fullscreen)
+        self.showNormal = MagicMock(side_effect=self._show_normal)
+        self.showMaximized = MagicMock(side_effect=self._show_maximized)
+        self.setGeometry = MagicMock(side_effect=self._set_geometry)
+
+    def _show_fullscreen(self):
+        self._state = "fullscreen"
+        self.is_full_screen = True
+
+    def _show_normal(self):
+        self._state = "normal"
+        self.is_full_screen = False
+
+    def _show_maximized(self):
+        self._state = "maximized"
+        self.is_full_screen = False
+
+    def _set_geometry(self, geometry):
+        self._geometry = geometry
+        self._normal_geometry = geometry
+
+    def isFullScreen(self):
+        return self._state == "fullscreen"
+
+    def isMaximized(self):
+        return self._state == "maximized"
+
+    def normalGeometry(self):
+        return self._normal_geometry
+
+    def geometry(self):
+        return self._geometry
+
+    def _sync_viewer_menu_actions(self):
+        self._sync_calls.append(True)
+
+
+def test_view_fullscreen_restores_saved_geometry_after_round_trip():
+    geometry = _FakeGeometry()
+    main_window = _StatefulFullscreenWindow(state="normal", geometry=geometry)
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    main_window.showFullScreen.assert_called_once()
+    main_window.showNormal.assert_called_once()
+    assert main_window.setGeometry.call_args_list[-1].args == (geometry,)
+    assert main_window.isFullScreen() is False
+    assert main_window.isMaximized() is False
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is None
+    assert main_window._sync_calls == [True, True]
+
+
+def test_view_fullscreen_restores_maximized_state_after_round_trip():
+    main_window = _StatefulFullscreenWindow(state="maximized")
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    main_window.showFullScreen.assert_called_once()
+    main_window.showMaximized.assert_called_once()
+    main_window.showNormal.assert_not_called()
+    main_window.setGeometry.assert_not_called()
+    assert main_window.isMaximized() is True
+    assert main_window.isFullScreen() is False
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is None
+    assert main_window._sync_calls == [True, True]
+
+
+def test_view_fullscreen_preserves_maximized_base_state_in_theatre():
+    main_window = _StatefulFullscreenWindow(state="maximized", is_theatre_mode=True)
+    main_window._was_maximized = True
+    main_window._was_custom_fullscreen = False
+    main_window._was_normal_geometry = main_window.normalGeometry()
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isMaximized() is True
+    assert main_window.isFullScreen() is False
+    assert main_window.showMaximized.call_count == 1
+    assert main_window._was_maximized is True
+    assert main_window._was_custom_fullscreen is False
+    assert main_window._was_normal_geometry == main_window.normalGeometry()
+    assert main_window._fullscreen_restore_geometry is None
+
+
+def test_view_fullscreen_preserves_normal_geometry_in_theatre():
+    geometry = _FakeGeometry()
+    main_window = _StatefulFullscreenWindow(
+        state="normal",
+        geometry=geometry,
+        is_theatre_mode=True,
+    )
+    main_window._was_maximized = False
+    main_window._was_custom_fullscreen = False
+    main_window._was_normal_geometry = geometry
+
+    view_fullscreen(main_window)
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isMaximized() is False
+    assert main_window.isFullScreen() is False
+    assert main_window.showNormal.call_count == 1
+    assert main_window.setGeometry.call_args_list[-1].args == (geometry,)
+    assert main_window._was_maximized is False
+    assert main_window._was_custom_fullscreen is False
+    assert main_window._was_normal_geometry is geometry
+
+
+def test_view_fullscreen_keeps_theatre_layout_active_during_round_trip():
+    main_window = _StatefulFullscreenWindow(state="normal", is_theatre_mode=True)
+    base_geometry = main_window.geometry()
+    main_window._was_maximized = False
+    main_window._was_custom_fullscreen = False
+    main_window._was_normal_geometry = base_geometry
+
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isFullScreen() is True
+    assert main_window._was_normal_geometry is base_geometry
+
+    view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window.isFullScreen() is False
+    assert main_window.geometry() is base_geometry
 
 
 class _FakeWidget:
@@ -305,6 +477,61 @@ def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(monkeypatch)
     main_window.showFullScreen.assert_not_called()
     main_window.showMaximized.assert_not_called()
     assert set_geometry_calls == [saved_geometry]
+    main_window.restoreState.assert_called_once_with("window-state")
+    assert [call.args for call in main_window.setUpdatesEnabled.call_args_list] == [
+        (False,),
+        (True,),
+    ]
+    assert main_window.is_full_screen is False
+
+
+def test_toggle_theatre_mode_restores_maximized_state_on_exit(monkeypatch):
+    monkeypatch.setattr(
+        video_control_actions, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_control_actions.layout_actions.fit_image_to_view_onchange.reset_mock()
+
+    menu_bar = _FakeMenuBar()
+    main_window = SimpleNamespace(
+        is_theatre_mode=True,
+        _was_custom_fullscreen=False,
+        _was_maximized=True,
+        _was_normal_geometry="normal-geometry",
+        _saved_window_state="window-state",
+        _saved_dock_states={},
+        _saved_layout_props={},
+        _main_v_spacers=[],
+        _top_bar_spacers=[],
+        _top_bar_widgets_state={},
+        input_Target_DockWidget=_FakeWidget(False),
+        input_Faces_DockWidget=_FakeWidget(False),
+        jobManagerDockWidget=_FakeWidget(False),
+        controlOptionsDockWidget=_FakeWidget(False),
+        facesPanelGroupBox=_FakeWidget(False),
+        menuBar=lambda: menu_bar,
+        horizontalLayout=_FakeLayout(),
+        verticalLayout=_FakeLayout(),
+        verticalLayoutMediaControls=_FakeLayout(),
+        panelVisibilityCheckBoxLayout=_FakeLayout(),
+        graphicsViewFrame=_FakeGraphicsViewFrame(),
+        isFullScreen=lambda: False,
+        isMaximized=lambda: False,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
+        showFullScreen=MagicMock(),
+        showMaximized=MagicMock(),
+        showNormal=MagicMock(),
+        setGeometry=MagicMock(),
+        restoreState=MagicMock(),
+        setUpdatesEnabled=MagicMock(),
+    )
+
+    toggle_theatre_mode(main_window)
+
+    main_window.showFullScreen.assert_not_called()
+    main_window.showMaximized.assert_called_once()
+    main_window.showNormal.assert_not_called()
+    main_window.setGeometry.assert_not_called()
     main_window.restoreState.assert_called_once_with("window-state")
     assert [call.args for call in main_window.setUpdatesEnabled.call_args_list] == [
         (False,),

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -217,6 +217,7 @@ class _StatefulFullscreenWindow:
         self._was_custom_fullscreen = False
         self._was_normal_geometry = self._normal_geometry
         self._sync_calls: list[bool] = []
+        self._theatre_snapshot_sync_calls = 0
         self.showFullScreen = MagicMock(side_effect=self._show_fullscreen)
         self.showNormal = MagicMock(side_effect=self._show_normal)
         self.showMaximized = MagicMock(side_effect=self._show_maximized)
@@ -252,6 +253,29 @@ class _StatefulFullscreenWindow:
 
     def _sync_viewer_menu_actions(self):
         self._sync_calls.append(True)
+
+    def _sync_theatre_base_window_snapshot(self):
+        self._theatre_snapshot_sync_calls += 1
+        if not self.is_theatre_mode:
+            return
+
+        if self.isFullScreen():
+            self._was_custom_fullscreen = True
+            self._was_maximized = False
+            self._was_normal_geometry = (
+                self._fullscreen_restore_geometry
+                if self._fullscreen_restore_geometry is not None
+                else self.normalGeometry()
+            )
+            return
+
+        self._was_custom_fullscreen = False
+        if self.isMaximized():
+            self._was_maximized = True
+            self._was_normal_geometry = self.normalGeometry()
+        else:
+            self._was_maximized = False
+            self._was_normal_geometry = self.geometry()
 
 
 def test_view_fullscreen_restores_saved_geometry_after_round_trip(video_actions_env):
@@ -305,6 +329,7 @@ def test_view_fullscreen_preserves_maximized_base_state_in_theatre(video_actions
     assert main_window._was_custom_fullscreen is False
     assert main_window._was_normal_geometry == main_window.normalGeometry()
     assert main_window._fullscreen_restore_geometry is None
+    assert main_window._theatre_snapshot_sync_calls == 2
 
 
 def test_view_fullscreen_preserves_normal_geometry_in_theatre(video_actions_env):
@@ -329,6 +354,7 @@ def test_view_fullscreen_preserves_normal_geometry_in_theatre(video_actions_env)
     assert main_window._was_maximized is False
     assert main_window._was_custom_fullscreen is False
     assert main_window._was_normal_geometry is geometry
+    assert main_window._theatre_snapshot_sync_calls == 2
 
 
 def test_view_fullscreen_keeps_theatre_layout_active_during_round_trip(
@@ -345,12 +371,15 @@ def test_view_fullscreen_keeps_theatre_layout_active_during_round_trip(
     assert main_window.is_theatre_mode is True
     assert main_window.isFullScreen() is True
     assert main_window._was_normal_geometry is base_geometry
+    assert main_window._was_custom_fullscreen is True
+    assert main_window._was_maximized is False
 
     video_actions_env.view_fullscreen(main_window)
 
     assert main_window.is_theatre_mode is True
     assert main_window.isFullScreen() is False
     assert main_window.geometry() is base_geometry
+    assert main_window._theatre_snapshot_sync_calls == 2
 
 
 class _FakeWidget:


### PR DESCRIPTION
## Summary

This fixes the remaining fullscreen, theatre mode, and workspace state issues around `F11`.

Theatre mode is now independent from fullscreen, so pressing `F11` no longer exits and re-enters theatre mode just to change window state. It can remain active in normal, maximized, or fullscreen modes, with fullscreen restore behavior and menu state staying in sync.

Workspace saving/loading was also corrected so the active window state and underlying restore geometry are preserved properly while theatre mode is active, without persisting theatre mode itself.

This branch also fixes the unit-test isolation issue in `test_video_control_actions.py` so the affected UI test files can run together in one pytest process.

## Changes

- Keep theatre mode active during `F11` fullscreen toggles
- Restore fullscreen back to the correct base window state
- Make `Esc` exit fullscreen before theatre mode
- Keep the fullscreen menu state in sync with the live window state
- Save the live fullscreen/maximized state while theatre mode is active
- Save fullscreen workspaces using the underlying normal restore geometry instead of the live fullscreen rect
- Seed fullscreen restore geometry when loading fullscreen workspaces so exiting fullscreen returns to the saved normal size
- Keep theatre base window snapshots synced during resize, move, and window-state transitions while theatre mode is active
- Restore the normal dock/layout state from the pre-theatre snapshot
- Do not persist theatre mode in saved workspaces
- Fix test harness isolation in `test_video_control_actions.py`

## Notes

- On Windows, leaving native fullscreen to maximized may still cause a brief visual hop. The restored state is still correct.
- Loading a workspace still does not reopen the app in theatre mode.
- A fullscreen workspace reload now exits back to the saved normal window geometry, not a persisted maximized base state.

## Testing

Ran:

```bash
.venv\Scripts\python.exe -m pytest --noconftest tests\unit\ui\test_video_control_actions.py -q
.venv\Scripts\python.exe -m pytest --noconftest tests\unit\ui\test_save_load_actions.py -q
.venv\Scripts\python.exe -m pytest --noconftest tests\unit\ui\test_video_control_actions.py tests\unit\ui\test_save_load_actions.py -q
pre-commit run --all-files