### PR TITLE
Scan tools stabilization

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -3179,9 +3179,16 @@ class VideoProcessor(QObject):
                 IssueScanTargetSnapshot,
                 dict(target_faces_snapshot),
             )
-        previous_last_detected_faces = copy.deepcopy(self.last_detected_faces)
-        previous_smoothed_kps = copy.deepcopy(self._smoothed_kps)
-        previous_smoothed_dense_kps = copy.deepcopy(self._smoothed_dense_kps)
+        previous_last_detected_faces = copy.deepcopy(
+            getattr(self, "last_detected_faces", [])
+        )
+        previous_smoothed_kps = copy.deepcopy(getattr(self, "_smoothed_kps", {}))
+        previous_smoothed_dense_kps = copy.deepcopy(
+            getattr(self, "_smoothed_dense_kps", {})
+        )
+        previous_smoothed_dense_kps_203 = copy.deepcopy(
+            getattr(self, "_smoothed_dense_kps_203", {})
+        )
         total_frames_scanned = 0
         tracking_enabled = False
         issue_frames_by_face: dict[str, set[int]] = {
@@ -3354,6 +3361,7 @@ class VideoProcessor(QObject):
             self.last_detected_faces = previous_last_detected_faces
             self._smoothed_kps = previous_smoothed_kps
             self._smoothed_dense_kps = previous_smoothed_dense_kps
+            self._smoothed_dense_kps_203 = previous_smoothed_dense_kps_203
             if tracking_enabled:
                 self.main_window.models_processor.face_detectors.reset_tracker()
             self.current_frame_number = (

--- a/app/ui/widgets/actions/card_actions.py
+++ b/app/ui/widgets/actions/card_actions.py
@@ -16,6 +16,13 @@ if TYPE_CHECKING:
 
 
 def clear_target_faces(main_window: "MainWindow", refresh_frame=True):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "clear target faces"
+    ):
+        return
+
     if main_window.video_processor.processing:
         main_window.video_processor.stop_processing()
     main_window.targetFacesList.clear()
@@ -38,14 +45,19 @@ def clear_target_faces(main_window: "MainWindow", refresh_frame=True):
     common_widget_actions.set_widgets_values_using_face_id_parameters(
         main_window=main_window, face_id=None
     )
-    from app.ui.widgets.actions import video_control_actions
-
     video_control_actions.update_scan_review_button_states(main_window)
     if refresh_frame:
         common_widget_actions.refresh_frame(main_window=main_window)
 
 
 def clear_input_faces(main_window: "MainWindow"):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "clear input faces"
+    ):
+        return
+
     main_window.inputFacesList.clear()
 
     for input_face in list(main_window.input_faces.values()):
@@ -59,6 +71,13 @@ def clear_input_faces(main_window: "MainWindow"):
 
 
 def clear_merged_embeddings(main_window: "MainWindow"):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "clear merged embeddings"
+    ):
+        return
+
     main_window.inputEmbeddingsList.clear()
 
     for embed_button in list(main_window.merged_embeddings.values()):
@@ -83,6 +102,11 @@ def uncheck_all_merged_embeddings(main_window: "MainWindow"):
 
 
 def find_target_faces(main_window: "MainWindow"):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(main_window, "find faces"):
+        return
+
     control = main_window.control.copy()
     video_processor = main_window.video_processor
     if video_processor.media_path:
@@ -240,8 +264,6 @@ def find_target_faces(main_window: "MainWindow"):
     if main_window.video_processor.processing:
         main_window.video_processor.stop_processing()
     common_widget_actions.refresh_frame(main_window)
-    from app.ui.widgets.actions import video_control_actions
-
     video_control_actions.update_scan_review_button_states(main_window)
 
     common_widget_actions.update_gpu_memory_progressbar(main_window)

--- a/app/ui/widgets/actions/common_actions.py
+++ b/app/ui/widgets/actions/common_actions.py
@@ -245,6 +245,13 @@ def copy_selected_face_parameters(
 def paste_selected_face_parameters(
     main_window: "MainWindow", face_id: str | None = None
 ) -> bool:
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "apply copied parameters"
+    ):
+        return False
+
     face_id = _resolve_target_face_id(main_window, face_id)
     if not face_id:
         _show_target_face_parameter_message(

--- a/app/ui/widgets/actions/job_manager_actions.py
+++ b/app/ui/widgets/actions/job_manager_actions.py
@@ -223,6 +223,9 @@ def load_job(main_window: "MainWindow"):
 
     This performs a FULL, HEAVY load of the workspace.
     """
+    if video_control_actions.block_if_issue_scan_active(main_window, "load a job"):
+        return
+
     selected_jobs = get_selected_jobs(main_window)
     if not selected_jobs:
         QMessageBox.warning(
@@ -1631,6 +1634,11 @@ def handle_batch_completion(main_window: "MainWindow"):
 
 def process_selected_job(main_window: "MainWindow"):
     """Starts a JobProcessor thread for only the selected jobs."""
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "start selected jobs"
+    ):
+        return
+
     selected_jobs = get_selected_jobs(main_window)
     if not selected_jobs:
         QMessageBox.warning(
@@ -1644,6 +1652,11 @@ def process_selected_job(main_window: "MainWindow"):
 
 def start_processing_all_jobs(main_window: "MainWindow"):
     """Starts a JobProcessor thread for all jobs in the list."""
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "start job processing"
+    ):
+        return
+
     print("[INFO] Processing all jobs...")
     start_job_processor(main_window, jobs_to_process=None)  # None means all jobs
 

--- a/app/ui/widgets/actions/list_view_actions.py
+++ b/app/ui/widgets/actions/list_view_actions.py
@@ -322,6 +322,11 @@ def select_target_medias(
 
 @QtCore.Slot()
 def filter_target_videos(main_window):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.is_issue_scan_active(main_window):
+        video_control_actions._mark_pending_target_media_refresh(main_window)
+        return
     filter_actions.filter_target_videos(main_window)
     load_target_webcams(main_window)
 
@@ -330,6 +335,11 @@ def filter_target_videos(main_window):
 def load_target_webcams(
     main_window: "MainWindow",
 ):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.is_issue_scan_active(main_window):
+        video_control_actions._mark_pending_target_media_refresh(main_window)
+        return
     if main_window.filterWebcamsCheckBox.isChecked():
         main_window.video_loader_worker = ui_workers.TargetMediaLoaderWorker(
             main_window=main_window, webcam_mode=True

--- a/app/ui/widgets/actions/list_view_actions.py
+++ b/app/ui/widgets/actions/list_view_actions.py
@@ -270,6 +270,13 @@ def clear_stop_loading_target_media(main_window: "MainWindow"):
 def select_target_medias(
     main_window: "MainWindow", source_type="folder", folder_name=False, files_list=None
 ):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "change target media"
+    ):
+        return
+
     files_list = files_list or []
     if source_type == "folder":
         folder_name = QtWidgets.QFileDialog.getExistingDirectory(
@@ -360,6 +367,13 @@ def clear_stop_loading_input_media(main_window: "MainWindow"):
 def select_input_face_images(
     main_window: "MainWindow", source_type="folder", folder_name=False, files_list=None
 ):
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "load input faces"
+    ):
+        return
+
     files_list = files_list or []
     if source_type == "folder":
         folder_name = QtWidgets.QFileDialog.getExistingDirectory(

--- a/app/ui/widgets/actions/save_load_actions.py
+++ b/app/ui/widgets/actions/save_load_actions.py
@@ -140,6 +140,9 @@ def _apply_workspace_window_state(
 
 
 def open_embeddings_from_file(main_window: "MainWindow"):
+    if video_control_actions.block_if_issue_scan_active(main_window, "load embeddings"):
+        return
+
     embedding_filename, _ = QtWidgets.QFileDialog.getOpenFileName(
         main_window,
         filter="JSON (*.json)",
@@ -290,6 +293,12 @@ def save_current_parameters_and_control(main_window: "MainWindow", face_id):
 def load_parameters_and_settings(
     main_window: "MainWindow", face_id, load_settings=False
 ):
+    if video_control_actions.block_if_issue_scan_active(
+        main_window,
+        "load parameters and settings" if load_settings else "load parameters",
+    ):
+        return
+
     data_filename, _ = QtWidgets.QFileDialog.getOpenFileName(
         main_window, filter="JSON (*.json)"
     )
@@ -332,6 +341,11 @@ def get_auto_load_workspace_toggle(
 def load_saved_workspace(
     main_window: "MainWindow", data_filename: Union[str, bool] = False
 ):
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "load a workspace"
+    ):
+        return
+
     if not data_filename:
         data_filename, _ = QtWidgets.QFileDialog.getOpenFileName(
             main_window, filter="JSON (*.json)"

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -266,6 +266,9 @@ def add_video_slider_marker(main_window: "MainWindow"):
     Shows an error message box if either precondition is not met, or if a marker
     already exists at that position.
     """
+    if block_if_issue_scan_active(main_window, "add a marker"):
+        return
+
     if (
         not isinstance(
             main_window.selected_video_button, widget_components.TargetMediaCardButton
@@ -306,6 +309,9 @@ def add_video_slider_marker(main_window: "MainWindow"):
 
 def show_add_marker_menu(main_window: "MainWindow"):
     """Shows a context menu for adding different types of markers."""
+    if block_if_issue_scan_active(main_window, "edit scan markers"):
+        return
+
     if (
         not isinstance(
             main_window.selected_video_button, widget_components.TargetMediaCardButton
@@ -354,6 +360,9 @@ def show_add_marker_menu(main_window: "MainWindow"):
 
 def set_job_start_frame(main_window: "MainWindow"):
     """Adds a new job marker pair starting at the current slider position."""
+    if block_if_issue_scan_active(main_window, "add a record start marker"):
+        return
+
     current_pos = int(main_window.videoSeekSlider.value())
 
     # Basic validation: Ensure we are not adding a start if the last pair is incomplete
@@ -375,6 +384,9 @@ def set_job_start_frame(main_window: "MainWindow"):
 
 def set_job_end_frame(main_window: "MainWindow"):
     """Sets the job end frame marker for the last incomplete pair."""
+    if block_if_issue_scan_active(main_window, "add a record end marker"):
+        return
+
     current_pos = int(main_window.videoSeekSlider.value())
 
     # Validation: Check if there's an incomplete pair to add an end to
@@ -416,6 +428,9 @@ def remove_video_slider_marker(main_window: "MainWindow"):
     If the position belongs to a job marker pair, the entire pair is removed.
     If no marker exists at the position, an error message box is shown.
     """
+    if block_if_issue_scan_active(main_window, "remove a marker"):
+        return
+
     if (
         not isinstance(
             main_window.selected_video_button, widget_components.TargetMediaCardButton
@@ -927,11 +942,141 @@ def _get_issue_scan_ui_state(main_window: "MainWindow") -> dict:
     return state
 
 
+def _copy_issue_frames_by_face(frames_by_face) -> dict[str, set[int]]:
+    """Return a detached copy of the per-face issue-frame mapping."""
+    return {
+        str(face_id): {int(frame) for frame in frames}
+        for face_id, frames in (frames_by_face or {}).items()
+    }
+
+
+def _restore_previous_issue_scan_results(main_window: "MainWindow") -> int:
+    """Restore the pre-scan findings snapshot and return its total frame count."""
+    state = _get_issue_scan_ui_state(main_window)
+    previous_results = _copy_issue_frames_by_face(
+        state.get("previous_issue_frames_by_face", {})
+    )
+    set_issue_frames_by_face(main_window, previous_results)
+    return sum(len(frames) for frames in previous_results.values())
+
+
 def _restore_issue_scan_display(main_window: "MainWindow") -> None:
     video_processor = getattr(main_window, "video_processor", None)
     process_current_frame = getattr(video_processor, "process_current_frame", None)
     if callable(process_current_frame):
         process_current_frame()
+
+
+def is_issue_scan_active(main_window: "MainWindow") -> bool:
+    return bool(
+        getattr(main_window, "scan_issue_worker", None) is not None
+        or _get_issue_scan_ui_state(main_window).get("active", False)
+    )
+
+
+def block_if_issue_scan_active(
+    main_window: "MainWindow", action_name: str, parent=None
+) -> bool:
+    if not is_issue_scan_active(main_window):
+        return False
+
+    common_widget_actions.create_and_show_toast_message(
+        main_window,
+        "Scan In Progress",
+        f"Cannot {action_name} while an issue scan is running.\nAbort the scan first, then retry the action.",
+        style_type="warning",
+    )
+    return True
+
+
+def _get_ui_object_enabled_state(widget) -> bool:
+    if widget is None:
+        return False
+    if hasattr(widget, "isEnabled") and callable(widget.isEnabled):
+        return bool(widget.isEnabled())
+    return bool(getattr(widget, "enabled", True))
+
+
+def _set_ui_object_enabled_state(widget, enabled: bool) -> None:
+    if widget is None:
+        return
+    if hasattr(widget, "setEnabled") and callable(widget.setEnabled):
+        widget.setEnabled(bool(enabled))
+        return
+    if hasattr(widget, "setDisabled") and callable(widget.setDisabled):
+        widget.setDisabled(not bool(enabled))
+        return
+    if hasattr(widget, "enabled"):
+        widget.enabled = bool(enabled)
+
+
+def _get_issue_scan_mutation_lock_targets(main_window: "MainWindow") -> list:
+    targets = []
+    for attr_name in (
+        "findTargetFacesButton",
+        "clearTargetFacesButton",
+        "buttonTargetVideosPath",
+        "buttonInputFacesPath",
+        "filterWebcamsCheckBox",
+        "openEmbeddingButton",
+        "addMarkerButton",
+        "removeMarkerButton",
+        "videoSeekSlider",
+        "frameAdvanceButton",
+        "frameRewindButton",
+        "nextMarkerButton",
+        "previousMarkerButton",
+        "swapfacesButton",
+        "editFacesButton",
+        "targetVideosList",
+        "inputFacesList",
+        "inputEmbeddingsList",
+        "jobQueueList",
+        "loadJobButton",
+        "buttonProcessAll",
+        "buttonProcessSelected",
+        "actionLoad_SavedWorkspace",
+        "actionOpen_Videos_Folder",
+        "actionOpen_Video_Files",
+        "actionLoad_Source_Image_Files",
+        "actionLoad_Source_Images_Folder",
+        "actionLoad_Embeddings",
+    ):
+        widget = getattr(main_window, attr_name, None)
+        if widget is not None:
+            targets.append(widget)
+
+    for collection_name in ("target_videos", "input_faces", "merged_embeddings"):
+        targets.extend(getattr(main_window, collection_name, {}).values())
+
+    unique_targets = []
+    seen_ids = set()
+    for target in targets:
+        if target is None:
+            continue
+        target_id = id(target)
+        if target_id in seen_ids:
+            continue
+        seen_ids.add(target_id)
+        unique_targets.append(target)
+    return unique_targets
+
+
+def _set_issue_scan_mutation_lock_state(
+    main_window: "MainWindow", scan_active: bool
+) -> None:
+    state = _get_issue_scan_ui_state(main_window)
+    if scan_active:
+        lock_targets = _get_issue_scan_mutation_lock_targets(main_window)
+        state["mutation_lock_enabled_states"] = [
+            (target, _get_ui_object_enabled_state(target)) for target in lock_targets
+        ]
+        for target in lock_targets:
+            _set_ui_object_enabled_state(target, False)
+        return
+
+    for target, was_enabled in state.pop("mutation_lock_enabled_states", []):
+        _set_ui_object_enabled_state(target, was_enabled)
 
 
 def _set_issue_scan_tool_button_state(
@@ -956,7 +1101,12 @@ def _set_issue_scan_tool_button_state(
             button.setEnabled(not scan_active)
 
 
-def _start_issue_scan_ui(main_window: "MainWindow", worker, scope_text: str) -> None:
+def _start_issue_scan_ui(
+    main_window: "MainWindow",
+    worker,
+    scope_text: str,
+    previous_issue_frames_by_face: dict[str, set[int]] | None = None,
+) -> None:
     state = _get_issue_scan_ui_state(main_window)
     state.clear()
     state.update(
@@ -965,8 +1115,16 @@ def _start_issue_scan_ui(main_window: "MainWindow", worker, scope_text: str) -> 
             "start_frame": int(main_window.videoSeekSlider.value()),
             "scope_text": scope_text,
             "keep_controls": bool(main_window.control.get("KeepControlsToggle", False)),
+            "previous_issue_frames_by_face": _copy_issue_frames_by_face(
+                previous_issue_frames_by_face
+                if previous_issue_frames_by_face is not None
+                else getattr(main_window, "issue_frames_by_face", {})
+            ),
+            "has_partial_results": False,
         }
     )
+
+    _set_issue_scan_mutation_lock_state(main_window, True)
 
     if not state["keep_controls"]:
         layout_actions.disable_all_parameters_and_control_widget(main_window)
@@ -1030,6 +1188,7 @@ def _restore_issue_scan_ui(main_window: "MainWindow") -> None:
     if toggle_button is not None:
         toggle_button.setEnabled(True)
 
+    _set_issue_scan_mutation_lock_state(main_window, False)
     state.clear()
     _set_issue_scan_tool_button_state(main_window, False)
     update_scan_review_button_states(main_window)
@@ -1064,6 +1223,7 @@ def _handle_issue_scan_progress(
 def _handle_issue_scan_issue_found(
     main_window: "MainWindow", face_id: str, frame_number: int
 ) -> None:
+    _get_issue_scan_ui_state(main_window)["has_partial_results"] = True
     add_issue_frame_for_face(main_window, face_id, frame_number)
 
 
@@ -1083,21 +1243,41 @@ def _handle_issue_scan_completed(
     elapsed_seconds: float,
     cancelled: bool = False,
 ):
-    set_issue_frames_by_face(main_window, issue_frames_by_face)
+    state = _get_issue_scan_ui_state(main_window)
+    partial_results_visible = bool(state.get("has_partial_results", False))
+    partial_results_visible = partial_results_visible or any(
+        bool(frames) for frames in issue_frames_by_face.values()
+    )
+    restored_previous_results = False
+    restored_issue_frames = 0
+
+    if cancelled and not partial_results_visible:
+        restored_previous_results = True
+        restored_issue_frames = _restore_previous_issue_scan_results(main_window)
+    else:
+        set_issue_frames_by_face(main_window, issue_frames_by_face)
+
     _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)
-    total_issue_frames = sum(
-        len(set(frames)) for frames in issue_frames_by_face.values()
+    total_issue_frames = (
+        restored_issue_frames
+        if restored_previous_results
+        else sum(len(set(frames)) for frames in issue_frames_by_face.values())
     )
     scan_fps = (frames_scanned / elapsed_seconds) if elapsed_seconds > 0 else 0.0
     print(
         f"[INFO] Scan: Scope: {scope_text.removeprefix('Scanning ')} | Frames: {frames_scanned} | Time: {elapsed_seconds:.1f}s | FPS: {scan_fps:.1f} | Issues: {total_issue_frames} | Faces with issues: {faces_with_issues} | Cancelled: {cancelled}"
     )
     if cancelled:
+        cancelled_message = (
+            f"Stopped after {frames_scanned} scanned frames. Restored the previous {total_issue_frames} issue frames."
+            if restored_previous_results
+            else f"Stopped after {frames_scanned} scanned frames. Kept {total_issue_frames} issue frames found so far."
+        )
         common_widget_actions.create_and_show_toast_message(
             main_window,
             "Scan Aborted",
-            f"Stopped after {frames_scanned} scanned frames. Kept {total_issue_frames} issue frames found so far.",
+            cancelled_message,
             style_type="warning",
         )
     elif total_issue_frames:
@@ -1115,17 +1295,29 @@ def _handle_issue_scan_completed(
 
 
 def _handle_issue_scan_cancelled(main_window: "MainWindow"):
+    state = _get_issue_scan_ui_state(main_window)
+    restored_previous_results = False
+    if not state.get("has_partial_results", False):
+        _restore_previous_issue_scan_results(main_window)
+        restored_previous_results = True
     _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)
     common_widget_actions.create_and_show_toast_message(
         main_window,
         "Scan Cancelled",
-        "Issue scan aborted before finalizing. Kept any issue frames found so far.",
+        (
+            "Issue scan aborted before finalizing. Restored the previous issue findings."
+            if restored_previous_results
+            else "Issue scan aborted before finalizing. Kept any issue frames found so far."
+        ),
         style_type="warning",
     )
 
 
 def _handle_issue_scan_failed(main_window: "MainWindow", error_message: str):
+    state = _get_issue_scan_ui_state(main_window)
+    if not state.get("has_partial_results", False):
+        _restore_previous_issue_scan_results(main_window)
     _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)
     common_widget_actions.create_and_show_messagebox(
@@ -1172,8 +1364,11 @@ def run_issue_scan(main_window: "MainWindow"):
     worker = ui_workers.IssueScanWorker(main_window)
     main_window.scan_issue_worker = worker
     scope_text = worker._scan_scope_text
+    previous_issue_frames_by_face = _copy_issue_frames_by_face(
+        getattr(main_window, "issue_frames_by_face", {})
+    )
     set_issue_frames_by_face(main_window, {})
-    _start_issue_scan_ui(main_window, worker, scope_text)
+    _start_issue_scan_ui(main_window, worker, scope_text, previous_issue_frames_by_face)
     worker.progress.connect(
         lambda processed, total, frame_number, scan_fps: _handle_issue_scan_progress(
             main_window, scope_text, processed, total, frame_number, scan_fps
@@ -1223,6 +1418,9 @@ def remove_face_parameters_and_control_from_markers(main_window: "MainWindow", f
 
 def remove_all_markers(main_window: "MainWindow"):
     """Removes all standard, issue, and dropped-frame markers plus job pairs."""
+    if block_if_issue_scan_active(main_window, "clear markers"):
+        return
+
     standard_markers_positions = list(main_window.markers.keys())
     for marker_position in standard_markers_positions:
         remove_marker(main_window, marker_position)

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -943,24 +943,6 @@ def _get_issue_scan_ui_state(main_window: "MainWindow") -> dict:
     return state
 
 
-def _copy_issue_frames_by_face(frames_by_face) -> dict[str, set[int]]:
-    """Return a detached copy of the per-face issue-frame mapping."""
-    return {
-        str(face_id): {int(frame) for frame in frames}
-        for face_id, frames in (frames_by_face or {}).items()
-    }
-
-
-def _restore_previous_issue_scan_results(main_window: "MainWindow") -> int:
-    """Restore the pre-scan findings snapshot and return its total frame count."""
-    state = _get_issue_scan_ui_state(main_window)
-    previous_results = _copy_issue_frames_by_face(
-        state.get("previous_issue_frames_by_face", {})
-    )
-    set_issue_frames_by_face(main_window, previous_results)
-    return sum(len(frames) for frames in previous_results.values())
-
-
 def _restore_issue_scan_display(main_window: "MainWindow") -> None:
     video_processor = getattr(main_window, "video_processor", None)
     process_current_frame = getattr(video_processor, "process_current_frame", None)
@@ -988,6 +970,24 @@ def block_if_issue_scan_active(
         style_type="warning",
     )
     return True
+
+
+def _mark_pending_target_media_refresh(main_window: "MainWindow") -> None:
+    _get_issue_scan_ui_state(main_window)["pending_target_media_refresh"] = True
+
+
+def _replay_pending_target_media_refresh(main_window: "MainWindow") -> None:
+    state = _get_issue_scan_ui_state(main_window)
+    if not state.get("pending_target_media_refresh", False):
+        return
+
+    from app.ui.widgets.actions import filter_actions
+
+    state["pending_target_media_refresh"] = False
+    filter_actions.filter_target_videos(main_window)
+    from app.ui.widgets.actions import list_view_actions
+
+    list_view_actions.load_target_webcams(main_window)
 
 
 def _get_ui_object_enabled_state(widget) -> bool:
@@ -1023,6 +1023,7 @@ def _get_issue_scan_mutation_lock_targets(main_window: "MainWindow") -> list:
         "addMarkerButton",
         "removeMarkerButton",
         "videoSeekSlider",
+        "videoSeekLineEdit",
         "frameAdvanceButton",
         "frameRewindButton",
         "nextMarkerButton",
@@ -1106,7 +1107,6 @@ def _start_issue_scan_ui(
     main_window: "MainWindow",
     worker,
     scope_text: str,
-    previous_issue_frames_by_face: dict[str, set[int]] | None = None,
 ) -> None:
     state = _get_issue_scan_ui_state(main_window)
     state.clear()
@@ -1116,13 +1116,7 @@ def _start_issue_scan_ui(
             "start_frame": int(main_window.videoSeekSlider.value()),
             "scope_text": scope_text,
             "keep_controls": bool(main_window.control.get("KeepControlsToggle", False)),
-            "previous_issue_frames_by_face": _copy_issue_frames_by_face(
-                previous_issue_frames_by_face
-                if previous_issue_frames_by_face is not None
-                else getattr(main_window, "issue_frames_by_face", {})
-            ),
             "frames_scanned": 0,
-            "has_partial_results": False,
         }
     )
 
@@ -1137,7 +1131,7 @@ def _start_issue_scan_ui(
     if run_button is not None:
         run_button.setText("Abort Scan")
         run_button.setToolTip(
-            f"{scope_text}\nAbort the active issue scan and keep the issue frames found so far."
+            f"{scope_text}\nAbort the active issue scan and keep only issue frames found during this scan attempt."
         )
 
     play_button = getattr(main_window, "buttonMediaPlay", None)
@@ -1191,6 +1185,10 @@ def _restore_issue_scan_ui(main_window: "MainWindow") -> None:
         toggle_button.setEnabled(True)
 
     _set_issue_scan_mutation_lock_state(main_window, False)
+    # Mark the scan inactive before replaying deferred refreshes so the
+    # refresh path does not treat teardown as an active scan.
+    state["active"] = False
+    _replay_pending_target_media_refresh(main_window)
     state.clear()
     _set_issue_scan_tool_button_state(main_window, False)
     update_scan_review_button_states(main_window)
@@ -1226,7 +1224,6 @@ def _handle_issue_scan_progress(
 def _handle_issue_scan_issue_found(
     main_window: "MainWindow", face_id: str, frame_number: int
 ) -> None:
-    _get_issue_scan_ui_state(main_window)["has_partial_results"] = True
     add_issue_frame_for_face(main_window, face_id, frame_number)
 
 
@@ -1247,43 +1244,21 @@ def _handle_issue_scan_completed(
     elapsed_seconds: float,
     cancelled: bool = False,
 ):
-    state = _get_issue_scan_ui_state(main_window)
-    frames_scanned_recorded = int(state.get("frames_scanned", 0))
-    scan_made_progress = max(frames_scanned_recorded, int(frames_scanned)) > 0
-    partial_results_visible = bool(state.get("has_partial_results", False))
-    partial_results_visible = partial_results_visible or any(
-        bool(frames) for frames in issue_frames_by_face.values()
-    )
-    restored_previous_results = False
-    restored_issue_frames = 0
-
-    if cancelled and not scan_made_progress:
-        restored_previous_results = True
-        restored_issue_frames = _restore_previous_issue_scan_results(main_window)
-    else:
-        set_issue_frames_by_face(main_window, issue_frames_by_face)
-
-    _restore_issue_scan_ui(main_window)
+    set_issue_frames_by_face(main_window, issue_frames_by_face)
     _cleanup_issue_scan_worker(main_window)
-    total_issue_frames = (
-        restored_issue_frames
-        if restored_previous_results
-        else sum(len(set(frames)) for frames in issue_frames_by_face.values())
+    _restore_issue_scan_ui(main_window)
+    total_issue_frames = sum(
+        len(set(frames)) for frames in issue_frames_by_face.values()
     )
     scan_fps = (frames_scanned / elapsed_seconds) if elapsed_seconds > 0 else 0.0
     print(
         f"[INFO] Scan: Scope: {scope_text.removeprefix('Scanning ')} | Frames: {frames_scanned} | Time: {elapsed_seconds:.1f}s | FPS: {scan_fps:.1f} | Issues: {total_issue_frames} | Faces with issues: {faces_with_issues} | Cancelled: {cancelled}"
     )
     if cancelled:
-        cancelled_message = (
-            f"Stopped after {frames_scanned} scanned frames. Restored the previous {total_issue_frames} issue frames."
-            if restored_previous_results
-            else f"Stopped after {frames_scanned} scanned frames. Kept {total_issue_frames} issue frames found so far."
-        )
         common_widget_actions.create_and_show_toast_message(
             main_window,
             "Scan Aborted",
-            cancelled_message,
+            f"Stopped after {frames_scanned} scanned frames. Kept {total_issue_frames} issue frames from this scan attempt.",
             style_type="warning",
         )
     elif total_issue_frames:
@@ -1301,35 +1276,36 @@ def _handle_issue_scan_completed(
 
 
 def _handle_issue_scan_cancelled(main_window: "MainWindow"):
-    state = _get_issue_scan_ui_state(main_window)
-    restored_previous_results = False
-    if int(state.get("frames_scanned", 0)) <= 0:
-        _restore_previous_issue_scan_results(main_window)
-        restored_previous_results = True
-    _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)
+    _restore_issue_scan_ui(main_window)
+    current_issue_frames = sum(
+        len(set(frames))
+        for frames in getattr(main_window, "issue_frames_by_face", {}).values()
+    )
     common_widget_actions.create_and_show_toast_message(
         main_window,
         "Scan Cancelled",
-        (
-            "Issue scan aborted before finalizing. Restored the previous issue findings."
-            if restored_previous_results
-            else "Issue scan aborted before finalizing. Kept any issue frames found so far."
-        ),
+        f"Issue scan aborted before finalizing. Kept {current_issue_frames} issue frames from this scan attempt.",
         style_type="warning",
     )
 
 
 def _handle_issue_scan_failed(main_window: "MainWindow", error_message: str):
     state = _get_issue_scan_ui_state(main_window)
-    if int(state.get("frames_scanned", 0)) <= 0:
-        _restore_previous_issue_scan_results(main_window)
-    _restore_issue_scan_ui(main_window)
+    active_scan = bool(state.get("active", False))
     _cleanup_issue_scan_worker(main_window)
+    _restore_issue_scan_ui(main_window)
+    message = error_message
+    if active_scan:
+        message = (
+            f"{error_message}\n\n"
+            "Any previous issue findings were cleared when this scan started. "
+            "Only findings from the current scan attempt remain visible."
+        )
     common_widget_actions.create_and_show_messagebox(
         main_window,
         "Scan Failed",
-        error_message,
+        message,
         main_window.runScanButton,
     )
 
@@ -1367,14 +1343,15 @@ def run_issue_scan(main_window: "MainWindow"):
     if was_processing:
         print("[INFO] Stopped active processing before running issue scan.")
 
-    worker = ui_workers.IssueScanWorker(main_window)
+    try:
+        worker = ui_workers.IssueScanWorker(main_window)
+    except Exception as exc:
+        _handle_issue_scan_failed(main_window, str(exc))
+        return
     main_window.scan_issue_worker = worker
     scope_text = worker._scan_scope_text
-    previous_issue_frames_by_face = _copy_issue_frames_by_face(
-        getattr(main_window, "issue_frames_by_face", {})
-    )
     set_issue_frames_by_face(main_window, {})
-    _start_issue_scan_ui(main_window, worker, scope_text, previous_issue_frames_by_face)
+    _start_issue_scan_ui(main_window, worker, scope_text)
     worker.progress.connect(
         lambda processed, total, frame_number, scan_fps: _handle_issue_scan_progress(
             main_window, scope_text, processed, total, frame_number, scan_fps

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -755,10 +755,11 @@ def update_scan_review_button_states(main_window: "MainWindow"):
     has_selected_face = (
         getattr(main_window, "selected_target_face_id", None) is not None
     )
+    scan_active = is_issue_scan_active(main_window)
 
     scan_button = getattr(main_window, "runScanButton", None)
     if scan_button is not None:
-        scan_button.setEnabled(has_target_faces)
+        scan_button.setEnabled(True if scan_active else has_target_faces)
 
     for button_name in (
         "runScanButton",
@@ -770,7 +771,7 @@ def update_scan_review_button_states(main_window: "MainWindow"):
         if button is not None:
             if button_name == "runScanButton":
                 continue
-            button.setEnabled(has_selected_face)
+            button.setEnabled(has_selected_face and not scan_active)
 
 
 def _set_slider_marker_values(
@@ -1120,6 +1121,7 @@ def _start_issue_scan_ui(
                 if previous_issue_frames_by_face is not None
                 else getattr(main_window, "issue_frames_by_face", {})
             ),
+            "frames_scanned": 0,
             "has_partial_results": False,
         }
     )
@@ -1213,6 +1215,7 @@ def _handle_issue_scan_progress(
     frame_number: int,
     scan_fps: float,
 ):
+    _get_issue_scan_ui_state(main_window)["frames_scanned"] = int(processed)
     _set_slider_frame_without_side_effects(main_window, frame_number)
     run_button = getattr(main_window, "runScanButton", None)
     if run_button is not None:
@@ -1232,6 +1235,7 @@ def _cleanup_issue_scan_worker(main_window: "MainWindow"):
     if worker is not None:
         worker.deleteLater()
         main_window.scan_issue_worker = None
+    update_scan_review_button_states(main_window)
 
 
 def _handle_issue_scan_completed(
@@ -1244,6 +1248,8 @@ def _handle_issue_scan_completed(
     cancelled: bool = False,
 ):
     state = _get_issue_scan_ui_state(main_window)
+    frames_scanned_recorded = int(state.get("frames_scanned", 0))
+    scan_made_progress = max(frames_scanned_recorded, int(frames_scanned)) > 0
     partial_results_visible = bool(state.get("has_partial_results", False))
     partial_results_visible = partial_results_visible or any(
         bool(frames) for frames in issue_frames_by_face.values()
@@ -1251,7 +1257,7 @@ def _handle_issue_scan_completed(
     restored_previous_results = False
     restored_issue_frames = 0
 
-    if cancelled and not partial_results_visible:
+    if cancelled and not scan_made_progress:
         restored_previous_results = True
         restored_issue_frames = _restore_previous_issue_scan_results(main_window)
     else:
@@ -1297,7 +1303,7 @@ def _handle_issue_scan_completed(
 def _handle_issue_scan_cancelled(main_window: "MainWindow"):
     state = _get_issue_scan_ui_state(main_window)
     restored_previous_results = False
-    if not state.get("has_partial_results", False):
+    if int(state.get("frames_scanned", 0)) <= 0:
         _restore_previous_issue_scan_results(main_window)
         restored_previous_results = True
     _restore_issue_scan_ui(main_window)
@@ -1316,7 +1322,7 @@ def _handle_issue_scan_cancelled(main_window: "MainWindow"):
 
 def _handle_issue_scan_failed(main_window: "MainWindow", error_message: str):
     state = _get_issue_scan_ui_state(main_window)
-    if not state.get("has_partial_results", False):
+    if int(state.get("frames_scanned", 0)) <= 0:
         _restore_previous_issue_scan_results(main_window)
     _restore_issue_scan_ui(main_window)
     _cleanup_issue_scan_worker(main_window)

--- a/app/ui/widgets/event_filters.py
+++ b/app/ui/widgets/event_filters.py
@@ -119,6 +119,11 @@ class ListWidgetEventFilter(QtCore.QObject):
             # Handle the drop event
             elif event.type() == QtCore.QEvent.Type.Drop:
                 if event.mimeData().hasUrls():
+                    if video_control_actions.block_if_issue_scan_active(
+                        self.main_window, "change target media"
+                    ):
+                        event.ignore()
+                        return True
                     # Extract file paths
                     file_paths = []
                     for url in event.mimeData().urls():
@@ -171,6 +176,11 @@ class ListWidgetEventFilter(QtCore.QObject):
             # Handle the drop event
             elif event.type() == QtCore.QEvent.Type.Drop:
                 if event.mimeData().hasUrls():
+                    if video_control_actions.block_if_issue_scan_active(
+                        self.main_window, "load input faces"
+                    ):
+                        event.ignore()
+                        return True
                     # Extract file paths
                     file_paths = []
                     for url in event.mimeData().urls():

--- a/app/ui/widgets/event_filters.py
+++ b/app/ui/widgets/event_filters.py
@@ -34,6 +34,8 @@ class videoSeekSliderLineEditEventFilter(QtCore.QObject):
         if event.type() == QtCore.QEvent.KeyPress:
             # Check if the pressed key is Enter/Return
             if event.key() in (QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return):
+                if video_control_actions.is_issue_scan_active(self.main_window):
+                    return True
                 new_value = line_edit.text()
                 # Reset the line edit value to the slider value if the user input an empty text
                 if new_value == "":

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -187,14 +187,6 @@ class IssueScanWorker(qtc.QThread):
             for widget_name, widget in main_window.parameter_widgets.items()
             if widget_name in main_window.control
         }
-        self._target_faces_snapshot = (
-            main_window.video_processor.prepare_issue_scan_target_faces_snapshot(
-                self._scan_ranges,
-                self._base_control,
-                self._base_params,
-                self._control_defaults_snapshot,
-            )
-        )
         self._reset_frame_number = int(main_window.videoSeekSlider.value())
 
     def cancel(self):
@@ -202,6 +194,20 @@ class IssueScanWorker(qtc.QThread):
 
     def run(self):
         try:
+            if self._cancel_event.is_set():
+                self.cancelled.emit()
+                return
+
+            target_faces_snapshot = self.main_window.video_processor.prepare_issue_scan_target_faces_snapshot(
+                self._scan_ranges,
+                self._base_control,
+                self._base_params,
+                self._control_defaults_snapshot,
+            )
+            if self._cancel_event.is_set():
+                self.cancelled.emit()
+                return
+
             start_time = time.monotonic()
 
             def progress_with_fps(
@@ -222,7 +228,7 @@ class IssueScanWorker(qtc.QThread):
                 target_height=self._target_height,
                 base_control=self._base_control,
                 base_params=self._base_params,
-                target_faces_snapshot=self._target_faces_snapshot,
+                target_faces_snapshot=target_faces_snapshot,
                 control_defaults_snapshot=self._control_defaults_snapshot,
                 reset_frame_number=self._reset_frame_number,
             )

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -187,6 +187,14 @@ class IssueScanWorker(qtc.QThread):
             for widget_name, widget in main_window.parameter_widgets.items()
             if widget_name in main_window.control
         }
+        self._target_faces_snapshot = (
+            main_window.video_processor.prepare_issue_scan_target_faces_snapshot(
+                self._scan_ranges,
+                self._base_control,
+                self._base_params,
+                self._control_defaults_snapshot,
+            )
+        )
         self._reset_frame_number = int(main_window.videoSeekSlider.value())
 
     def cancel(self):
@@ -198,12 +206,6 @@ class IssueScanWorker(qtc.QThread):
                 self.cancelled.emit()
                 return
 
-            target_faces_snapshot = self.main_window.video_processor.prepare_issue_scan_target_faces_snapshot(
-                self._scan_ranges,
-                self._base_control,
-                self._base_params,
-                self._control_defaults_snapshot,
-            )
             if self._cancel_event.is_set():
                 self.cancelled.emit()
                 return
@@ -228,7 +230,7 @@ class IssueScanWorker(qtc.QThread):
                 target_height=self._target_height,
                 base_control=self._base_control,
                 base_params=self._base_params,
-                target_faces_snapshot=target_faces_snapshot,
+                target_faces_snapshot=self._target_faces_snapshot,
                 control_defaults_snapshot=self._control_defaults_snapshot,
                 reset_frame_number=self._reset_frame_number,
             )

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -33,6 +33,11 @@ class CardButton(QPushButton):
         self.list_item = None
         self.list_widget: QtWidgets.QListWidget = None
 
+    def _restore_pre_click_checked_state(self):
+        self.blockSignals(True)
+        self.setChecked(not self.isChecked())
+        self.blockSignals(False)
+
     def get_item_position(self):
         for i in range(self.list_widget.count() - 1, -1, -1):
             list_item = self.list_widget.item(i)
@@ -172,6 +177,12 @@ class TargetMediaCardButton(CardButton):
 
     def load_media(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "change target media"
+        ):
+            self._restore_pre_click_checked_state()
+            return
+
         # Deselect the currently selected video
         if main_window.selected_video_button:
             main_window.selected_video_button.toggle()  # Deselect the previous video
@@ -304,6 +315,11 @@ class TargetMediaCardButton(CardButton):
         # list_view_actions.find_target_faces(main_window)
 
     def deselect_currently_selected_video(self, main_window):
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "deselect the current media"
+        ):
+            return
+
         # Deselect the currently selected video
         if main_window.selected_video_button == self:
             self.reset_media_state()
@@ -355,11 +371,19 @@ class TargetMediaCardButton(CardButton):
 
     def remove_target_media_from_list(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "remove target media"
+        ):
+            return
         self.deselect_currently_selected_video(main_window)
         self.deleteLater()
 
     def delete_target_media_to_trash(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "delete target media"
+        ):
+            return
         self.deselect_currently_selected_video(main_window)
 
         # Send the file to the trash
@@ -396,20 +420,23 @@ class TargetMediaCardButton(CardButton):
 
     def create_context_menu(self):
         self.popMenu = QtWidgets.QMenu(self)
-        remove_action = QtGui.QAction("Remove from list", self)
-        remove_action.triggered.connect(self.remove_target_media_from_list)
-        self.popMenu.addAction(remove_action)
+        self.remove_action = QtGui.QAction("Remove from list", self)
+        self.remove_action.triggered.connect(self.remove_target_media_from_list)
+        self.popMenu.addAction(self.remove_action)
 
-        delete_action = QtGui.QAction("Delete file to recycle bin", self)
-        delete_action.triggered.connect(self.delete_target_media_to_trash)
-        self.popMenu.addAction(delete_action)
+        self.delete_action = QtGui.QAction("Delete file to recycle bin", self)
+        self.delete_action.triggered.connect(self.delete_target_media_to_trash)
+        self.popMenu.addAction(self.delete_action)
 
-        open_path_action = QtGui.QAction("Open file location", self)
-        open_path_action.triggered.connect(self.open_target_path_by_explorer)
-        self.popMenu.addAction(open_path_action)
+        self.open_path_action = QtGui.QAction("Open file location", self)
+        self.open_path_action.triggered.connect(self.open_target_path_by_explorer)
+        self.popMenu.addAction(self.open_path_action)
 
     def on_context_menu(self, point):
         # show context menu
+        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+        self.remove_action.setEnabled(not scan_active)
+        self.delete_action.setEnabled(not scan_active)
         self.popMenu.exec_(self.mapToGlobal(point))
 
 
@@ -803,32 +830,32 @@ class TargetFaceCardButton(CardButton):
     def create_context_menu(self):
         # create context menu
         self.popMenu = QtWidgets.QMenu(self)
-        parameters_copy_action = QtGui.QAction("Copy Parameters", self)
-        parameters_copy_action.triggered.connect(self.copy_parameters)
-        parameters_paste_action = QtGui.QAction("Apply Copied Parameters", self)
-        parameters_paste_action.triggered.connect(self.paste_and_apply_parameters)
-        save_parameters_action = QtGui.QAction(
+        self.parameters_copy_action = QtGui.QAction("Copy Parameters", self)
+        self.parameters_copy_action.triggered.connect(self.copy_parameters)
+        self.parameters_paste_action = QtGui.QAction("Apply Copied Parameters", self)
+        self.parameters_paste_action.triggered.connect(self.paste_and_apply_parameters)
+        self.save_parameters_action = QtGui.QAction(
             "Save Current Parameters and Settings", self
         )
-        save_parameters_action.triggered.connect(
+        self.save_parameters_action.triggered.connect(
             partial(
                 save_load_actions.save_current_parameters_and_control,
                 self.main_window,
                 self.face_id,
             )
         )
-        load_parameters_action = QtGui.QAction("Load Parameters", self)
-        load_parameters_action.triggered.connect(
+        self.load_parameters_action = QtGui.QAction("Load Parameters", self)
+        self.load_parameters_action.triggered.connect(
             partial(
                 save_load_actions.load_parameters_and_settings,
                 self.main_window,
                 self.face_id,
             )
         )
-        load_parameters_and_settings_action = QtGui.QAction(
+        self.load_parameters_and_settings_action = QtGui.QAction(
             "Load Parameters and Settings", self
         )
-        load_parameters_and_settings_action.triggered.connect(
+        self.load_parameters_and_settings_action.triggered.connect(
             partial(
                 save_load_actions.load_parameters_and_settings,
                 self.main_window,
@@ -836,21 +863,30 @@ class TargetFaceCardButton(CardButton):
                 True,
             )
         )
-        remove_action = QtGui.QAction("Remove from List", self)
-        remove_action.triggered.connect(self.remove_target_face_from_list)
-        self.popMenu.addAction(parameters_copy_action)
-        self.popMenu.addAction(parameters_paste_action)
-        self.popMenu.addAction(save_parameters_action)
-        self.popMenu.addAction(load_parameters_action)
-        self.popMenu.addAction(load_parameters_and_settings_action)
-        self.popMenu.addAction(remove_action)
+        self.remove_action = QtGui.QAction("Remove from List", self)
+        self.remove_action.triggered.connect(self.remove_target_face_from_list)
+        self.popMenu.addAction(self.parameters_copy_action)
+        self.popMenu.addAction(self.parameters_paste_action)
+        self.popMenu.addAction(self.save_parameters_action)
+        self.popMenu.addAction(self.load_parameters_action)
+        self.popMenu.addAction(self.load_parameters_and_settings_action)
+        self.popMenu.addAction(self.remove_action)
 
     def on_context_menu(self, point):
         # show context menu
+        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+        self.parameters_paste_action.setEnabled(not scan_active)
+        self.load_parameters_action.setEnabled(not scan_active)
+        self.load_parameters_and_settings_action.setEnabled(not scan_active)
+        self.remove_action.setEnabled(not scan_active)
         self.popMenu.exec_(self.mapToGlobal(point))
 
     def remove_target_face_from_list(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "remove a target face"
+        ):
+            return
 
         if main_window.video_processor.processing:
             main_window.video_processor.stop_processing()
@@ -952,6 +988,11 @@ class InputFaceCardButton(CardButton):
 
     def load_input_face(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "change input-face assignments"
+        ):
+            self._restore_pre_click_checked_state()
+            return
 
         if main_window.cur_selected_target_face_button:
             cur_selected_target_face_button = (
@@ -1076,6 +1117,10 @@ class InputFaceCardButton(CardButton):
 
     def remove_input_face_from_list(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "remove input faces"
+        ):
+            return
         faces_to_remove = [
             face_button
             for _, face_button in main_window.input_faces.items()
@@ -1101,6 +1146,10 @@ class InputFaceCardButton(CardButton):
 
     def delete_input_face_to_trash(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "delete input faces"
+        ):
+            return
         self.remove_kv_data_file()
         self._remove_face_from_lists()
 
@@ -1143,29 +1192,40 @@ class InputFaceCardButton(CardButton):
     def create_context_menu(self):
         # create context menu
         self.popMenu = QtWidgets.QMenu(self)
-        create_embed_action = QtGui.QAction(
+        self.create_embed_action = QtGui.QAction(
             "Create embedding from selected faces", self
         )
-        create_embed_action.triggered.connect(self.create_embedding_from_selected_faces)
-        self.popMenu.addAction(create_embed_action)
+        self.create_embed_action.triggered.connect(
+            self.create_embedding_from_selected_faces
+        )
+        self.popMenu.addAction(self.create_embed_action)
 
-        remove_action = QtGui.QAction("Remove from list", self)
-        remove_action.triggered.connect(self.remove_input_face_from_list)
-        self.popMenu.addAction(remove_action)
+        self.remove_action = QtGui.QAction("Remove from list", self)
+        self.remove_action.triggered.connect(self.remove_input_face_from_list)
+        self.popMenu.addAction(self.remove_action)
 
-        delete_action = QtGui.QAction("Delete file to recycle bin", self)
-        delete_action.triggered.connect(self.delete_input_face_to_trash)
-        self.popMenu.addAction(delete_action)
+        self.delete_action = QtGui.QAction("Delete file to recycle bin", self)
+        self.delete_action.triggered.connect(self.delete_input_face_to_trash)
+        self.popMenu.addAction(self.delete_action)
 
-        open_path_action = QtGui.QAction("Open file location", self)
-        open_path_action.triggered.connect(self.open_target_path_by_explorer)
-        self.popMenu.addAction(open_path_action)
+        self.open_path_action = QtGui.QAction("Open file location", self)
+        self.open_path_action.triggered.connect(self.open_target_path_by_explorer)
+        self.popMenu.addAction(self.open_path_action)
 
     def on_context_menu(self, point):
         # show context menu
+        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+        self.create_embed_action.setEnabled(not scan_active)
+        self.remove_action.setEnabled(not scan_active)
+        self.delete_action.setEnabled(not scan_active)
         self.popMenu.exec_(self.mapToGlobal(point))
 
     def create_embedding_from_selected_faces(self):
+        if video_control_actions.block_if_issue_scan_active(
+            self.main_window, "create embeddings"
+        ):
+            return
+
         # Raccogli l'intero embedding_store dalle facce selezionate
         selected_faces_embeddings_store = [
             input_face.embedding_store
@@ -1224,6 +1284,12 @@ class EmbeddingCardButton(CardButton):
 
     def load_embedding(self):
         main_window = self.main_window
+        if video_control_actions.block_if_issue_scan_active(
+            main_window, "change merged-embedding assignments"
+        ):
+            self._restore_pre_click_checked_state()
+            return
+
         if main_window.cur_selected_target_face_button:
             cur_selected_target_face_button = (
                 main_window.cur_selected_target_face_button
@@ -1264,15 +1330,23 @@ class EmbeddingCardButton(CardButton):
     def create_context_menu(self):
         # create context menu
         self.popMenu = QtWidgets.QMenu(self)
-        remove_action = QtGui.QAction("Remove Embedding", self)
-        remove_action.triggered.connect(self.remove_embedding_from_list)
-        self.popMenu.addAction(remove_action)
+        self.remove_action = QtGui.QAction("Remove Embedding", self)
+        self.remove_action.triggered.connect(self.remove_embedding_from_list)
+        self.popMenu.addAction(self.remove_action)
 
     def on_context_menu(self, point):
         # show context menu
+        self.remove_action.setEnabled(
+            not video_control_actions.is_issue_scan_active(self.main_window)
+        )
         self.popMenu.exec_(self.mapToGlobal(point))
 
     def remove_embedding_from_list(self):
+        if video_control_actions.block_if_issue_scan_active(
+            self.main_window, "remove embeddings"
+        ):
+            return
+
         main_window = self.main_window
         for i in range(main_window.inputEmbeddingsList.count() - 1, -1, -1):
             list_item = main_window.inputEmbeddingsList.item(i)

--- a/tests/unit/processors/test_frame_worker_vr.py
+++ b/tests/unit/processors/test_frame_worker_vr.py
@@ -7,6 +7,7 @@ decision logic without loading any ML models or requiring a GPU.
 
 from __future__ import annotations
 
+import importlib
 import sys
 import threading
 from unittest.mock import MagicMock, patch
@@ -74,13 +75,65 @@ _STUBS = [
     # paths (empty detections) that never call get_scaling_transforms etc., so no
     # module-level patches to that module are required.
 ]
-for _s in _STUBS:
-    if _s not in sys.modules:
-        sys.modules[_s] = _stub(_s)
 
-# Stub FrameEnhancers / FrameEdits constructors
-sys.modules["app.processors.frame_enhancers"].FrameEnhancers = MagicMock  # type: ignore[attr-defined]
-sys.modules["app.processors.frame_edits"].FrameEdits = MagicMock  # type: ignore[attr-defined]
+
+def _load_frame_worker_module():
+    saved_modules = {name: sys.modules.get(name) for name in _STUBS}
+    saved_modules["app.processors.workers.frame_worker"] = sys.modules.pop(
+        "app.processors.workers.frame_worker", None
+    )
+    saved_package_attrs: dict[tuple[str, str], tuple[bool, object | None]] = {}
+
+    for module_name in [*_STUBS, "app.processors.workers.frame_worker"]:
+        parent_name, _, attr_name = module_name.rpartition(".")
+        if not parent_name:
+            continue
+        parent_module = sys.modules.get(parent_name)
+        had_attr = parent_module is not None and hasattr(parent_module, attr_name)
+        saved_package_attrs[(parent_name, attr_name)] = (
+            had_attr,
+            getattr(parent_module, attr_name) if had_attr else None,
+        )
+
+    try:
+        for stub_name in _STUBS:
+            sys.modules[stub_name] = _stub(stub_name)
+
+        for module_name in _STUBS:
+            parent_name, _, attr_name = module_name.rpartition(".")
+            parent_module = sys.modules.get(parent_name)
+            if parent_module is not None and attr_name:
+                setattr(parent_module, attr_name, sys.modules[module_name])
+
+        # Stub FrameEnhancers / FrameEdits constructors before importing the worker.
+        sys.modules["app.processors.frame_enhancers"].FrameEnhancers = MagicMock()  # type: ignore[attr-defined]
+        sys.modules["app.processors.frame_edits"].FrameEdits = MagicMock()  # type: ignore[attr-defined]
+
+        module = importlib.import_module("app.processors.workers.frame_worker")
+    finally:
+        for name, original_module in saved_modules.items():
+            if original_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original_module
+
+        for (parent_name, attr_name), (
+            had_attr,
+            original_value,
+        ) in saved_package_attrs.items():
+            parent_module = sys.modules.get(parent_name)
+            if parent_module is None:
+                continue
+            if had_attr:
+                setattr(parent_module, attr_name, original_value)
+            elif hasattr(parent_module, attr_name):
+                delattr(parent_module, attr_name)
+
+    return module
+
+
+frame_worker_module = _load_frame_worker_module()
+FrameWorker = frame_worker_module.FrameWorker
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -128,8 +181,6 @@ def _make_worker(main_window):
         patch("app.helpers.vr_utils.E2P_Equirectangular", MagicMock()),
         patch("app.helpers.vr_utils.P2E_Perspective", MagicMock()),
     ):
-        from app.processors.workers.frame_worker import FrameWorker
-
         worker = FrameWorker.__new__(FrameWorker)
         # Must call Thread.__init__ so the .name property setter works
         threading.Thread.__init__(worker)
@@ -308,8 +359,9 @@ def test_empty_bboxes_returns_original(mock_main_window, small_equirect):
         mock_ec.height = small_equirect.shape[0]
         mock_ec.width = small_equirect.shape[1]
 
-        with patch(
-            "app.processors.workers.frame_worker.EquirectangularConverter",
+        with patch.object(
+            frame_worker_module,
+            "EquirectangularConverter",
             return_value=mock_ec,
         ):
             result = worker._process_frame_vr180(
@@ -358,13 +410,12 @@ def test_no_crops_skips_perspective_converter(mock_main_window, small_equirect):
         worker = _make_worker(mock_main_window)
 
         with (
-            patch(
-                "app.processors.workers.frame_worker.EquirectangularConverter",
+            patch.object(
+                frame_worker_module,
+                "EquirectangularConverter",
                 return_value=mock_ec,
             ),
-            patch(
-                "app.processors.workers.frame_worker.PerspectiveConverter"
-            ) as mock_pc_cls,
+            patch.object(frame_worker_module, "PerspectiveConverter") as mock_pc_cls,
         ):
             worker._process_frame_vr180(
                 img_numpy_rgb_uint8=small_equirect,
@@ -458,8 +509,12 @@ def test_ghostface_models_frozenset():
         patch("app.helpers.vr_utils.E2P_Equirectangular", MagicMock()),
         patch("app.helpers.vr_utils.P2E_Perspective", MagicMock()),
     ):
-        from app.processors.workers.frame_worker import FrameWorker
-
         expected = {"GhostFace-v1", "GhostFace-v2", "GhostFace-v3"}
         assert FrameWorker.GHOSTFACE_MODELS == expected
         assert isinstance(FrameWorker.GHOSTFACE_MODELS, frozenset)
+
+
+def test_frame_worker_import_restores_stubbed_sys_modules():
+    assert not isinstance(
+        sys.modules.get("app.ui.widgets.actions.common_actions"), MagicMock
+    )

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -23,6 +23,15 @@ class _DummyTargetFace:
         return self._embeddings.get(recognition_model)
 
 
+def _empty_scan_detection_result():
+    return (
+        np.empty((0, 4), dtype=np.float32),
+        np.empty((0, 5, 2), dtype=np.float32),
+        np.empty((0, 68, 2), dtype=np.float32),
+        np.empty((0, 203, 2), dtype=np.float32),
+    )
+
+
 def _make_target_snapshot(face_id, embeddings_by_model=None):
     return {
         str(face_id): {
@@ -41,6 +50,7 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
     processor.last_detected_faces = [{"id": 1}]
     processor._smoothed_kps = {1: np.array([[1.0, 2.0]], dtype=np.float32)}
     processor._smoothed_dense_kps = {1: np.array([[3.0, 4.0]], dtype=np.float32)}
+    processor._smoothed_dense_kps_203 = {1: np.array([[5.0, 6.0]], dtype=np.float32)}
     processor.last_detected_faces = [{"id": 1}]
     processor.main_window = SimpleNamespace(
         control={},
@@ -78,6 +88,10 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
     )
     np.testing.assert_array_equal(
         processor._smoothed_kps[1], np.array([[1.0, 2.0]], dtype=np.float32)
+    )
+    np.testing.assert_array_equal(
+        processor._smoothed_dense_kps_203[1],
+        np.array([[5.0, 6.0]], dtype=np.float32),
     )
     assert processor.last_detected_faces == [{"id": 1}]
     assert processor.current_frame_number == 3
@@ -365,12 +379,7 @@ def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
         patch.object(
             processor,
             "_run_sequential_detection",
-            return_value=(
-                np.empty((0, 4), dtype=np.float32),
-                np.empty((0, 5, 2), dtype=np.float32),
-                np.empty((0, 68, 2), dtype=np.float32),
-                None,
-            ),
+            return_value=_empty_scan_detection_result(),
         ),
     ):
         result = processor.scan_issue_frames(
@@ -469,12 +478,7 @@ def test_scan_issue_frames_emits_incremental_issue_callback():
         patch.object(
             processor,
             "_run_sequential_detection",
-            return_value=(
-                np.empty((0, 4), dtype=np.float32),
-                np.empty((0, 5, 2), dtype=np.float32),
-                np.empty((0, 68, 2), dtype=np.float32),
-                None,
-            ),
+            return_value=_empty_scan_detection_result(),
         ),
     ):
         result = processor.scan_issue_frames(
@@ -553,12 +557,7 @@ def test_scan_issue_frames_returns_partial_results_on_cancel():
         patch.object(
             processor,
             "_run_sequential_detection",
-            return_value=(
-                np.empty((0, 4), dtype=np.float32),
-                np.empty((0, 5, 2), dtype=np.float32),
-                np.empty((0, 68, 2), dtype=np.float32),
-                None,
-            ),
+            return_value=_empty_scan_detection_result(),
         ),
     ):
         result = processor.scan_issue_frames(
@@ -680,6 +679,7 @@ def test_scan_issue_frames_resets_tracker_when_marker_segment_enables_tracking()
         target_faces={},
         dropped_frames=set(),
         markers={},
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
         videoSeekSlider=SimpleNamespace(value=lambda: 0),
         default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
         models_processor=SimpleNamespace(
@@ -722,12 +722,7 @@ def test_scan_issue_frames_resets_tracker_when_marker_segment_enables_tracking()
         patch.object(
             processor,
             "_run_sequential_detection",
-            return_value=(
-                np.empty((0, 4), dtype=np.float32),
-                np.empty((0, 5, 2), dtype=np.float32),
-                np.empty((0, 68, 2), dtype=np.float32),
-                None,
-            ),
+            return_value=_empty_scan_detection_result(),
         ),
     ):
         result = processor.scan_issue_frames(
@@ -765,6 +760,7 @@ def test_scan_issue_frames_resets_tracker_when_tracking_re_enters_after_disabled
         target_faces={},
         dropped_frames=set(),
         markers={},
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
         videoSeekSlider=SimpleNamespace(value=lambda: 0),
         default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
         models_processor=SimpleNamespace(
@@ -808,12 +804,7 @@ def test_scan_issue_frames_resets_tracker_when_tracking_re_enters_after_disabled
         patch.object(
             processor,
             "_run_sequential_detection",
-            return_value=(
-                np.empty((0, 4), dtype=np.float32),
-                np.empty((0, 5, 2), dtype=np.float32),
-                np.empty((0, 68, 2), dtype=np.float32),
-                None,
-            ),
+            return_value=_empty_scan_detection_result(),
         ),
     ):
         result = processor.scan_issue_frames(
@@ -842,6 +833,7 @@ def test_scan_issue_frames_clears_sequential_state_when_tracking_re_enters():
     processor.last_detected_faces = [{"persisted": True}]
     processor._smoothed_kps = {1: np.array([[1.0, 2.0]], dtype=np.float32)}
     processor._smoothed_dense_kps = {1: np.array([[3.0, 4.0]], dtype=np.float32)}
+    processor._smoothed_dense_kps_203 = {1: np.array([[5.0, 6.0]], dtype=np.float32)}
     reset_state_snapshots = []
     frame = np.zeros((4, 4, 3), dtype=np.uint8)
 
@@ -851,6 +843,7 @@ def test_scan_issue_frames_clears_sequential_state_when_tracking_re_enters():
         target_faces={},
         dropped_frames=set(),
         markers={},
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
         videoSeekSlider=SimpleNamespace(value=lambda: 0),
         default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
         models_processor=SimpleNamespace(
@@ -873,6 +866,7 @@ def test_scan_issue_frames_clears_sequential_state_when_tracking_re_enters():
                 list(processor.last_detected_faces),
                 dict(processor._smoothed_kps),
                 dict(processor._smoothed_dense_kps),
+                dict(processor._smoothed_dense_kps_203),
             )
         )
         processor.last_detected_faces = [
@@ -884,12 +878,10 @@ def test_scan_issue_frames_clears_sequential_state_when_tracking_re_enters():
         processor._smoothed_dense_kps = {
             processor.current_frame_number: np.array([[8.0, 8.0]], dtype=np.float32)
         }
-        return (
-            np.empty((0, 4), dtype=np.float32),
-            np.empty((0, 5, 2), dtype=np.float32),
-            np.empty((0, 68, 2), dtype=np.float32),
-            None,
-        )
+        processor._smoothed_dense_kps_203 = {
+            processor.current_frame_number: np.array([[7.0, 7.0]], dtype=np.float32)
+        }
+        return _empty_scan_detection_result()
 
     with (
         patch(
@@ -936,5 +928,9 @@ def test_scan_issue_frames_clears_sequential_state_when_tracking_re_enters():
         "faces_with_issues": 0,
         "cancelled": False,
     }
-    assert reset_state_snapshots[0] == ([], {}, {})
-    assert reset_state_snapshots[2] == ([], {}, {})
+    assert reset_state_snapshots[0] == ([], {}, {}, {})
+    assert reset_state_snapshots[2] == ([], {}, {}, {})
+    np.testing.assert_array_equal(
+        processor._smoothed_dense_kps_203[1],
+        np.array([[5.0, 6.0]], dtype=np.float32),
+    )

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -1,14 +1,21 @@
 from types import SimpleNamespace
 
+from app.ui.widgets.actions import card_actions, job_manager_actions, list_view_actions
+from app.ui.widgets.actions import save_load_actions
 from app.ui.widgets.actions.video_control_actions import (
     _handle_issue_scan_cancelled,
     _handle_issue_scan_completed,
     _handle_issue_scan_failed,
     _handle_issue_scan_issue_found,
     _handle_issue_scan_progress,
+    add_video_slider_marker,
+    block_if_issue_scan_active,
+    is_issue_scan_active,
+    remove_all_markers,
     run_issue_scan,
     toggle_issue_scan,
 )
+from app.ui.widgets import widget_components
 from app.ui.widgets.ui_workers import IssueScanWorker
 
 
@@ -49,15 +56,28 @@ class _DummyButton:
     def setChecked(self, checked):
         self.checked = bool(checked)
 
+    def isEnabled(self):
+        return self.enabled
+
 
 class _DummySlider:
     def __init__(self, value=0):
         self._value = value
+        self.enabled = True
         self.block_calls = []
         self.updated = 0
 
     def value(self):
         return self._value
+
+    def setEnabled(self, value):
+        self.enabled = bool(value)
+
+    def setDisabled(self, value):
+        self.enabled = not bool(value)
+
+    def isEnabled(self):
+        return self.enabled
 
     def blockSignals(self, value):
         self.block_calls.append(bool(value))
@@ -114,16 +134,48 @@ def _make_scan_main_window(keep_controls=False):
     main_window = SimpleNamespace(
         control={"KeepControlsToggle": keep_controls},
         parameters={},
-        target_faces={"face_1": object()},
+        target_faces={"face_1": _DummyButton("Face 1")},
+        target_videos={"media_1": _DummyButton("Media 1")},
+        input_faces={"input_1": _DummyButton("Input 1")},
+        merged_embeddings={"embed_1": _DummyButton("Embedding 1")},
         parameter_widgets={},
         issue_frames_by_face={"face_1": {3, 5}, "face_2": {9}},
         issue_frames=set(),
         dropped_frames=set(),
         markers={},
+        job_marker_pairs=[],
         selected_target_face_id="face_1",
+        selected_video_button=SimpleNamespace(file_type="video"),
         scan_issue_worker=None,
         scan_issue_ui_state={},
         videoSeekSlider=slider,
+        targetVideosList=_DummyButton("Target Videos"),
+        inputFacesList=_DummyButton("Input Faces"),
+        inputEmbeddingsList=_DummyButton("Input Embeddings"),
+        jobQueueList=_DummyButton("Job Queue"),
+        buttonTargetVideosPath=_DummyButton("Target Path"),
+        buttonInputFacesPath=_DummyButton("Input Path"),
+        filterWebcamsCheckBox=_DummyButton("Filter Webcams"),
+        findTargetFacesButton=_DummyButton("Find Faces"),
+        clearTargetFacesButton=_DummyButton("Clear Faces"),
+        addMarkerButton=_DummyButton("Add Marker"),
+        removeMarkerButton=_DummyButton("Remove Marker"),
+        frameAdvanceButton=_DummyButton("Frame Advance"),
+        frameRewindButton=_DummyButton("Frame Rewind"),
+        nextMarkerButton=_DummyButton("Next Marker"),
+        previousMarkerButton=_DummyButton("Previous Marker"),
+        swapfacesButton=_DummyButton("Swap Faces"),
+        editFacesButton=_DummyButton("Edit Faces"),
+        openEmbeddingButton=_DummyButton("Open Embeddings"),
+        loadJobButton=_DummyButton("Load Job"),
+        buttonProcessAll=_DummyButton("Process All"),
+        buttonProcessSelected=_DummyButton("Process Selected"),
+        actionLoad_SavedWorkspace=_DummyButton("Load Workspace"),
+        actionOpen_Videos_Folder=_DummyButton("Open Videos Folder"),
+        actionOpen_Video_Files=_DummyButton("Open Video Files"),
+        actionLoad_Source_Image_Files=_DummyButton("Load Source Files"),
+        actionLoad_Source_Images_Folder=_DummyButton("Load Source Folder"),
+        actionLoad_Embeddings=_DummyButton("Load Embeddings"),
         videoSeekLineEdit=SimpleNamespace(
             text=lambda: "24", setText=lambda _text: None
         ),
@@ -207,6 +259,41 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
         (3, 3, 12, 2.0),
     ]
     assert completed == [({}, 3, 0, "Scanning 1 marked range", 2.0, False)]
+
+
+def test_issue_scan_worker_defers_target_snapshot_prep_until_run():
+    main_window = _make_worker_main_window()
+    prep_calls = []
+    captured = {}
+
+    def fake_prepare_issue_scan_target_faces_snapshot(*_args, **_kwargs):
+        prep_calls.append("prepared")
+        return {"face_1": {"face_id": "face_1", "embeddings_by_model": {}}}
+
+    def fake_scan_issue_frames(**kwargs):
+        captured["target_faces_snapshot"] = kwargs["target_faces_snapshot"]
+        return {
+            "issue_frames_by_face": {},
+            "frames_scanned": 1,
+            "faces_with_issues": 0,
+            "cancelled": False,
+        }
+
+    main_window.video_processor.prepare_issue_scan_target_faces_snapshot = (
+        fake_prepare_issue_scan_target_faces_snapshot
+    )
+    main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
+
+    worker = IssueScanWorker(main_window)
+
+    assert prep_calls == []
+
+    worker.run()
+
+    assert prep_calls == ["prepared"]
+    assert captured["target_faces_snapshot"] == {
+        "face_1": {"face_id": "face_1", "embeddings_by_model": {}}
+    }
 
 
 def test_issue_scan_worker_passes_control_defaults_snapshot():
@@ -325,6 +412,26 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
     }
 
 
+def test_issue_scan_worker_reports_prep_failures_via_failed_signal():
+    main_window = _make_worker_main_window()
+    failures = []
+
+    def fake_prepare_issue_scan_target_faces_snapshot(*_args, **_kwargs):
+        raise RuntimeError("prep boom")
+
+    main_window.video_processor.prepare_issue_scan_target_faces_snapshot = (
+        fake_prepare_issue_scan_target_faces_snapshot
+    )
+    main_window.video_processor.scan_issue_frames = lambda **_kwargs: None
+
+    worker = IssueScanWorker(main_window)
+    worker.failed.connect(failures.append)
+
+    worker.run()
+
+    assert failures == ["prep boom"]
+
+
 def test_handle_issue_scan_progress_moves_slider_and_updates_abort_button(monkeypatch):
     main_window = _make_scan_main_window()
     main_window.runScanButton.tooltip = (
@@ -404,6 +511,10 @@ def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
     assert fake_worker.started is True
     assert disabled_calls == ["disabled"]
     assert main_window.scan_issue_worker is fake_worker
+    assert main_window.scan_issue_ui_state["previous_issue_frames_by_face"] == {
+        "face_1": {3, 5},
+        "face_2": {9},
+    }
     assert main_window.runScanButton.enabled is True
     assert main_window.runScanButton.text == "Abort Scan"
     assert "processed" not in main_window.runScanButton.tooltip
@@ -412,6 +523,28 @@ def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
     assert main_window.buttonMediaPlay.enabled is False
     assert main_window.buttonMediaRecord.enabled is False
     assert main_window.scanToolsToggleButton.enabled is False
+    assert main_window.findTargetFacesButton.enabled is False
+    assert main_window.clearTargetFacesButton.enabled is False
+    assert main_window.filterWebcamsCheckBox.enabled is False
+    assert main_window.addMarkerButton.enabled is False
+    assert main_window.removeMarkerButton.enabled is False
+    assert main_window.videoSeekSlider.enabled is False
+    assert main_window.frameAdvanceButton.enabled is False
+    assert main_window.frameRewindButton.enabled is False
+    assert main_window.nextMarkerButton.enabled is False
+    assert main_window.previousMarkerButton.enabled is False
+    assert main_window.swapfacesButton.enabled is False
+    assert main_window.editFacesButton.enabled is False
+    assert main_window.openEmbeddingButton.enabled is False
+    assert main_window.buttonTargetVideosPath.enabled is False
+    assert main_window.buttonInputFacesPath.enabled is False
+    assert main_window.targetVideosList.enabled is False
+    assert main_window.inputFacesList.enabled is False
+    assert main_window.inputEmbeddingsList.enabled is False
+    assert main_window.loadJobButton.enabled is False
+    assert main_window.buttonProcessAll.enabled is False
+    assert main_window.buttonProcessSelected.enabled is False
+    assert main_window.actionLoad_SavedWorkspace.enabled is False
     assert main_window.prevIssueButton.enabled is False
     assert main_window.nextIssueButton.enabled is False
     assert main_window.dropFrameButton.enabled is False
@@ -424,6 +557,9 @@ def test_run_issue_scan_respects_keep_controls_toggle(monkeypatch):
     main_window = _make_scan_main_window(keep_controls=True)
     fake_worker = _FakeIssueScanWorker(main_window)
     disabled_calls = []
+    main_window.frameAdvanceButton.enabled = False
+    main_window.openEmbeddingButton.enabled = False
+    main_window.filterWebcamsCheckBox.enabled = False
 
     monkeypatch.setattr(
         "app.ui.widgets.actions.video_control_actions.ui_workers.IssueScanWorker",
@@ -451,6 +587,29 @@ def test_run_issue_scan_respects_keep_controls_toggle(monkeypatch):
     assert "processed" not in main_window.runScanButton.tooltip
     assert "FPS" not in main_window.runScanButton.tooltip
     assert main_window.issue_frames_by_face == {}
+    assert main_window.findTargetFacesButton.enabled is False
+    assert main_window.clearTargetFacesButton.enabled is False
+    assert main_window.filterWebcamsCheckBox.enabled is False
+    assert main_window.addMarkerButton.enabled is False
+    assert main_window.removeMarkerButton.enabled is False
+    assert main_window.videoSeekSlider.enabled is False
+    assert main_window.frameAdvanceButton.enabled is False
+    assert main_window.frameRewindButton.enabled is False
+    assert main_window.nextMarkerButton.enabled is False
+    assert main_window.previousMarkerButton.enabled is False
+    assert main_window.swapfacesButton.enabled is False
+    assert main_window.editFacesButton.enabled is False
+    assert main_window.openEmbeddingButton.enabled is False
+    assert main_window.buttonTargetVideosPath.enabled is False
+    assert main_window.buttonInputFacesPath.enabled is False
+    assert main_window.targetVideosList.enabled is False
+    assert main_window.inputFacesList.enabled is False
+    assert main_window.inputEmbeddingsList.enabled is False
+    assert main_window.loadJobButton.enabled is False
+    assert main_window.buttonProcessAll.enabled is False
+    assert main_window.buttonProcessSelected.enabled is False
+    assert main_window.actionLoad_SavedWorkspace.enabled is False
+    assert main_window.target_faces["face_1"].enabled is True
     assert main_window.prevIssueButton.enabled is False
     assert main_window.nextIssueButton.enabled is False
     assert main_window.dropFrameButton.enabled is False
@@ -520,7 +679,35 @@ def test_issue_scan_completion_restores_slider_and_ui(monkeypatch):
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": False,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "has_partial_results": True,
+        "mutation_lock_enabled_states": [
+            (main_window.findTargetFacesButton, True),
+            (main_window.clearTargetFacesButton, True),
+            (main_window.filterWebcamsCheckBox, True),
+            (main_window.videoSeekSlider, True),
+            (main_window.frameAdvanceButton, False),
+            (main_window.frameRewindButton, True),
+            (main_window.nextMarkerButton, True),
+            (main_window.previousMarkerButton, False),
+            (main_window.swapfacesButton, True),
+            (main_window.editFacesButton, False),
+            (main_window.openEmbeddingButton, False),
+            (main_window.loadJobButton, True),
+        ],
     }
+    main_window.findTargetFacesButton.enabled = False
+    main_window.clearTargetFacesButton.enabled = False
+    main_window.filterWebcamsCheckBox.enabled = False
+    main_window.videoSeekSlider.enabled = False
+    main_window.frameAdvanceButton.enabled = False
+    main_window.frameRewindButton.enabled = False
+    main_window.nextMarkerButton.enabled = False
+    main_window.previousMarkerButton.enabled = False
+    main_window.swapfacesButton.enabled = False
+    main_window.editFacesButton.enabled = False
+    main_window.openEmbeddingButton.enabled = False
+    main_window.loadJobButton.enabled = False
     main_window.videoSeekSlider.setValue(90)
     main_window.video_processor.current_frame_number = 90
 
@@ -541,6 +728,18 @@ def test_issue_scan_completion_restores_slider_and_ui(monkeypatch):
     assert fake_worker.deleted is True
     assert main_window.runScanButton.text == "Scan for Issues"
     assert main_window.buttonMediaPlay.enabled is True
+    assert main_window.findTargetFacesButton.enabled is True
+    assert main_window.clearTargetFacesButton.enabled is True
+    assert main_window.filterWebcamsCheckBox.enabled is True
+    assert main_window.videoSeekSlider.enabled is True
+    assert main_window.frameAdvanceButton.enabled is False
+    assert main_window.frameRewindButton.enabled is True
+    assert main_window.nextMarkerButton.enabled is True
+    assert main_window.previousMarkerButton.enabled is False
+    assert main_window.swapfacesButton.enabled is True
+    assert main_window.editFacesButton.enabled is False
+    assert main_window.openEmbeddingButton.enabled is False
+    assert main_window.loadJobButton.enabled is True
     assert main_window.prevIssueButton.enabled is True
     assert main_window.nextIssueButton.enabled is True
     assert main_window.dropFrameButton.enabled is True
@@ -576,6 +775,8 @@ def test_issue_scan_partial_completion_keeps_partial_results(monkeypatch):
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "has_partial_results": True,
     }
     main_window.videoSeekSlider.setValue(91)
 
@@ -628,14 +829,29 @@ def test_issue_scan_failed_restores_ui_and_shows_message(monkeypatch):
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "has_partial_results": False,
+        "mutation_lock_enabled_states": [
+            (main_window.videoSeekSlider, True),
+            (main_window.frameAdvanceButton, False),
+            (main_window.filterWebcamsCheckBox, True),
+        ],
     }
     main_window.videoSeekSlider.setValue(101)
+    main_window.issue_frames_by_face = {}
+    main_window.videoSeekSlider.enabled = False
+    main_window.frameAdvanceButton.enabled = False
+    main_window.filterWebcamsCheckBox.enabled = False
 
     _handle_issue_scan_failed(main_window, "boom")
 
     assert main_window.videoSeekSlider.value() == 24
+    assert main_window.issue_frames_by_face == {"face_1": {3, 5}, "face_2": {9}}
     assert main_window.scan_issue_worker is None
     assert fake_worker.deleted is True
+    assert main_window.videoSeekSlider.enabled is True
+    assert main_window.frameAdvanceButton.enabled is False
+    assert main_window.filterWebcamsCheckBox.enabled is True
     assert main_window.prevIssueButton.enabled is True
     assert main_window.nextIssueButton.enabled is True
     assert main_window.dropFrameButton.enabled is True
@@ -673,6 +889,8 @@ def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "has_partial_results": True,
     }
 
     _handle_issue_scan_cancelled(main_window)
@@ -682,3 +900,211 @@ def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch
     assert restore_calls == ["restored"]
     assert toast_calls[0][0][1] == "Scan Cancelled"
     assert "Kept any issue frames found so far." in toast_calls[0][0][2]
+
+
+def test_issue_scan_cancelled_completion_without_partial_results_restores_previous_findings(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    toast_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.issue_frames_by_face = {}
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "has_partial_results": False,
+    }
+
+    _handle_issue_scan_completed(
+        main_window,
+        {},
+        12,
+        0,
+        "Scanning full clip",
+        2.0,
+        True,
+    )
+
+    assert main_window.issue_frames_by_face == {"face_1": {3, 5}, "face_2": {9}}
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert restore_calls == ["restored"]
+    assert toast_calls[0][0][1] == "Scan Aborted"
+    assert "Restored the previous 3 issue frames." in toast_calls[0][0][2]
+
+
+def test_issue_scan_cancelled_without_progress_restores_previous_findings(monkeypatch):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    toast_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.issue_frames_by_face = {}
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 0,
+        "has_partial_results": False,
+        "mutation_lock_enabled_states": [
+            (main_window.nextMarkerButton, True),
+            (main_window.swapfacesButton, True),
+            (main_window.filterWebcamsCheckBox, False),
+        ],
+    }
+    main_window.nextMarkerButton.enabled = False
+    main_window.swapfacesButton.enabled = False
+    main_window.filterWebcamsCheckBox.enabled = False
+
+    _handle_issue_scan_cancelled(main_window)
+
+    assert main_window.issue_frames_by_face == {"face_1": {3, 5}, "face_2": {9}}
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert main_window.nextMarkerButton.enabled is True
+    assert main_window.swapfacesButton.enabled is True
+    assert main_window.filterWebcamsCheckBox.enabled is False
+    assert restore_calls == ["restored"]
+    assert toast_calls[0][0][1] == "Scan Cancelled"
+    assert "Restored the previous issue findings." in toast_calls[0][0][2]
+
+
+def test_issue_scan_cancelled_after_progress_keeps_current_results(monkeypatch):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    toast_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.issue_frames_by_face = {}
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 6,
+        "has_partial_results": False,
+    }
+
+    _handle_issue_scan_cancelled(main_window)
+
+    assert main_window.issue_frames_by_face == {}
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert restore_calls == ["restored"]
+    assert toast_calls[0][0][1] == "Scan Cancelled"
+    assert "Kept any issue frames found so far." in toast_calls[0][0][2]
+
+
+def test_issue_scan_guard_helpers_block_structural_mutations(monkeypatch):
+    main_window = _make_scan_main_window(keep_controls=True)
+    main_window.scan_issue_worker = object()
+    toast_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.card_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.job_manager_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+
+    assert is_issue_scan_active(main_window) is True
+    assert block_if_issue_scan_active(main_window, "load a workspace") is True
+
+    original_target_videos = dict(main_window.target_videos)
+    original_input_faces = dict(main_window.input_faces)
+    original_embeddings = dict(main_window.merged_embeddings)
+
+    card_actions.find_target_faces(main_window)
+    list_view_actions.select_target_medias(
+        main_window, "files", files_list=["clip.mp4"]
+    )
+    save_load_actions.load_saved_workspace(main_window, "workspace.json")
+    job_manager_actions.load_job(main_window)
+    add_video_slider_marker(main_window)
+    remove_all_markers(main_window)
+
+    widget_components.TargetMediaCardButton.load_media(
+        SimpleNamespace(
+            main_window=main_window,
+            blockSignals=lambda *_args: None,
+            setChecked=lambda *_args: None,
+        )
+    )
+    widget_components.TargetFaceCardButton.remove_target_face_from_list(
+        SimpleNamespace(main_window=main_window)
+    )
+    widget_components.InputFaceCardButton.load_input_face(
+        SimpleNamespace(
+            main_window=main_window,
+            blockSignals=lambda *_args: None,
+            setChecked=lambda *_args: None,
+        )
+    )
+    widget_components.EmbeddingCardButton.load_embedding(
+        SimpleNamespace(
+            main_window=main_window,
+            blockSignals=lambda *_args: None,
+            setChecked=lambda *_args: None,
+        )
+    )
+
+    assert main_window.target_videos == original_target_videos
+    assert main_window.input_faces == original_input_faces
+    assert main_window.merged_embeddings == original_embeddings
+    assert toast_calls

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from app.ui.widgets.actions import common_actions
 from app.ui.widgets.actions import card_actions, job_manager_actions, list_view_actions
 from app.ui.widgets.actions import save_load_actions
+from app.ui.widgets import event_filters
 from app.ui.widgets.actions.video_control_actions import (
     _handle_issue_scan_cancelled,
     _handle_issue_scan_completed,
@@ -93,6 +94,31 @@ class _DummySlider:
 
     def update(self):
         self.updated += 1
+
+
+class _DummyLineEdit:
+    def __init__(self, text=""):
+        self._text = str(text)
+        self.enabled = True
+        self.block_calls = []
+
+    def text(self):
+        return self._text
+
+    def setText(self, text):
+        self._text = str(text)
+
+    def setEnabled(self, value):
+        self.enabled = bool(value)
+
+    def setDisabled(self, value):
+        self.enabled = not bool(value)
+
+    def isEnabled(self):
+        return self.enabled
+
+    def blockSignals(self, value):
+        self.block_calls.append(bool(value))
 
 
 def _make_guarded_card(main_window, checked=False):
@@ -191,9 +217,7 @@ def _make_scan_main_window(keep_controls=False):
         actionLoad_Source_Image_Files=_DummyButton("Load Source Files"),
         actionLoad_Source_Images_Folder=_DummyButton("Load Source Folder"),
         actionLoad_Embeddings=_DummyButton("Load Embeddings"),
-        videoSeekLineEdit=SimpleNamespace(
-            text=lambda: "24", setText=lambda _text: None
-        ),
+        videoSeekLineEdit=_DummyLineEdit("24"),
         graphicsViewFrame=SimpleNamespace(
             scene=lambda: SimpleNamespace(items=lambda: []),
             setSceneRect=lambda *_args: None,
@@ -276,7 +300,7 @@ def test_issue_scan_worker_progress_emits_live_fps(monkeypatch):
     assert completed == [({}, 3, 0, "Scanning 1 marked range", 2.0, False)]
 
 
-def test_issue_scan_worker_defers_target_snapshot_prep_until_run():
+def test_issue_scan_worker_prepares_target_snapshot_during_construction():
     main_window = _make_worker_main_window()
     prep_calls = []
     captured = {}
@@ -301,11 +325,10 @@ def test_issue_scan_worker_defers_target_snapshot_prep_until_run():
 
     worker = IssueScanWorker(main_window)
 
-    assert prep_calls == []
+    assert prep_calls == ["prepared"]
 
     worker.run()
 
-    assert prep_calls == ["prepared"]
     assert captured["target_faces_snapshot"] == {
         "face_1": {"face_id": "face_1", "embeddings_by_model": {}}
     }
@@ -425,26 +448,6 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
             },
         }
     }
-
-
-def test_issue_scan_worker_reports_prep_failures_via_failed_signal():
-    main_window = _make_worker_main_window()
-    failures = []
-
-    def fake_prepare_issue_scan_target_faces_snapshot(*_args, **_kwargs):
-        raise RuntimeError("prep boom")
-
-    main_window.video_processor.prepare_issue_scan_target_faces_snapshot = (
-        fake_prepare_issue_scan_target_faces_snapshot
-    )
-    main_window.video_processor.scan_issue_frames = lambda **_kwargs: None
-
-    worker = IssueScanWorker(main_window)
-    worker.failed.connect(failures.append)
-
-    worker.run()
-
-    assert failures == ["prep boom"]
 
 
 def test_handle_issue_scan_progress_moves_slider_and_updates_abort_button(monkeypatch):
@@ -590,10 +593,6 @@ def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
     assert fake_worker.started is True
     assert disabled_calls == ["disabled"]
     assert main_window.scan_issue_worker is fake_worker
-    assert main_window.scan_issue_ui_state["previous_issue_frames_by_face"] == {
-        "face_1": {3, 5},
-        "face_2": {9},
-    }
     assert main_window.scan_issue_ui_state["frames_scanned"] == 0
     assert main_window.runScanButton.enabled is True
     assert main_window.runScanButton.text == "Abort Scan"
@@ -609,6 +608,7 @@ def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
     assert main_window.addMarkerButton.enabled is False
     assert main_window.removeMarkerButton.enabled is False
     assert main_window.videoSeekSlider.enabled is False
+    assert main_window.videoSeekLineEdit.enabled is False
     assert main_window.frameAdvanceButton.enabled is False
     assert main_window.frameRewindButton.enabled is False
     assert main_window.nextMarkerButton.enabled is False
@@ -673,6 +673,7 @@ def test_run_issue_scan_respects_keep_controls_toggle(monkeypatch):
     assert main_window.addMarkerButton.enabled is False
     assert main_window.removeMarkerButton.enabled is False
     assert main_window.videoSeekSlider.enabled is False
+    assert main_window.videoSeekLineEdit.enabled is False
     assert main_window.frameAdvanceButton.enabled is False
     assert main_window.frameRewindButton.enabled is False
     assert main_window.nextMarkerButton.enabled is False
@@ -698,6 +699,28 @@ def test_run_issue_scan_respects_keep_controls_toggle(monkeypatch):
     assert main_window.clearDroppedFramesButton.enabled is False
 
 
+def test_seek_line_edit_event_filter_blocks_manual_seek_while_scan_active():
+    main_window = _make_scan_main_window()
+    main_window.scan_issue_worker = object()
+    processed = []
+    main_window.video_processor.process_current_frame = lambda: processed.append(
+        "processed"
+    )
+    main_window.videoSeekLineEdit.setText("77")
+    event_filter = event_filters.videoSeekSliderLineEditEventFilter(main_window)
+    event = SimpleNamespace(
+        type=lambda: event_filters.QtCore.QEvent.KeyPress,
+        key=lambda: event_filters.QtCore.Qt.Key_Return,
+    )
+
+    handled = event_filter.eventFilter(main_window.videoSeekLineEdit, event)
+
+    assert handled is True
+    assert main_window.videoSeekSlider.value() == 24
+    assert main_window.videoSeekLineEdit.text() == "77"
+    assert processed == []
+
+
 def test_run_issue_scan_does_not_start_twice(monkeypatch):
     main_window = _make_scan_main_window()
     existing_worker = _FakeIssueScanWorker(main_window)
@@ -717,6 +740,38 @@ def test_run_issue_scan_does_not_start_twice(monkeypatch):
 
     assert worker_calls == []
     assert main_window.scan_issue_worker is existing_worker
+
+
+def test_run_issue_scan_reports_construction_failures_without_clearing_results(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window()
+    main_window.issue_frames_by_face = {"face_1": {8}}
+    messagebox_calls = []
+
+    def raise_on_snapshot(_main_window):
+        raise RuntimeError("prep boom")
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.ui_workers.IssueScanWorker",
+        raise_on_snapshot,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.Path.is_file",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_messagebox",
+        lambda *_args, **_kwargs: messagebox_calls.append((_args, _kwargs)),
+    )
+
+    run_issue_scan(main_window)
+
+    assert main_window.issue_frames_by_face == {"face_1": {8}}
+    assert main_window.scan_issue_worker is None
+    assert main_window.scan_issue_ui_state == {}
+    assert messagebox_calls[0][0][1] == "Scan Failed"
+    assert messagebox_calls[0][0][2] == "prep boom"
 
 
 def test_toggle_issue_scan_cancels_active_worker():
@@ -759,14 +814,13 @@ def test_issue_scan_completion_restores_slider_and_ui(monkeypatch):
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": False,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 50,
-        "has_partial_results": True,
         "mutation_lock_enabled_states": [
             (main_window.findTargetFacesButton, True),
             (main_window.clearTargetFacesButton, True),
             (main_window.filterWebcamsCheckBox, True),
             (main_window.videoSeekSlider, True),
+            (main_window.videoSeekLineEdit, True),
             (main_window.frameAdvanceButton, False),
             (main_window.frameRewindButton, True),
             (main_window.nextMarkerButton, True),
@@ -781,6 +835,7 @@ def test_issue_scan_completion_restores_slider_and_ui(monkeypatch):
     main_window.clearTargetFacesButton.enabled = False
     main_window.filterWebcamsCheckBox.enabled = False
     main_window.videoSeekSlider.enabled = False
+    main_window.videoSeekLineEdit.enabled = False
     main_window.frameAdvanceButton.enabled = False
     main_window.frameRewindButton.enabled = False
     main_window.nextMarkerButton.enabled = False
@@ -813,6 +868,7 @@ def test_issue_scan_completion_restores_slider_and_ui(monkeypatch):
     assert main_window.clearTargetFacesButton.enabled is True
     assert main_window.filterWebcamsCheckBox.enabled is True
     assert main_window.videoSeekSlider.enabled is True
+    assert main_window.videoSeekLineEdit.enabled is True
     assert main_window.frameAdvanceButton.enabled is False
     assert main_window.frameRewindButton.enabled is True
     assert main_window.nextMarkerButton.enabled is True
@@ -856,9 +912,7 @@ def test_issue_scan_partial_completion_keeps_partial_results(monkeypatch):
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 12,
-        "has_partial_results": True,
     }
     main_window.videoSeekSlider.setValue(91)
 
@@ -886,7 +940,9 @@ def test_issue_scan_partial_completion_keeps_partial_results(monkeypatch):
     assert toast_calls[0][0][1] == "Scan Aborted"
 
 
-def test_issue_scan_failed_without_progress_restores_previous_findings(monkeypatch):
+def test_issue_scan_failed_without_progress_keeps_current_attempt_results_only(
+    monkeypatch,
+):
     main_window = _make_scan_main_window()
     fake_worker = _FakeIssueScanWorker(main_window)
     messagebox_calls = []
@@ -911,11 +967,10 @@ def test_issue_scan_failed_without_progress_restores_previous_findings(monkeypat
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 0,
-        "has_partial_results": False,
         "mutation_lock_enabled_states": [
             (main_window.videoSeekSlider, True),
+            (main_window.videoSeekLineEdit, True),
             (main_window.frameAdvanceButton, False),
             (main_window.filterWebcamsCheckBox, True),
         ],
@@ -923,16 +978,18 @@ def test_issue_scan_failed_without_progress_restores_previous_findings(monkeypat
     main_window.videoSeekSlider.setValue(101)
     main_window.issue_frames_by_face = {}
     main_window.videoSeekSlider.enabled = False
+    main_window.videoSeekLineEdit.enabled = False
     main_window.frameAdvanceButton.enabled = False
     main_window.filterWebcamsCheckBox.enabled = False
 
     _handle_issue_scan_failed(main_window, "boom")
 
     assert main_window.videoSeekSlider.value() == 24
-    assert main_window.issue_frames_by_face == {"face_1": {3, 5}, "face_2": {9}}
+    assert main_window.issue_frames_by_face == {}
     assert main_window.scan_issue_worker is None
     assert fake_worker.deleted is True
     assert main_window.videoSeekSlider.enabled is True
+    assert main_window.videoSeekLineEdit.enabled is True
     assert main_window.frameAdvanceButton.enabled is False
     assert main_window.filterWebcamsCheckBox.enabled is True
     assert main_window.prevIssueButton.enabled is True
@@ -943,7 +1000,8 @@ def test_issue_scan_failed_without_progress_restores_previous_findings(monkeypat
     assert main_window.clearDroppedFramesButton.enabled is True
     assert restore_calls == ["restored"]
     assert messagebox_calls[0][0][1] == "Scan Failed"
-    assert messagebox_calls[0][0][2] == "boom"
+    assert "boom" in messagebox_calls[0][0][2]
+    assert "Any previous issue findings were cleared" in messagebox_calls[0][0][2]
 
 
 def test_issue_scan_failed_after_progress_keeps_current_results(monkeypatch):
@@ -971,9 +1029,7 @@ def test_issue_scan_failed_after_progress_keeps_current_results(monkeypatch):
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 4,
-        "has_partial_results": False,
     }
     main_window.videoSeekSlider.setValue(101)
     main_window.issue_frames_by_face = {}
@@ -986,7 +1042,53 @@ def test_issue_scan_failed_after_progress_keeps_current_results(monkeypatch):
     assert fake_worker.deleted is True
     assert restore_calls == ["restored"]
     assert messagebox_calls[0][0][1] == "Scan Failed"
-    assert messagebox_calls[0][0][2] == "boom"
+    assert "boom" in messagebox_calls[0][0][2]
+
+
+def test_issue_scan_failed_after_partial_hits_keeps_current_attempt_findings(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    messagebox_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_messagebox",
+        lambda *_args, **_kwargs: messagebox_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+        "frames_scanned": 4,
+    }
+    main_window.videoSeekSlider.setValue(101)
+    main_window.issue_frames_by_face = {"face_1": {8}}
+
+    _handle_issue_scan_failed(main_window, "boom")
+
+    assert main_window.videoSeekSlider.value() == 24
+    assert main_window.issue_frames_by_face == {"face_1": {8}}
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert restore_calls == ["restored"]
+    assert messagebox_calls[0][0][1] == "Scan Failed"
+    assert (
+        "Only findings from the current scan attempt remain visible."
+        in (messagebox_calls[0][0][2])
+    )
 
 
 def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch):
@@ -1015,9 +1117,7 @@ def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 12,
-        "has_partial_results": True,
     }
 
     _handle_issue_scan_cancelled(main_window)
@@ -1026,7 +1126,7 @@ def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch
     assert fake_worker.deleted is True
     assert restore_calls == ["restored"]
     assert toast_calls[0][0][1] == "Scan Cancelled"
-    assert "Kept any issue frames found so far." in toast_calls[0][0][2]
+    assert "Kept 1 issue frames from this scan attempt." in toast_calls[0][0][2]
 
 
 def test_issue_scan_cancelled_completion_after_progress_keeps_empty_results(
@@ -1057,9 +1157,7 @@ def test_issue_scan_cancelled_completion_after_progress_keeps_empty_results(
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 12,
-        "has_partial_results": False,
     }
 
     _handle_issue_scan_completed(
@@ -1077,10 +1175,10 @@ def test_issue_scan_cancelled_completion_after_progress_keeps_empty_results(
     assert fake_worker.deleted is True
     assert restore_calls == ["restored"]
     assert toast_calls[0][0][1] == "Scan Aborted"
-    assert "Kept 0 issue frames found so far." in toast_calls[0][0][2]
+    assert "Kept 0 issue frames from this scan attempt." in toast_calls[0][0][2]
 
 
-def test_issue_scan_cancelled_completion_without_progress_restores_previous_findings(
+def test_issue_scan_cancelled_completion_without_progress_keeps_empty_results(
     monkeypatch,
 ):
     main_window = _make_scan_main_window()
@@ -1108,9 +1206,7 @@ def test_issue_scan_cancelled_completion_without_progress_restores_previous_find
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 0,
-        "has_partial_results": False,
     }
 
     _handle_issue_scan_completed(
@@ -1123,15 +1219,15 @@ def test_issue_scan_cancelled_completion_without_progress_restores_previous_find
         True,
     )
 
-    assert main_window.issue_frames_by_face == {"face_1": {3, 5}, "face_2": {9}}
+    assert main_window.issue_frames_by_face == {}
     assert main_window.scan_issue_worker is None
     assert fake_worker.deleted is True
     assert restore_calls == ["restored"]
     assert toast_calls[0][0][1] == "Scan Aborted"
-    assert "Restored the previous 3 issue frames." in toast_calls[0][0][2]
+    assert "Kept 0 issue frames from this scan attempt." in toast_calls[0][0][2]
 
 
-def test_issue_scan_cancelled_without_progress_restores_previous_findings(monkeypatch):
+def test_issue_scan_cancelled_without_progress_keeps_empty_results(monkeypatch):
     main_window = _make_scan_main_window()
     fake_worker = _FakeIssueScanWorker(main_window)
     toast_calls = []
@@ -1157,13 +1253,12 @@ def test_issue_scan_cancelled_without_progress_restores_previous_findings(monkey
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 0,
-        "has_partial_results": False,
         "mutation_lock_enabled_states": [
             (main_window.nextMarkerButton, True),
             (main_window.swapfacesButton, True),
             (main_window.filterWebcamsCheckBox, False),
+            (main_window.videoSeekLineEdit, True),
         ],
     }
     main_window.nextMarkerButton.enabled = False
@@ -1172,15 +1267,16 @@ def test_issue_scan_cancelled_without_progress_restores_previous_findings(monkey
 
     _handle_issue_scan_cancelled(main_window)
 
-    assert main_window.issue_frames_by_face == {"face_1": {3, 5}, "face_2": {9}}
+    assert main_window.issue_frames_by_face == {}
     assert main_window.scan_issue_worker is None
     assert fake_worker.deleted is True
     assert main_window.nextMarkerButton.enabled is True
     assert main_window.swapfacesButton.enabled is True
     assert main_window.filterWebcamsCheckBox.enabled is False
+    assert main_window.videoSeekLineEdit.enabled is True
     assert restore_calls == ["restored"]
     assert toast_calls[0][0][1] == "Scan Cancelled"
-    assert "Restored the previous issue findings." in toast_calls[0][0][2]
+    assert "Kept 0 issue frames from this scan attempt." in toast_calls[0][0][2]
 
 
 def test_issue_scan_cancelled_after_progress_keeps_current_results(monkeypatch):
@@ -1209,9 +1305,7 @@ def test_issue_scan_cancelled_after_progress_keeps_current_results(monkeypatch):
         "start_frame": 24,
         "scope_text": "Scanning full clip",
         "keep_controls": True,
-        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
         "frames_scanned": 6,
-        "has_partial_results": False,
     }
 
     _handle_issue_scan_cancelled(main_window)
@@ -1221,7 +1315,177 @@ def test_issue_scan_cancelled_after_progress_keeps_current_results(monkeypatch):
     assert fake_worker.deleted is True
     assert restore_calls == ["restored"]
     assert toast_calls[0][0][1] == "Scan Cancelled"
-    assert "Kept any issue frames found so far." in toast_calls[0][0][2]
+    assert "Kept 0 issue frames from this scan attempt." in toast_calls[0][0][2]
+
+
+def test_filter_target_videos_defers_refresh_while_scan_is_active(monkeypatch):
+    main_window = _make_scan_main_window()
+    main_window.scan_issue_worker = object()
+    calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.filter_actions.filter_target_videos",
+        lambda _main_window: calls.append("filtered"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.load_target_webcams",
+        lambda _main_window: calls.append("webcams"),
+    )
+
+    list_view_actions.filter_target_videos(main_window)
+
+    assert calls == []
+    assert main_window.scan_issue_ui_state["pending_target_media_refresh"] is True
+
+
+def test_issue_scan_completion_replays_deferred_target_media_refresh_once(monkeypatch):
+    main_window = _make_scan_main_window(keep_controls=False)
+    fake_worker = _FakeIssueScanWorker(main_window)
+    enabled_calls = []
+    restore_calls = []
+    replay_calls = []
+    toast_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.layout_actions.enable_all_parameters_and_control_widget",
+        lambda _main_window: enabled_calls.append("enabled"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.filter_actions.filter_target_videos",
+        lambda _main_window: replay_calls.append("filtered"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.load_target_webcams",
+        lambda _main_window: replay_calls.append("webcams"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": False,
+        "frames_scanned": 50,
+        "pending_target_media_refresh": True,
+        "mutation_lock_enabled_states": [
+            (main_window.findTargetFacesButton, True),
+            (main_window.filterWebcamsCheckBox, True),
+            (main_window.videoSeekSlider, True),
+        ],
+    }
+    main_window.findTargetFacesButton.enabled = False
+    main_window.filterWebcamsCheckBox.enabled = False
+    main_window.videoSeekSlider.enabled = False
+    main_window.videoSeekSlider.setValue(90)
+    main_window.video_processor.current_frame_number = 90
+
+    _handle_issue_scan_completed(
+        main_window,
+        {"face_1": [1, 2]},
+        50,
+        1,
+        "Scanning full clip",
+        5.0,
+        False,
+    )
+
+    assert enabled_calls == ["enabled"]
+    assert replay_calls == ["filtered", "webcams"]
+    assert main_window.scan_issue_ui_state == {}
+    assert restore_calls == ["restored"]
+    assert fake_worker.deleted is True
+    assert toast_calls[0][0][1] == "Scan Complete"
+
+
+def test_issue_scan_completion_replays_deferred_refresh_after_scan_is_inactive(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window(keep_controls=False)
+    fake_worker = _FakeIssueScanWorker(main_window)
+    replay_calls = []
+
+    class _FakeTargetMediaLoaderWorker:
+        def __init__(self, main_window, webcam_mode=False):
+            replay_calls.append(("worker_init", webcam_mode))
+            self.main_window = main_window
+            self.webcam_mode = webcam_mode
+            self.webcam_thumbnail_ready = _DummySignal()
+
+        def start(self):
+            replay_calls.append(("worker_start", self.webcam_mode))
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.layout_actions.enable_all_parameters_and_control_widget",
+        lambda _main_window: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.filter_actions.filter_target_videos",
+        lambda _main_window: replay_calls.append(
+            ("filter", is_issue_scan_active(_main_window))
+        ),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.ui_workers.TargetMediaLoaderWorker",
+        _FakeTargetMediaLoaderWorker,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: None,
+    )
+
+    main_window.filterWebcamsCheckBox.setChecked(True)
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": False,
+        "frames_scanned": 50,
+        "pending_target_media_refresh": True,
+        "mutation_lock_enabled_states": [
+            (main_window.findTargetFacesButton, True),
+            (main_window.filterWebcamsCheckBox, True),
+            (main_window.videoSeekSlider, True),
+        ],
+    }
+
+    _handle_issue_scan_completed(
+        main_window,
+        {"face_1": [1, 2]},
+        50,
+        1,
+        "Scanning full clip",
+        5.0,
+        False,
+    )
+
+    assert replay_calls == [
+        ("filter", False),
+        ("worker_init", True),
+        ("worker_start", True),
+    ]
+    assert main_window.scan_issue_worker is None
+    assert main_window.scan_issue_ui_state == {}
 
 
 def test_issue_scan_guard_helpers_block_structural_mutations(monkeypatch):

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from app.ui.widgets.actions import common_actions
 from app.ui.widgets.actions import card_actions, job_manager_actions, list_view_actions
 from app.ui.widgets.actions import save_load_actions
 from app.ui.widgets.actions.video_control_actions import (
@@ -14,6 +15,7 @@ from app.ui.widgets.actions.video_control_actions import (
     remove_all_markers,
     run_issue_scan,
     toggle_issue_scan,
+    update_scan_review_button_states,
 )
 from app.ui.widgets import widget_components
 from app.ui.widgets.ui_workers import IssueScanWorker
@@ -37,6 +39,7 @@ class _DummyButton:
         self.text = text
         self.tooltip = ""
         self.checked = checked
+        self.block_calls = []
 
     def setEnabled(self, value):
         self.enabled = bool(value)
@@ -58,6 +61,9 @@ class _DummyButton:
 
     def isEnabled(self):
         return self.enabled
+
+    def blockSignals(self, value):
+        self.block_calls.append(bool(value))
 
 
 class _DummySlider:
@@ -87,6 +93,15 @@ class _DummySlider:
 
     def update(self):
         self.updated += 1
+
+
+def _make_guarded_card(main_window, checked=False):
+    card = _DummyButton(checked=checked)
+    card.main_window = main_window
+    card._restore_pre_click_checked_state = lambda: (
+        widget_components.CardButton._restore_pre_click_checked_state(card)
+    )
+    return card
 
 
 class _FakeIssueScanWorker:
@@ -482,6 +497,70 @@ def test_handle_issue_scan_issue_found_merges_and_refreshes_selected_face(monkey
     ]
 
 
+def test_handle_issue_scan_issue_found_keeps_review_controls_disabled_while_active(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window()
+    main_window.issue_frames_by_face = {}
+    main_window.scan_issue_worker = object()
+    main_window.prevIssueButton.enabled = False
+    main_window.nextIssueButton.enabled = False
+    main_window.dropAllIssueFramesButton.enabled = False
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+
+    _handle_issue_scan_issue_found(main_window, "face_1", 12)
+
+    assert main_window.issue_frames_by_face == {"face_1": {12}}
+    assert main_window.prevIssueButton.enabled is False
+    assert main_window.nextIssueButton.enabled is False
+    assert main_window.dropAllIssueFramesButton.enabled is False
+
+
+def test_handle_issue_scan_progress_records_processed_frames(monkeypatch):
+    main_window = _make_scan_main_window()
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+
+    _handle_issue_scan_progress(
+        main_window,
+        "Scanning full clip",
+        7,
+        20,
+        88,
+        5.5,
+    )
+
+    assert main_window.scan_issue_ui_state["frames_scanned"] == 7
+
+
+def test_update_scan_review_button_states_respects_active_scan_state():
+    main_window = _make_scan_main_window()
+    main_window.prevIssueButton.enabled = False
+    main_window.nextIssueButton.enabled = False
+    main_window.dropAllIssueFramesButton.enabled = False
+    main_window.runScanButton.enabled = False
+
+    update_scan_review_button_states(main_window)
+
+    assert main_window.runScanButton.enabled is True
+    assert main_window.prevIssueButton.enabled is True
+    assert main_window.nextIssueButton.enabled is True
+    assert main_window.dropAllIssueFramesButton.enabled is True
+
+    main_window.scan_issue_worker = object()
+    update_scan_review_button_states(main_window)
+
+    assert main_window.runScanButton.enabled is True
+    assert main_window.prevIssueButton.enabled is False
+    assert main_window.nextIssueButton.enabled is False
+    assert main_window.dropAllIssueFramesButton.enabled is False
+
+
 def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
     monkeypatch,
 ):
@@ -515,6 +594,7 @@ def test_run_issue_scan_disables_controls_like_recording_when_keep_controls_off(
         "face_1": {3, 5},
         "face_2": {9},
     }
+    assert main_window.scan_issue_ui_state["frames_scanned"] == 0
     assert main_window.runScanButton.enabled is True
     assert main_window.runScanButton.text == "Abort Scan"
     assert "processed" not in main_window.runScanButton.tooltip
@@ -680,6 +760,7 @@ def test_issue_scan_completion_restores_slider_and_ui(monkeypatch):
         "scope_text": "Scanning full clip",
         "keep_controls": False,
         "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 50,
         "has_partial_results": True,
         "mutation_lock_enabled_states": [
             (main_window.findTargetFacesButton, True),
@@ -776,6 +857,7 @@ def test_issue_scan_partial_completion_keeps_partial_results(monkeypatch):
         "scope_text": "Scanning full clip",
         "keep_controls": True,
         "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 12,
         "has_partial_results": True,
     }
     main_window.videoSeekSlider.setValue(91)
@@ -804,7 +886,7 @@ def test_issue_scan_partial_completion_keeps_partial_results(monkeypatch):
     assert toast_calls[0][0][1] == "Scan Aborted"
 
 
-def test_issue_scan_failed_restores_ui_and_shows_message(monkeypatch):
+def test_issue_scan_failed_without_progress_restores_previous_findings(monkeypatch):
     main_window = _make_scan_main_window()
     fake_worker = _FakeIssueScanWorker(main_window)
     messagebox_calls = []
@@ -830,6 +912,7 @@ def test_issue_scan_failed_restores_ui_and_shows_message(monkeypatch):
         "scope_text": "Scanning full clip",
         "keep_controls": True,
         "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 0,
         "has_partial_results": False,
         "mutation_lock_enabled_states": [
             (main_window.videoSeekSlider, True),
@@ -863,6 +946,49 @@ def test_issue_scan_failed_restores_ui_and_shows_message(monkeypatch):
     assert messagebox_calls[0][0][2] == "boom"
 
 
+def test_issue_scan_failed_after_progress_keeps_current_results(monkeypatch):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    messagebox_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_messagebox",
+        lambda *_args, **_kwargs: messagebox_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 4,
+        "has_partial_results": False,
+    }
+    main_window.videoSeekSlider.setValue(101)
+    main_window.issue_frames_by_face = {}
+
+    _handle_issue_scan_failed(main_window, "boom")
+
+    assert main_window.videoSeekSlider.value() == 24
+    assert main_window.issue_frames_by_face == {}
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert restore_calls == ["restored"]
+    assert messagebox_calls[0][0][1] == "Scan Failed"
+    assert messagebox_calls[0][0][2] == "boom"
+
+
 def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch):
     main_window = _make_scan_main_window()
     fake_worker = _FakeIssueScanWorker(main_window)
@@ -890,6 +1016,7 @@ def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch
         "scope_text": "Scanning full clip",
         "keep_controls": True,
         "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 12,
         "has_partial_results": True,
     }
 
@@ -902,7 +1029,7 @@ def test_issue_scan_cancelled_fallback_keeps_partial_results_message(monkeypatch
     assert "Kept any issue frames found so far." in toast_calls[0][0][2]
 
 
-def test_issue_scan_cancelled_completion_without_partial_results_restores_previous_findings(
+def test_issue_scan_cancelled_completion_after_progress_keeps_empty_results(
     monkeypatch,
 ):
     main_window = _make_scan_main_window()
@@ -931,6 +1058,7 @@ def test_issue_scan_cancelled_completion_without_partial_results_restores_previo
         "scope_text": "Scanning full clip",
         "keep_controls": True,
         "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 12,
         "has_partial_results": False,
     }
 
@@ -938,6 +1066,57 @@ def test_issue_scan_cancelled_completion_without_partial_results_restores_previo
         main_window,
         {},
         12,
+        0,
+        "Scanning full clip",
+        2.0,
+        True,
+    )
+
+    assert main_window.issue_frames_by_face == {}
+    assert main_window.scan_issue_worker is None
+    assert fake_worker.deleted is True
+    assert restore_calls == ["restored"]
+    assert toast_calls[0][0][1] == "Scan Aborted"
+    assert "Kept 0 issue frames found so far." in toast_calls[0][0][2]
+
+
+def test_issue_scan_cancelled_completion_without_progress_restores_previous_findings(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window()
+    fake_worker = _FakeIssueScanWorker(main_window)
+    toast_calls = []
+    restore_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.QtCore.QCoreApplication.processEvents",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions._restore_issue_scan_display",
+        lambda _main_window: restore_calls.append("restored"),
+    )
+
+    main_window.scan_issue_worker = fake_worker
+    main_window.issue_frames_by_face = {}
+    main_window.scan_issue_ui_state = {
+        "active": True,
+        "start_frame": 24,
+        "scope_text": "Scanning full clip",
+        "keep_controls": True,
+        "previous_issue_frames_by_face": {"face_1": {3, 5}, "face_2": {9}},
+        "frames_scanned": 0,
+        "has_partial_results": False,
+    }
+
+    _handle_issue_scan_completed(
+        main_window,
+        {},
+        0,
         0,
         "Scanning full clip",
         2.0,
@@ -1080,31 +1259,175 @@ def test_issue_scan_guard_helpers_block_structural_mutations(monkeypatch):
     remove_all_markers(main_window)
 
     widget_components.TargetMediaCardButton.load_media(
-        SimpleNamespace(
-            main_window=main_window,
-            blockSignals=lambda *_args: None,
-            setChecked=lambda *_args: None,
-        )
+        _make_guarded_card(main_window, checked=True)
     )
     widget_components.TargetFaceCardButton.remove_target_face_from_list(
         SimpleNamespace(main_window=main_window)
     )
     widget_components.InputFaceCardButton.load_input_face(
-        SimpleNamespace(
-            main_window=main_window,
-            blockSignals=lambda *_args: None,
-            setChecked=lambda *_args: None,
-        )
+        _make_guarded_card(main_window, checked=True)
     )
     widget_components.EmbeddingCardButton.load_embedding(
-        SimpleNamespace(
-            main_window=main_window,
-            blockSignals=lambda *_args: None,
-            setChecked=lambda *_args: None,
-        )
+        _make_guarded_card(main_window, checked=True)
     )
 
     assert main_window.target_videos == original_target_videos
     assert main_window.input_faces == original_input_faces
     assert main_window.merged_embeddings == original_embeddings
     assert toast_calls
+
+
+def test_scan_guard_restores_target_media_card_checked_state(monkeypatch):
+    main_window = _make_scan_main_window(keep_controls=True)
+    main_window.scan_issue_worker = object()
+    toast_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+
+    checked_card = _make_guarded_card(main_window, checked=False)
+    widget_components.TargetMediaCardButton.load_media(checked_card)
+
+    unchecked_card = _make_guarded_card(main_window, checked=True)
+    widget_components.TargetMediaCardButton.load_media(unchecked_card)
+
+    assert checked_card.checked is True
+    assert unchecked_card.checked is False
+    assert checked_card.block_calls == [True, False]
+    assert unchecked_card.block_calls == [True, False]
+    assert len(toast_calls) == 2
+
+
+def test_scan_guard_restores_input_face_card_checked_state(monkeypatch):
+    main_window = _make_scan_main_window(keep_controls=True)
+    main_window.scan_issue_worker = object()
+    main_window.cur_selected_target_face_button = None
+    toast_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+
+    checked_card = _make_guarded_card(main_window, checked=False)
+    widget_components.InputFaceCardButton.load_input_face(checked_card)
+
+    unchecked_card = _make_guarded_card(main_window, checked=True)
+    widget_components.InputFaceCardButton.load_input_face(unchecked_card)
+
+    assert checked_card.checked is True
+    assert unchecked_card.checked is False
+    assert checked_card.block_calls == [True, False]
+    assert unchecked_card.block_calls == [True, False]
+    assert len(toast_calls) == 2
+
+
+def test_scan_guard_restores_embedding_card_checked_state(monkeypatch):
+    main_window = _make_scan_main_window(keep_controls=True)
+    main_window.scan_issue_worker = object()
+    main_window.cur_selected_target_face_button = None
+    toast_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+
+    checked_card = _make_guarded_card(main_window, checked=False)
+    widget_components.EmbeddingCardButton.load_embedding(checked_card)
+
+    unchecked_card = _make_guarded_card(main_window, checked=True)
+    widget_components.EmbeddingCardButton.load_embedding(unchecked_card)
+
+    assert checked_card.checked is True
+    assert unchecked_card.checked is False
+    assert checked_card.block_calls == [True, False]
+    assert unchecked_card.block_calls == [True, False]
+    assert len(toast_calls) == 2
+
+
+def test_target_face_parameter_mutations_are_blocked_while_scan_is_active(
+    monkeypatch,
+):
+    main_window = _make_scan_main_window(keep_controls=True)
+    main_window.scan_issue_worker = object()
+    main_window.parameters = {"face_1": {"mode": "original"}}
+    main_window.copied_parameters = {"mode": "copied"}
+    main_window.control["ExistingSetting"] = "before"
+    main_window.selected_target_face_id = "face_1"
+    toast_calls = []
+    widget_value_updates = []
+    control_value_updates = []
+    refresh_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_toast_message",
+        lambda *_args, **_kwargs: toast_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.common_actions.set_widgets_values_using_face_id_parameters",
+        lambda *_args, **_kwargs: widget_value_updates.append("updated"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.save_load_actions.common_widget_actions.set_control_widgets_values",
+        lambda *_args, **_kwargs: control_value_updates.append("updated"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.save_load_actions.common_widget_actions.refresh_frame",
+        lambda *_args, **_kwargs: refresh_calls.append("refreshed"),
+    )
+
+    assert common_actions.paste_selected_face_parameters(main_window, "face_1") is False
+    assert save_load_actions.load_parameters_and_settings(main_window, "face_1") is None
+    assert (
+        save_load_actions.load_parameters_and_settings(main_window, "face_1", True)
+        is None
+    )
+
+    assert main_window.parameters == {"face_1": {"mode": "original"}}
+    assert main_window.control["ExistingSetting"] == "before"
+    assert widget_value_updates == []
+    assert control_value_updates == []
+    assert refresh_calls == []
+    assert len(toast_calls) == 3
+
+
+def test_target_face_context_menu_disables_mutating_actions_while_scan_is_active():
+    menu_exec_calls = []
+    target_face_button = SimpleNamespace(
+        main_window=_make_scan_main_window(keep_controls=True),
+        parameters_copy_action=_DummyButton("Copy Parameters"),
+        parameters_paste_action=_DummyButton("Apply Copied Parameters"),
+        save_parameters_action=_DummyButton("Save Current Parameters and Settings"),
+        load_parameters_action=_DummyButton("Load Parameters"),
+        load_parameters_and_settings_action=_DummyButton(
+            "Load Parameters and Settings"
+        ),
+        remove_action=_DummyButton("Remove from List"),
+        mapToGlobal=lambda point: point,
+        popMenu=SimpleNamespace(exec_=lambda point: menu_exec_calls.append(point)),
+    )
+    target_face_button.main_window.scan_issue_worker = object()
+
+    widget_components.TargetFaceCardButton.on_context_menu(target_face_button, 12)
+
+    assert target_face_button.parameters_copy_action.enabled is True
+    assert target_face_button.save_parameters_action.enabled is True
+    assert target_face_button.parameters_paste_action.enabled is False
+    assert target_face_button.load_parameters_action.enabled is False
+    assert target_face_button.load_parameters_and_settings_action.enabled is False
+    assert target_face_button.remove_action.enabled is False
+    assert menu_exec_calls == [12]
+
+    target_face_button.main_window.scan_issue_worker = None
+    target_face_button.main_window.scan_issue_ui_state = {}
+
+    widget_components.TargetFaceCardButton.on_context_menu(target_face_button, 34)
+
+    assert target_face_button.parameters_paste_action.enabled is True
+    assert target_face_button.load_parameters_action.enabled is True
+    assert target_face_button.load_parameters_and_settings_action.enabled is True
+    assert target_face_button.remove_action.enabled is True
+    assert menu_exec_calls == [12, 34]

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -11,6 +11,7 @@ All PySide6, widget, and UI imports are stubbed so this runs without Qt.
 
 from __future__ import annotations
 
+import importlib
 import sys
 import json
 import copy
@@ -51,27 +52,39 @@ _STUBS = [
     "app.ui.widgets.actions.layout_actions",
     "app.ui.widgets.actions.filter_actions",
 ]
-for _s in _STUBS:
-    if _s not in sys.modules:
-        sys.modules[_s] = _stub(_s)
 
-widget_components_stub = sys.modules["app.ui.widgets.widget_components"]
-setattr(
-    widget_components_stub,
-    "TargetMediaCardButton",
-    type("TargetMediaCardButton", (), {}),
-)
+
+def _load_save_load_actions_module():
+    for stub_name in _STUBS:
+        sys.modules[stub_name] = _stub(stub_name)
+
+    widget_components_stub = sys.modules["app.ui.widgets.widget_components"]
+    setattr(
+        widget_components_stub,
+        "TargetMediaCardButton",
+        type("TargetMediaCardButton", (), {}),
+    )
+
+    sys.modules.pop("app.ui.widgets.actions.save_load_actions", None)
+    module = importlib.import_module("app.ui.widgets.actions.save_load_actions")
+
+    # These tests validate serialization/window-state behavior, not Qt UI display.
+    module.common_widget_actions.create_and_show_toast_message = MagicMock()
+    module.common_widget_actions.create_and_show_messagebox = MagicMock()
+    return module
+
 
 # Provide the real ParametersDict through misc_helpers
 from app.helpers.miscellaneous import ParametersDict  # noqa: E402
 
 # Now import the module under test
-from app.ui.widgets.actions.save_load_actions import (  # noqa: E402
-    _apply_workspace_window_state,
-    convert_parameters_to_supported_type,
-    convert_markers_to_supported_type,
-    save_current_workspace,
+save_load_actions = _load_save_load_actions_module()
+_apply_workspace_window_state = save_load_actions._apply_workspace_window_state
+convert_parameters_to_supported_type = (
+    save_load_actions.convert_parameters_to_supported_type
 )
+convert_markers_to_supported_type = save_load_actions.convert_markers_to_supported_type
+save_current_workspace = save_load_actions.save_current_workspace
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -55,18 +55,35 @@ _STUBS = [
 
 
 def _load_save_load_actions_module():
-    for stub_name in _STUBS:
-        sys.modules[stub_name] = _stub(stub_name)
-
-    widget_components_stub = sys.modules["app.ui.widgets.widget_components"]
-    setattr(
-        widget_components_stub,
-        "TargetMediaCardButton",
-        type("TargetMediaCardButton", (), {}),
+    original_modules = {stub_name: sys.modules.get(stub_name) for stub_name in _STUBS}
+    original_save_load_actions = sys.modules.pop(
+        "app.ui.widgets.actions.save_load_actions", None
     )
+    try:
+        for stub_name in _STUBS:
+            sys.modules[stub_name] = _stub(stub_name)
 
-    sys.modules.pop("app.ui.widgets.actions.save_load_actions", None)
-    module = importlib.import_module("app.ui.widgets.actions.save_load_actions")
+        widget_components_stub = sys.modules["app.ui.widgets.widget_components"]
+        setattr(
+            widget_components_stub,
+            "TargetMediaCardButton",
+            type("TargetMediaCardButton", (), {}),
+        )
+
+        module = importlib.import_module("app.ui.widgets.actions.save_load_actions")
+    finally:
+        for stub_name, original_module in original_modules.items():
+            if original_module is None:
+                sys.modules.pop(stub_name, None)
+            else:
+                sys.modules[stub_name] = original_module
+
+        if original_save_load_actions is not None:
+            sys.modules["app.ui.widgets.actions.save_load_actions"] = (
+                original_save_load_actions
+            )
+        else:
+            sys.modules.pop("app.ui.widgets.actions.save_load_actions", None)
 
     # These tests validate serialization/window-state behavior, not Qt UI display.
     module.common_widget_actions.create_and_show_toast_message = MagicMock()
@@ -112,6 +129,22 @@ def sample_params_dict(default_params_data) -> ParametersDict:
 @pytest.fixture
 def sample_plain_dict() -> dict:
     return {"brightness": 1.5, "contrast": 0.9}
+
+
+def test_load_save_actions_module_restores_stubbed_sys_modules():
+    sentinel = object()
+    original_common_actions = sys.modules.get("app.ui.widgets.actions.common_actions")
+    sys.modules["app.ui.widgets.actions.common_actions"] = sentinel
+    try:
+        _load_save_load_actions_module()
+        assert sys.modules["app.ui.widgets.actions.common_actions"] is sentinel
+    finally:
+        if original_common_actions is None:
+            sys.modules.pop("app.ui.widgets.actions.common_actions", None)
+        else:
+            sys.modules["app.ui.widgets.actions.common_actions"] = (
+                original_common_actions
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -622,7 +655,8 @@ def test_apply_workspace_window_state_fullscreen_seeds_restore_geometry(monkeypa
     )
 
     monkeypatch.setattr(
-        "app.ui.widgets.actions.save_load_actions._get_clamped_window_geometry",
+        save_load_actions,
+        "_get_clamped_window_geometry",
         lambda *_args, **_kwargs: restored_rect,
     )
 
@@ -670,7 +704,8 @@ def test_apply_workspace_window_state_normal_clears_fullscreen_restore_state(
     )
 
     monkeypatch.setattr(
-        "app.ui.widgets.actions.save_load_actions._get_clamped_window_geometry",
+        save_load_actions,
+        "_get_clamped_window_geometry",
         lambda *_args, **_kwargs: restored_rect,
     )
 


### PR DESCRIPTION
## Summary
Stabilizes scan tools and closes the remaining issue-scan regressions on this branch.

## Changes
- Stabilizes issue-scan worker startup and processor state restoration
- Tightens issue-scan completion, cancellation, and failure teardown behavior
- Blocks structural UI mutations while an issue scan is active
- Replays deferred target-media refreshes safely after scan exit
- Adds regression coverage for scan lifecycle, mutation guards, and deferred refresh handling

## Verification
- `pre-commit run --all-files`
- `python -m pytest -q`
- Manual scan-tools validation for completion, cancellation, deferred refresh, and post-scan UI recovery
