### PR TITLE
Removed detection intervall

### DIFF
--- a/app/processors/face_detectors.py
+++ b/app/processors/face_detectors.py
@@ -459,101 +459,6 @@ class FaceDetectors:
 
         return net_outs
 
-    def track_faces(self, img, previous_detections, **kwargs):
-        """
-        Attempts to track faces based on their previous positions using landmark detection directly.
-        Returns: (det, kpss, scores) or (None, None, None) if tracking failed for any face.
-        """
-        if not previous_detections:
-            return None, None, None
-
-        tracked_det = []
-        tracked_kpss = []
-        tracked_scores = []
-
-        img_height, img_width = img.shape[1], img.shape[2]
-
-        # Parameters for tracking
-        landmark_score_threshold = kwargs.get("landmark_score", 0.5)
-        detect_mode = kwargs.get("landmark_detect_mode", "203")
-        use_mean_eyes = kwargs.get("use_mean_eyes", False)
-
-        for prev_face in previous_detections:
-            # Previous bounding box
-            bbox = prev_face["bbox"]
-
-            # Expand the box slightly to account for movement
-            expansion_factor = 0.2  # 20% expansion
-            w = bbox[2] - bbox[0]
-            h = bbox[3] - bbox[1]
-
-            expanded_bbox = np.array(
-                [
-                    max(0, bbox[0] - w * expansion_factor),
-                    max(0, bbox[1] - h * expansion_factor),
-                    min(img_width, bbox[2] + w * expansion_factor),
-                    min(img_height, bbox[3] + h * expansion_factor),
-                ]
-            )
-
-            # Run landmark detection directly on the expanded previous area
-            # We assume kpss_5 is enough to verify presence
-            kpss_5, kpss_all, scores = self.models_processor.run_detect_landmark(
-                img,
-                expanded_bbox,
-                None,  # No initial keypoints known for this frame yet
-                detect_mode=detect_mode,
-                score=landmark_score_threshold,
-                from_points=False,  # Must be False here as we only have a box
-                use_mean_eyes=use_mean_eyes,
-            )
-
-            # Verification: If no landmarks found, tracking failed -> Full Redetect needed
-            if len(kpss_5) == 0:
-                return None, None, None
-
-            # Determine which keypoints to use for bbox recalculation
-            # Use dense landmarks if available (more precise), otherwise 5 points
-            current_kpss = (
-                kpss_all if (kpss_all is not None and len(kpss_all) > 0) else kpss_5
-            )
-
-            # Recalculate Bounding Box from the new landmarks
-            # This allows the box to "move" and follow the face
-            if current_kpss is not None and len(current_kpss) > 0:
-                min_x, min_y = np.min(current_kpss, axis=0)
-                max_x, max_y = np.max(current_kpss, axis=0)
-
-                # Add a little padding to the new box so it doesn't shrink over time
-                pad_w = (max_x - min_x) * 0.1
-                pad_h = (max_y - min_y) * 0.1
-
-                new_bbox = np.array(
-                    [
-                        max(0, min_x - pad_w),
-                        max(0, min_y - pad_h),
-                        min(img_width, max_x + pad_w),
-                        min(img_height, max_y + pad_h),
-                    ]
-                )
-
-                # Append results
-                tracked_det.append(new_bbox)
-                tracked_kpss.append(
-                    kpss_5
-                )  # We keep the 5-points format for consistency
-                # BT-14: use a conservative fallback score (0.5) rather than 0.99,
-                # so secondary landmark models can improve the result when confidence is uncertain
-                tracked_scores.append(prev_face.get("score", 0.5))
-            else:
-                return None, None, None
-
-        return (
-            np.array(tracked_det, dtype=np.float32),
-            np.array(tracked_kpss, dtype=np.float32),
-            np.array(tracked_scores, dtype=np.float32),
-        )
-
     def run_detect(
         self,
         img,
@@ -566,7 +471,6 @@ class FaceDetectors:
         landmark_score=0.5,
         from_points=False,
         rotation_angles=None,
-        previous_detections=None,
         bypass_bytetrack=False,
         **kwargs,
     ):
@@ -585,7 +489,6 @@ class FaceDetectors:
         # upside-down face crop that landmark detectors cannot handle, which corrupts
         # kpss_5 and causes wrong embeddings / ghost-face artifacts.
         if use_multi_rotation:
-            previous_detections = None
             from_points = True
 
         control = self.models_processor.main_window.control
@@ -595,92 +498,7 @@ class FaceDetectors:
         if bypass_bytetrack:
             use_bytetrack = False
 
-        # ByteTrack skip-frame shortcut: when ByteTrack is active, the tracker has been
-        # initialised, AND this is a detection-interval skip frame (indicated by non-empty
-        # previous_detections), advance the Kalman filter with empty detections rather than
-        # running the full detector.  This makes FaceDetectionIntervalSlider effective even
-        # when ByteTrack is enabled (previously the slider was silently ignored).
-        if (
-            use_bytetrack
-            and BYTETracker is not None
-            and previous_detections is not None
-            and len(previous_detections) > 0
-        ):
-            with self._tracker_lock:
-                if self.tracker is not None:
-                    img_hw = (int(img.shape[1]), int(img.shape[2]))
-                    online_targets = self.tracker.update(
-                        np.empty((0, 5)), img_hw, img_hw
-                    )
-                else:
-                    online_targets = []
-
-            # Build return arrays from coasted tracks (Kalman-predicted positions
-            # with last known landmarks) — same logic as the main ByteTrack path below
-            tracked_det: list = []
-            tracked_kpss_5: list = []
-            tracked_kpss_all: list = []
-            tracked_scores: list = []
-            for t in online_targets:
-                tlwh = t.tlwh
-                tid = t.track_id
-                t_bbox = np.array(
-                    [tlwh[0], tlwh[1], tlwh[0] + tlwh[2], tlwh[1] + tlwh[3]]
-                )
-                with self._track_history_lock:
-                    hist = self.track_history.get(tid)
-                if hist is not None and hist.get("kps") is not None:
-                    tracked_det.append(t_bbox)
-                    tracked_kpss_5.append(hist["kps"])
-                    tracked_kpss_all.append(hist["kps"])
-                    tracked_scores.append(hist["cum_score"])
-
-            if tracked_det:
-                return (
-                    np.array(tracked_det, dtype=np.float32),
-                    np.array(tracked_kpss_5, dtype=np.float32),
-                    np.array(tracked_kpss_all, dtype=object),
-                )
-            # Tracker had no active tracks (e.g. first ever frame) → fall through to full detection
-            # so the user sees faces immediately rather than waiting one extra frame.
-
-        # TRACKING ATTEMPT (Simple Fallback)
-        # If we have previous faces and tracking is requested (via implicit logic or kwargs)
-        # We skip this if ByteTrack is enabled to prioritize the advanced tracker
-        if (
-            not use_bytetrack
-            and previous_detections is not None
-            and len(previous_detections) > 0
-        ):
-            # Try to track
-            t_det, t_kpss, t_scores = self.track_faces(
-                img,
-                previous_detections,
-                landmark_score=landmark_score,
-                landmark_detect_mode=landmark_detect_mode,
-                **kwargs,
-            )
-
-            # If tracking succeeded (returns are not None), skip heavy detection
-            if t_det is not None:
-                # Optionally refine landmarks (if the user wants detailed landmarks)
-                if use_landmark_detection:
-                    det_r, kpss_5_r, kpss_r, _ = self._refine_landmarks(
-                        img,
-                        t_det,
-                        t_kpss,
-                        t_scores,
-                        use_landmark_detection,
-                        landmark_detect_mode,
-                        landmark_score,
-                        from_points,
-                        **kwargs,
-                    )
-                    return det_r, kpss_5_r, kpss_r
-                return t_det, t_kpss, t_kpss
-
         # FULL DETECTION FALLBACK
-        # If no previous detections or tracking failed, run the heavy model
         detector = self.detector_map.get(detect_mode)
         if not detector:
             return np.empty((0, 4)), np.empty((0, 5, 2)), np.empty((0, 5, 2))

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -532,19 +532,7 @@ class VideoProcessor(QObject):
                             break
 
             # DO NOT override user choice! We preserve use_landmark and landmark_mode.
-
-            detection_interval = int(
-                local_control_for_worker.get("FaceDetectionIntervalSlider", 1)
-            )
-            previous_faces_arg = None
-
-            if (
-                len(self.last_detected_faces) > 0
-                and self.current_frame_number % detection_interval != 0
-            ):
-                previous_faces_arg = self.last_detected_faces
             device = self.main_window.models_processor.device
-
             owns_frame_tensor = frame_tensor is None
             if frame_tensor is None:
                 frame_tensor = (
@@ -573,7 +561,6 @@ class VideoProcessor(QObject):
                 use_mean_eyes=local_control_for_worker.get(
                     "LandmarkMeanEyesToggle", False
                 ),
-                previous_detections=previous_faces_arg,
             )
 
             # 2. Smart Double-Scan for 203 points
@@ -608,7 +595,6 @@ class VideoProcessor(QObject):
                         use_mean_eyes=local_control_for_worker.get(
                             "LandmarkMeanEyesToggle", False
                         ),
-                        previous_detections=previous_faces_arg,
                         bypass_bytetrack=True,  # Prevent double-incrementing the object tracker
                     )
 

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -1185,19 +1185,6 @@ class FrameWorker(threading.Thread):
             self.set_scaling_transforms(control)
             self._last_vr_scaling_control = _vr_scaling_keys
 
-        # Detection interval / previous-detections setup (mirrors standard-mode logic).
-        _vr_detection_interval = int(control.get("FaceDetectionIntervalSlider", 1))
-        _previous_faces_vr: list | None = None
-        with self.lock:
-            _last_detected_vr = self.last_detected_faces_vr
-            _last_frame_no_vr = self.last_processed_frame_number_vr
-        if (
-            len(_last_detected_vr) > 0
-            and self.frame_number % _vr_detection_interval != 0
-            and self.frame_number == _last_frame_no_vr + 1
-        ):
-            _previous_faces_vr = _last_detected_vr
-
         # Improvement D: in Both-Eyes mode, detect on each eye-half separately.
         # A standard VR180 SBS equirect is 2:1 (W=2H), so each half is square (H×H).
         # Detecting on each 1:1 half gives the detector 4× more pixels per face vs
@@ -1217,7 +1204,7 @@ class FrameWorker(threading.Thread):
         _lm_score = control["LandmarkDetectScoreSlider"] / 100.0
         _use_mean_eyes = control.get("LandmarkMeanEyesToggle", False)
 
-        def _run_det(tensor, prev_dets=None, bypass_bytetrack=False):
+        def _run_det(tensor, bypass_bytetrack=False):
             return self.models_processor.run_detect(
                 tensor,
                 _det_mode,
@@ -1229,7 +1216,6 @@ class FrameWorker(threading.Thread):
                 from_points=False,
                 rotation_angles=vr_rotation_angles,
                 use_mean_eyes=_use_mean_eyes,
-                previous_detections=prev_dets,
                 bypass_bytetrack=bypass_bytetrack,
             )
 
@@ -1245,37 +1231,13 @@ class FrameWorker(threading.Thread):
             _left_tensor = original_equirect_tensor_for_vr[:, :, :_half_w]
             _right_tensor = original_equirect_tensor_for_vr[:, :, _half_w:]
 
-            # Split previous_detections into per-eye coordinate spaces
-            _prev_left: list | None = None
-            _prev_right: list | None = None
-            if _previous_faces_vr is not None:
-                _prev_left = [
-                    f
-                    for f in _previous_faces_vr
-                    if (f["bbox"][0] + f["bbox"][2]) / 2.0 < _half_w
-                ]
-                _prev_right = [
-                    {
-                        "bbox": [
-                            f["bbox"][0] - _half_w,
-                            f["bbox"][1],
-                            f["bbox"][2] - _half_w,
-                            f["bbox"][3],
-                        ],
-                        "score": f.get("score", 1.0),
-                    }
-                    for f in _previous_faces_vr
-                    if (f["bbox"][0] + f["bbox"][2]) / 2.0 >= _half_w
-                ]
-
             # bypass_bytetrack=True: per-eye detection uses half-width coordinate spaces,
             # which would corrupt the tracker's Kalman state if ByteTrack ran on both halves.
-            # Simple fallback tracking (via previous_detections) handles the interval skip.
             _bboxes_left = _norm_bboxes(
-                _run_det(_left_tensor, _prev_left, bypass_bytetrack=True)[0]
+                _run_det(_left_tensor, bypass_bytetrack=True)[0]
             )
             _bboxes_right = _norm_bboxes(
-                _run_det(_right_tensor, _prev_right, bypass_bytetrack=True)[0]
+                _run_det(_right_tensor, bypass_bytetrack=True)[0]
             )
 
             # Offset right-half x-coordinates into full-equirect space
@@ -1293,9 +1255,7 @@ class FrameWorker(threading.Thread):
         else:
             # Single Eye or non-2:1 equirect — detect on the full frame as before.
             # Use the standard (512, 512) input size — TRT engines are compiled for this shape.
-            bboxes_eq_np = _norm_bboxes(
-                _run_det(original_equirect_tensor_for_vr, _previous_faces_vr)[0]
-            )
+            bboxes_eq_np = _norm_bboxes(_run_det(original_equirect_tensor_for_vr)[0])
 
         if not isinstance(bboxes_eq_np, np.ndarray):
             bboxes_eq_np = np.array(bboxes_eq_np)
@@ -1305,14 +1265,7 @@ class FrameWorker(threading.Thread):
             bboxes_eq_np = bboxes_eq_np.reshape(1, -1)
 
         # Improvement A: tiled perspective detection — catch faces missed by equirect
-        # detection (distorted at high elevation, near ±180° seam, or large near-camera faces).
-        # Guard: only run on detection keyframes (same interval as equirect detection) to avoid
-        # running 24 full inference passes every frame, which causes major slowdowns.
-        _is_detection_keyframe = (
-            _vr_detection_interval <= 1
-            or self.frame_number % _vr_detection_interval == 0
-        )
-        if control.get("VR180TileDetectionToggle", False) and _is_detection_keyframe:
+        if control.get("VR180TileDetectionToggle", False):
             _tile_bboxes = self._detect_faces_vr_tiled(
                 equirect_converter,
                 control,

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -359,15 +359,6 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
             "step": 1,
             "help": "Set the confidence score threshold for face detection. Higher values ensure more confident detections but may miss some faces.",
         },
-        "FaceDetectionIntervalSlider": {
-            "level": 1,
-            "label": "Detection Interval (Frames)",
-            "min_value": "1",
-            "max_value": "30",
-            "default": "1",
-            "step": 1,
-            "help": "How often to run the full face detector. Higher values improve FPS but may lose fast-moving faces. 1 = Detect every frame (Slowest).",
-        },
         "MaxFacesToDetectSlider": {
             "level": 1,
             "label": "Max No of Faces to Detect",


### PR DESCRIPTION
Summary of Changes
Removed Face Detection Interval Skip-Frame Logic

This PR removes the FaceDetectionIntervalSlider feature and all related skip-frame tracking mechanisms:

❌ Deleted track_faces() method and simple fallback tracking logic from face_detectors.py
❌ Removed previous_detections parameter from run_detect() method
❌ Removed FaceDetectionIntervalSlider UI widget from settings
❌ Cleaned up detection interval logic from:
video_processor.py (sequential detection)
frame_worker.py (standard and VR180 modes)
Impact: Face detection now runs on every frame instead of skipping frames based on the interval slider. This simplifies the detection pipeline and removes the lightweight tracking fallback, though it may impact FPS on resource-constrained systems