### PR TITLE
Tweak mean / median embeddings with norm

### DIFF
--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -686,30 +686,29 @@ class TargetFaceCardButton(CardButton):
 
         # Calcolo degli embedding se presenti
         if len(all_input_embeddings) > 0:
-            if control["EmbMergeMethodSelection"] == "Mean":
-                self.assigned_input_embedding = {
-                    model: np.mean(
-                        [
-                            store[model]
-                            for store in all_input_embeddings
-                            if model in store
-                        ],
-                        axis=0,
-                    )
-                    for model in all_embedding_swap_models
-                }
-            elif control["EmbMergeMethodSelection"] == "Median":
-                self.assigned_input_embedding = {
-                    model: np.median(
-                        [
-                            store[model]
-                            for store in all_input_embeddings
-                            if model in store
-                        ],
-                        axis=0,
-                    )
-                    for model in all_embedding_swap_models
-                }
+            self.assigned_input_embedding = {}
+            for model in all_embedding_swap_models:
+                # Gather all embeddings for the current swap model
+                embeddings_to_merge = [
+                    store[model] for store in all_input_embeddings if model in store
+                ]
+
+                # 1. Apply Mean or Median
+                if control["EmbMergeMethodSelection"] == "Mean":
+                    merged_emb = np.mean(embeddings_to_merge, axis=0)
+                elif control["EmbMergeMethodSelection"] == "Median":
+                    merged_emb = np.median(embeddings_to_merge, axis=0)
+                else:
+                    merged_emb = np.mean(embeddings_to_merge, axis=0)  # Fallback
+
+                # 2. Apply L2 Normalization
+                # Face embeddings must remain on the unit hypersphere.
+                # Without this, mean/median shrinks the vector length
+                norm = np.linalg.norm(merged_emb)
+                if norm > 0:
+                    merged_emb = merged_emb / norm
+
+                self.assigned_input_embedding[model] = merged_emb
 
         else:
             self.assigned_input_embedding = {}
@@ -808,15 +807,8 @@ class TargetFaceCardButton(CardButton):
                             if tensors_to_merge:
                                 # Stack all tensors along a new dimension (dim=0)
                                 stacked = torch.stack(tensors_to_merge, dim=0)
-
-                                # Use the same merging method as for embeddings (Mean or Median)
-                                if (
-                                    control.get("EmbMergeMethodSelection", "Mean")
-                                    == "Median"
-                                ):
-                                    merged_tensor = torch.median(stacked, dim=0).values
-                                else:
-                                    merged_tensor = torch.mean(stacked, dim=0)
+                                # Never use Median on spacial k/v
+                                merged_tensor = torch.mean(stacked, dim=0)
 
                                 merged_kv_map[layer_key][kv_key] = merged_tensor
 
@@ -1422,10 +1414,21 @@ class CreateEmbeddingDialog(QtWidgets.QDialog):
             # Calcola l'embedding unito per ciascun embedding_swap_model
             final_embedding_store = {}
             for swap_model, embeddings in merged_embedding_store.items():
+                # 1. Apply Mean or Median
                 if self.merge_type == "Mean":
-                    final_embedding_store[swap_model] = np.mean(embeddings, axis=0)
+                    merged_emb = np.mean(embeddings, axis=0)
                 elif self.merge_type == "Median":
-                    final_embedding_store[swap_model] = np.median(embeddings, axis=0)
+                    merged_emb = np.median(embeddings, axis=0)
+                else:
+                    merged_emb = np.mean(embeddings, axis=0)  # Fallback
+
+                # 2. Apply L2 Normalization
+                # Ensures the resulting embedding vector length is 1.0
+                norm = np.linalg.norm(merged_emb)
+                if norm > 0:
+                    merged_emb = merged_emb / norm
+
+                final_embedding_store[swap_model] = merged_emb
 
             # Crea e aggiungi il nuovo embedding_store con tutti i modelli di swap
             from app.ui.widgets.actions import list_view_actions


### PR DESCRIPTION
**Summary of Changes**

**File: `app/ui/widgets/widget_components.py`**

- **Refactored embedding merge logic** in `calculate_assigned_input_embedding()`: Replaced nested if/elif dictionary comprehensions with a cleaner loop-based approach for improved readability.

- **Added L2 Normalization**: Implemented L2 normalization of merged embeddings to maintain unit vector length on the hypersphere, ensuring face embeddings remain properly scaled after mean/median operations.

- **Updated KV tensor merging**: Removed median option for spatial k/v tensors in the cross-attention mechanism—now exclusively uses mean merging to preserve spatial relationships.

- **Enhanced `create_embedding()` method**: Applied the same L2 normalization logic to merged embeddings in the final embedding store creation with added fallback to mean method.

**Impact**: Improves embedding quality and consistency by ensuring proper normalization while simplifying code maintainability.
