### PR TITLE
Fix/target video preview and reaging UI

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -241,6 +241,7 @@ class VideoProcessor(QObject):
 
         # Frame cache
         self._last_requested_frame_num: int | None = None
+        self._cached_raw_frame_media_path: str | None = None
         self._cached_raw_frame_number: int | None = None
         self._cached_raw_frame_target_height: int | None = None
         self._cached_raw_frame_bgr: numpy.ndarray | None = None
@@ -1762,6 +1763,17 @@ class VideoProcessor(QObject):
 
         self._current_single_frame_worker = None
 
+    def _clear_single_frame_preview_caches(self):
+        self._last_requested_frame_num = None
+        self._cached_raw_frame_media_path = None
+        self._cached_raw_frame_number = None
+        self._cached_raw_frame_target_height = None
+        self._cached_raw_frame_bgr = None
+        self._cached_raw_image_path = None
+        self._cached_raw_image_target_height = None
+        self._cached_raw_image_bgr = None
+        self._seek_cached_frame = None
+
     def start_frame_worker(
         self,
         frame_number,
@@ -1877,7 +1889,8 @@ class VideoProcessor(QObject):
         # --- Read the frame based on file type ---
         if self.file_type == "video" and self.media_capture:
             is_cached = (
-                self._cached_raw_frame_number == self.current_frame_number
+                self._cached_raw_frame_media_path == self.media_path
+                and self._cached_raw_frame_number == self.current_frame_number
                 and self._cached_raw_frame_target_height == target_height
                 and self._cached_raw_frame_bgr is not None
             )
@@ -1893,6 +1906,7 @@ class VideoProcessor(QObject):
                     preview_target_height=target_height,
                 )
                 if ret and frame_bgr is not None:
+                    self._cached_raw_frame_media_path = self.media_path
                     self._cached_raw_frame_number = self.current_frame_number
                     self._cached_raw_frame_target_height = target_height
                     self._cached_raw_frame_bgr = frame_bgr.copy()
@@ -2025,6 +2039,7 @@ class VideoProcessor(QObject):
         # VP-34: Check if capture is missing/broken while idle. If so, fix it.
         if not was_active:
             self._cancel_single_frame_preview_state()
+            self._clear_single_frame_preview_caches()
             if self.file_type == "video" and self.media_path:
                 if not self.media_capture or not self.media_capture.isOpened():
                     print(
@@ -2077,7 +2092,7 @@ class VideoProcessor(QObject):
         # VP-24: We clear the queue and then send poison pills to wake workers
         # blocked on queue.get().
         self.frames_to_display.clear()
-        self._seek_cached_frame = None  # release seek-preview frame (~6–25 MB at HD/4K)
+        self._clear_single_frame_preview_caches()
         self.webcam_frames_to_display.queue.clear()
         with self.frame_queue.mutex:
             self.frame_queue.queue.clear()

--- a/app/ui/widgets/actions/common_actions.py
+++ b/app/ui/widgets/actions/common_actions.py
@@ -298,6 +298,8 @@ def set_parameter_row_visibility(current_widget, visible: bool):
         current_widget.row_widget.setVisible(visible)
     else:
         current_widget.setVisible(visible)
+    if hasattr(current_widget, "below_row_widget") and current_widget.below_row_widget:
+        current_widget.below_row_widget.setVisible(visible)
 
     # Keep the child widgets in sync so internal widget state matches the row state.
     current_widget.setVisible(visible)

--- a/app/ui/widgets/actions/layout_actions.py
+++ b/app/ui/widgets/actions/layout_actions.py
@@ -53,6 +53,19 @@ def add_widgets_to_tab_layout(
         category_layout.addRow(row_widget)
         return row_widget, horizontal_layout
 
+    def create_layout_action_button(button_data: dict):
+        action_button = QtWidgets.QPushButton(cast(str, button_data["label"]))
+        action_button.setToolTip(cast(str, button_data.get("help", "")))
+        if "fixed_width" in button_data:
+            action_button.setFixedWidth(cast(int, button_data["fixed_width"]))
+        else:
+            action_button.setMaximumWidth(55)
+        if "exec_function" in button_data:
+            action_button.clicked.connect(
+                partial(cast(Callable, button_data["exec_function"]), main_window)
+            )
+        return action_button
+
     def build_section_id(category_name: str) -> str:
         normalized_name = re.sub(r"[^a-z0-9]+", "_", category_name.lower()).strip("_")
         return f"{section_namespace}:{normalized_name}"
@@ -379,23 +392,28 @@ def add_widgets_to_tab_layout(
                 ]
                 if "action_button" in widget_data:
                     _ab_data: dict = cast(dict, widget_data["action_button"])
-                    _action_btn = QtWidgets.QPushButton(cast(str, _ab_data["label"]))
-                    _action_btn.setToolTip(cast(str, _ab_data.get("help", "")))
-                    if "fixed_width" in _ab_data:
-                        _action_btn.setFixedWidth(cast(int, _ab_data["fixed_width"]))
-                    else:
-                        _action_btn.setMaximumWidth(55)
-                    if "exec_function" in _ab_data:
-                        _action_btn.clicked.connect(
-                            partial(
-                                cast(Callable, _ab_data["exec_function"]), main_window
-                            )
-                        )
+                    _action_btn = create_layout_action_button(_ab_data)
                     _slider_row_widgets.append(_action_btn)
                 row_widget, horizontal_layout = add_horizontal_layout_to_category(
                     category_layout,
                     *_slider_row_widgets,
                 )
+                if "below_row_button" in widget_data:
+                    _below_ab_data: dict = cast(dict, widget_data["below_row_button"])
+                    _below_action_btn = create_layout_action_button(_below_ab_data)
+                    _below_spacer = QtWidgets.QWidget()
+                    _below_spacer.setSizePolicy(
+                        QtWidgets.QSizePolicy.Policy.Expanding,
+                        QtWidgets.QSizePolicy.Policy.Maximum,
+                    )
+                    _below_row_widget, _below_horizontal_layout = (
+                        add_horizontal_layout_to_category(
+                            category_layout,
+                            _below_action_btn,
+                            _below_spacer,
+                        )
+                    )
+                    widget.below_row_widget = _below_row_widget
 
                 if data_type == "parameter":
                     common_widget_actions.create_default_parameter(

--- a/app/ui/widgets/swapper_layout_data.py
+++ b/app/ui/widgets/swapper_layout_data.py
@@ -1725,7 +1725,7 @@ SWAPPER_LAYOUT_DATA: Any = {  # noqa: F811
             "requiredToggleValue": True,
             "enable_refresh_frame": False,
             "help": "Target age to transform the input face to (0–100). Click 'Apply' after changing this value.",
-            "action_button": {
+            "below_row_button": {
                 "label": "Apply",
                 "fixed_width": 68,
                 "help": "Apply the age transformation to the input face and re-compute embeddings and KV maps.",

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -301,6 +301,7 @@ class TargetMediaCardButton(CardButton):
 
         # Stop the current video processing
         main_window.video_processor.stop_processing()
+        main_window.video_processor._clear_single_frame_preview_caches()
 
         if main_window.selected_target_face_id:
             main_window.current_widget_parameters = main_window.parameters[

--- a/tests/unit/processors/test_video_processor_audio.py
+++ b/tests/unit/processors/test_video_processor_audio.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import queue
 from pathlib import Path
 from types import SimpleNamespace
+import numpy as np
+import torch
 
 from app.processors.video_processor import VideoProcessor
 
@@ -12,6 +14,100 @@ class _RunResult:
         self.returncode = returncode
         self.stderr = stderr
         self.stdout = stdout
+
+
+def test_clear_single_frame_preview_caches_resets_all_preview_state():
+    dummy = SimpleNamespace(
+        _last_requested_frame_num=7,
+        _cached_raw_frame_media_path="video_a.mp4",
+        _cached_raw_frame_number=12,
+        _cached_raw_frame_target_height=720,
+        _cached_raw_frame_bgr=np.zeros((2, 2, 3), dtype=np.uint8),
+        _cached_raw_image_path="image_a.png",
+        _cached_raw_image_target_height=1080,
+        _cached_raw_image_bgr=np.ones((2, 2, 3), dtype=np.uint8),
+        _seek_cached_frame=(12, np.ones((2, 2, 3), dtype=np.uint8)),
+    )
+
+    VideoProcessor._clear_single_frame_preview_caches(dummy)
+
+    assert dummy._last_requested_frame_num is None
+    assert dummy._cached_raw_frame_media_path is None
+    assert dummy._cached_raw_frame_number is None
+    assert dummy._cached_raw_frame_target_height is None
+    assert dummy._cached_raw_frame_bgr is None
+    assert dummy._cached_raw_image_path is None
+    assert dummy._cached_raw_image_target_height is None
+    assert dummy._cached_raw_image_bgr is None
+    assert dummy._seek_cached_frame is None
+
+
+def test_process_current_frame_ignores_cached_video_frame_from_other_media(monkeypatch):
+    read_calls = []
+    displayed_frames = []
+    started_workers = []
+    fresh_frame_bgr = np.full((2, 3, 3), 77, dtype=np.uint8)
+
+    dummy = SimpleNamespace(
+        processing=False,
+        is_processing_segments=False,
+        main_window=SimpleNamespace(
+            control={"DenoiserBaseSeedSlider": 220},
+            videoSeekSlider=SimpleNamespace(value=lambda: 0),
+            last_seek_read_failed=False,
+        ),
+        file_type="video",
+        media_capture=object(),
+        current_frame_number=0,
+        next_frame_to_display=0,
+        media_path="video_b.mp4",
+        media_rotation=0,
+        max_frame_number=20,
+        _last_requested_frame_num=None,
+        _cached_raw_frame_media_path="video_a.mp4",
+        _cached_raw_frame_number=0,
+        _cached_raw_frame_target_height=None,
+        _cached_raw_frame_bgr=np.full((2, 3, 3), 11, dtype=np.uint8),
+        _seek_cached_frame=None,
+        _get_target_input_height=lambda: None,
+        display_current_frame=lambda **kwargs: displayed_frames.append(kwargs),
+        start_frame_worker=lambda frame_number, frame, is_single_frame, synchronous, fit_on_complete: (
+            started_workers.append(
+                (
+                    frame_number,
+                    frame.copy(),
+                    is_single_frame,
+                    synchronous,
+                    fit_on_complete,
+                )
+            )
+            or "worker"
+        ),
+    )
+
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.seek_frame",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def fake_read_frame(*_args, **_kwargs):
+        read_calls.append(True)
+        return True, fresh_frame_bgr.copy()
+
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.read_frame", fake_read_frame
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    result = VideoProcessor.process_current_frame(dummy, synchronous=True)
+
+    assert result == "worker"
+    assert read_calls == [True]
+    assert dummy._cached_raw_frame_media_path == "video_b.mp4"
+    assert len(displayed_frames) == 1
+    assert np.array_equal(displayed_frames[0]["frame"], fresh_frame_bgr)
+    assert len(started_workers) == 1
+    assert np.array_equal(started_workers[0][1], fresh_frame_bgr[..., ::-1])
 
 
 def test_mark_skipped_frame_tracks_reason_counts():

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -1566,6 +1566,115 @@ def test_scan_guard_restores_target_media_card_checked_state(monkeypatch):
     assert len(toast_calls) == 2
 
 
+def test_target_media_load_clears_single_frame_preview_caches(monkeypatch):
+    class _Capture:
+        def __init__(self):
+            self.released = False
+            self.set_calls = []
+
+        def isOpened(self):
+            return True
+
+        def set(self, prop, value):
+            self.set_calls.append((prop, value))
+
+        def get(self, prop):
+            if prop == widget_components.cv2.CAP_PROP_FRAME_COUNT:
+                return 5
+            if prop == widget_components.cv2.CAP_PROP_FPS:
+                return 24
+            return 0
+
+        def release(self):
+            self.released = True
+
+    refresh_calls = []
+    clear_calls = []
+    capture = _Capture()
+    toggled = []
+
+    main_window = SimpleNamespace(
+        selected_video_button=SimpleNamespace(toggle=lambda: toggled.append(True)),
+        selected_target_face_id=None,
+        current_widget_parameters={},
+        parameters={},
+        control={
+            "AutoSwapToggle": False,
+            "SendVirtCamFramesEnableToggle": False,
+        },
+        video_processor=SimpleNamespace(
+            stop_processing=lambda: False,
+            _clear_single_frame_preview_caches=lambda: clear_calls.append(True),
+            current_frame_number=99,
+            media_path="old.mp4",
+            current_frame=[],
+            media_capture=None,
+            media_rotation=0,
+            fps=0,
+            max_frame_number=0,
+            next_frame_to_display=99,
+            file_type=None,
+        ),
+        scene=SimpleNamespace(clear=lambda: None),
+        graphicsViewFrame=SimpleNamespace(update=lambda: None),
+        videoSeekSlider=SimpleNamespace(
+            blockSignals=lambda *_args, **_kwargs: None,
+            setMaximum=lambda *_args, **_kwargs: None,
+            setValue=lambda *_args, **_kwargs: None,
+        ),
+        loading_new_media=False,
+    )
+
+    card = SimpleNamespace(
+        main_window=main_window,
+        file_type="video",
+        media_path="new.mp4",
+        media_capture=None,
+        reset_related_widgets_and_values=lambda: None,
+        _restore_pre_click_checked_state=lambda: None,
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.get_video_rotation", lambda *_args: 0
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.misc_helpers.check_and_warn_vfr",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.cv2.VideoCapture", lambda *_args: capture
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.misc_helpers.read_frame",
+        lambda *_args, **_kwargs: (True, "frame0"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.common_widget_actions.get_pixmap_from_frame",
+        lambda *_args, **_kwargs: "pixmap",
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.graphics_view_actions.update_graphics_view",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.common_widget_actions.set_widgets_values_using_face_id_parameters",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.widget_components.common_widget_actions.refresh_frame",
+        lambda *_args, **kwargs: refresh_calls.append(kwargs),
+    )
+
+    widget_components.TargetMediaCardButton.load_media(card)
+
+    assert toggled == [True]
+    assert clear_calls == [True]
+    assert refresh_calls == [{"synchronous": True}]
+    assert main_window.video_processor.current_frame == "frame0"
+    assert main_window.video_processor.media_capture is capture
+    assert main_window.selected_video_button is card
+
+
 def test_scan_guard_restores_input_face_card_checked_state(monkeypatch):
     main_window = _make_scan_main_window(keep_controls=True)
     main_window.scan_issue_worker = object()

--- a/tests/unit/ui/test_widget_logic.py
+++ b/tests/unit/ui/test_widget_logic.py
@@ -206,6 +206,22 @@ def test_toggle_on_required_false_hides_child():
 # ---------------------------------------------------------------------------
 
 
+def test_toggle_updates_below_row_widget_visibility():
+    mw, parent, child = _make_toggle_setup(
+        parent_name="FaceReagingEnableToggle",
+        child_name="FaceReagingTargetAgeSlider",
+        required_toggle_value=False,
+        parent_is_checked=True,
+    )
+    child.below_row_widget = MagicMock()
+
+    show_hide_related_widgets(mw, parent, "FaceReagingEnableToggle")
+
+    child.row_widget.setVisible.assert_called_once_with(False)
+    child.below_row_widget.setVisible.assert_called_once_with(False)
+    child.setVisible.assert_called_once_with(False)
+
+
 def test_child_not_in_parameter_widgets_is_skipped():
     parent_widget = MagicMock()
     parent_widget.isChecked.return_value = True


### PR DESCRIPTION
## Summary

This branch fixes two issues.

It fixes stale preview frames when switching target videos by clearing single-frame preview caches on media switch/stop and preventing cached raw frames from being reused across different media.

It also fixes the Face Re-Aging layout by moving the `Apply` button onto its own row below the age controls, with visibility kept in sync with the rest of the re-aging controls.

## Included changes

- Invalidate preview/raw-frame caches when switching target video
- Prevent cross-media reuse of cached raw preview frames
- Move `Face Re-Aging Apply` below the age controls
- Keep the below-row `Apply` button visibility tied to re-aging controls

## Verification

- `tests/unit/processors/test_video_processor_audio.py`
- `tests/unit/ui/test_issue_scan_progress.py`
- `tests/unit/ui/test_widget_logic.py`
- `pre-commit run --all-files`