### PR TITLE
fix issue scanning error when KPS smoothing enabled

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -818,30 +818,46 @@ class VideoProcessor(QObject):
                                 new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
 
                         # Smoothing on Dense KPS 203
-                        if has_dense_kps_203:
-                            if _best_match_key in self._smoothed_dense_kps_203:
-                                new_smoothed_dense_kps_203[_i] = (
-                                    dynamic_alpha * valid_kpss_203[_i]
-                                    + (1.0 - dynamic_alpha)
-                                    * self._smoothed_dense_kps_203[_best_match_key]
-                                )
-                                del self._smoothed_dense_kps_203[_best_match_key]
+                        if (has_dense_kps_203):
+                            # check if kpss_5 has more shapes than valid_kpss_203
+                            if _i < valid_kpss_203.shape[0]:
+                                if _best_match_key in self._smoothed_dense_kps_203:
+                                    new_smoothed_dense_kps_203[_i] = (
+                                        dynamic_alpha * valid_kpss_203[_i]
+                                        + (1.0 - dynamic_alpha)
+                                        * self._smoothed_dense_kps_203[_best_match_key]
+                                    )
+                                    del self._smoothed_dense_kps_203[_best_match_key]
+                                else:
+                                    new_smoothed_dense_kps_203[_i] = valid_kpss_203[
+                                        _i
+                                    ].copy()
                             else:
-                                new_smoothed_dense_kps_203[_i] = valid_kpss_203[
-                                    _i
-                                ].copy()
+                                print(f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found.")
+
                     else:
                         new_smoothed_kps[_i] = _raw.copy()
                         if has_dense_kps:
                             new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
-                        if has_dense_kps_203:
-                            new_smoothed_dense_kps_203[_i] = valid_kpss_203[_i].copy()
+                        if (has_dense_kps_203):
+                            # check if kpss_5 has more shapes than valid_kpss_203
+                            if _i < valid_kpss_203.shape[0]:
+                                new_smoothed_dense_kps_203[_i] = valid_kpss_203[
+                                    _i
+                                ].copy()
+                            else:
+                                print(f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found.")
+
 
                     kpss_5[_i] = new_smoothed_kps[_i]
                     if has_dense_kps:
                         valid_kpss[_i] = new_smoothed_dense_kps[_i]
-                    if has_dense_kps_203:
-                        valid_kpss_203[_i] = new_smoothed_dense_kps_203[_i]
+                    if (has_dense_kps_203):
+                        # check if kpss_5 has more shapes than valid_kpss_203
+                        if _i < valid_kpss_203.shape[0]:
+                            valid_kpss_203[_i] = new_smoothed_dense_kps_203[_i]
+                        else:
+                            print(f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found.")
 
                 self._smoothed_kps = new_smoothed_kps
                 self._smoothed_dense_kps = new_smoothed_dense_kps
@@ -1541,6 +1557,10 @@ class VideoProcessor(QObject):
                 )
                 if embedding_name:
                     output_folder = os.path.join(output_folder, embedding_name)
+                else:
+                    print(
+                        f"[WARN] ClusterOutputBySourceToggle enabled but embedding_name is falsy"
+                    )
             self.active_output_folder = output_folder
             # Disable UI elements
             if not self.main_window.control["KeepControlsToggle"]:

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -247,6 +247,8 @@ class IssueScanWorker(qtc.QThread):
                 bool(result.get("cancelled", False)),
             )
         except Exception as exc:
+            print(f"[ERROR] IssueScanWorker Failed to run: {exc}")
+            traceback.print_exc()
             self.failed.emit(str(exc))
 
 


### PR DESCRIPTION
apparently when KPS smoothing is enabled, kpss_5 shapes can mismatch the 203 dense KPS when smoothing. this arose during issue scanning so that's all that was tested.