### PR TITLE
Render-predictive issue scan fixes and scan-state isolation

### DIFF
--- a/app/processors/face_detectors.py
+++ b/app/processors/face_detectors.py
@@ -472,6 +472,7 @@ class FaceDetectors:
         from_points=False,
         rotation_angles=None,
         bypass_bytetrack=False,
+        control_override=None,
         **kwargs,
     ):
         """
@@ -491,7 +492,11 @@ class FaceDetectors:
         if use_multi_rotation:
             from_points = True
 
-        control = self.models_processor.main_window.control
+        control = (
+            control_override
+            if isinstance(control_override, dict)
+            else self.models_processor.main_window.control
+        )
         use_bytetrack = control.get("FaceTrackingEnableToggle", False)
         # bypass_bytetrack=True disables ByteTrack for this call only (e.g. per-eye VR
         # detection where the half-width coordinate space would corrupt tracker state)

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -1,5 +1,6 @@
 import threading
 import queue
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any, Dict, Tuple, Optional, cast, List
 import time
 import subprocess
@@ -40,6 +41,31 @@ if TYPE_CHECKING:
 
 IssueScanTargetEmbeddings = dict[str, dict[str, numpy.ndarray]]
 IssueScanTargetSnapshot = dict[str, dict[str, Any]]
+
+SCAN_CONTROL_ALLOWLIST = frozenset(
+    {
+        "GlobalInputResizeToggle",
+        "GlobalInputResizeSizeSelection",
+        "DetectorModelSelection",
+        "MaxFacesToDetectSlider",
+        "DetectorScoreSlider",
+        "LandmarkDetectToggle",
+        "LandmarkDetectModelSelection",
+        "LandmarkDetectScoreSlider",
+        "DetectFromPointsToggle",
+        "AutoRotationToggle",
+        "LandmarkMeanEyesToggle",
+        "FaceTrackingEnableToggle",
+        "ByteTrackTrackThreshSlider",
+        "ByteTrackMatchThreshSlider",
+        "ByteTrackTrackBufferSlider",
+        "KPSSmoothingEnableToggle",
+        "KPSEmaAlphaSlider",
+        "RecognitionModelSelection",
+        "SimilarityTypeSelection",
+    }
+)
+SCAN_FACE_PARAM_ALLOWLIST = frozenset({"SimilarityThresholdSlider"})
 
 TAIL_TOLERANCE = 30  # BUG-07: 10 was too tight — codec trailing B-frames can cause read
 # failures in the last ~10 frames on H.264/H.265 content, dropping valid end frames.
@@ -445,15 +471,27 @@ class VideoProcessor(QObject):
         Helper to determine the target input height if global resize is enabled.
         Returns None if resizing is disabled or invalid.
         """
-        resize_enabled = self.main_window.control.get("GlobalInputResizeToggle", False)
+        return self._get_target_input_height_for_control(self.main_window.control)
+
+    @staticmethod
+    def _get_target_input_height_for_control(
+        control: Mapping[str, Any] | None,
+    ) -> Optional[int]:
+        resize_enabled = (
+            bool(control.get("GlobalInputResizeToggle", False))
+            if isinstance(control, Mapping)
+            else False
+        )
 
         if not resize_enabled:
             return None
 
         try:
             # Get the selected resolution string (e.g., "720p")
-            size_str = self.main_window.control.get(
-                "GlobalInputResizeSizeSelection", "720p"
+            size_str = (
+                control.get("GlobalInputResizeSizeSelection", "720p")
+                if isinstance(control, Mapping)
+                else "720p"
             )
             # Extract the number (e.g., 720)
             return int(str(size_str).replace("p", ""))
@@ -463,12 +501,151 @@ class VideoProcessor(QObject):
             )
             return None
 
+    @staticmethod
+    def _filter_scan_control(control: Mapping[str, Any] | None) -> ControlTypes:
+        if not isinstance(control, Mapping):
+            return cast(ControlTypes, {})
+        return cast(
+            ControlTypes,
+            {
+                str(key): copy.deepcopy(value)
+                for key, value in control.items()
+                if str(key) in SCAN_CONTROL_ALLOWLIST
+            },
+        )
+
+    @staticmethod
+    def _filter_scan_face_params(
+        params: Mapping[str, Any] | None,
+        target_face_ids: Iterable[str] | None = None,
+    ) -> FacesParametersTypes:
+        if not isinstance(params, Mapping):
+            return cast(FacesParametersTypes, {})
+
+        allowed_face_ids = (
+            {str(face_id) for face_id in target_face_ids}
+            if target_face_ids is not None
+            else None
+        )
+        filtered: FacesParametersTypes = cast(FacesParametersTypes, {})
+
+        for face_id, raw_face_params in params.items():
+            face_id_str = str(face_id)
+            if allowed_face_ids is not None and face_id_str not in allowed_face_ids:
+                continue
+            if not isinstance(raw_face_params, Mapping):
+                filtered[face_id_str] = cast(ParametersTypes, {})
+                continue
+            filtered_face_params = {
+                str(key): copy.deepcopy(value)
+                for key, value in raw_face_params.items()
+                if str(key) in SCAN_FACE_PARAM_ALLOWLIST
+            }
+            filtered[face_id_str] = cast(ParametersTypes, filtered_face_params)
+
+        return filtered
+
+    @staticmethod
+    def _marker_control_data_for_position(
+        markers: Mapping[Any, Any] | None, frame_number: int
+    ) -> Mapping[str, Any] | None:
+        if not isinstance(markers, Mapping) or not markers:
+            return None
+
+        latest_key: Any = None
+        latest_frame = None
+        for raw_key in markers.keys():
+            try:
+                marker_frame = int(raw_key)
+            except (TypeError, ValueError):
+                continue
+            if marker_frame > frame_number:
+                continue
+            if latest_frame is None or marker_frame > latest_frame:
+                latest_frame = marker_frame
+                latest_key = raw_key
+
+        if latest_key is None:
+            return None
+
+        marker_data = markers.get(latest_key)
+        if not isinstance(marker_data, Mapping):
+            return None
+        control_data = marker_data.get("control")
+        return control_data if isinstance(control_data, Mapping) else None
+
+    @staticmethod
+    def _issue_scan_vr180_enabled(control: Mapping[str, Any] | None) -> bool:
+        return isinstance(control, Mapping) and bool(
+            control.get("VR180ModeEnableToggle")
+        )
+
+    @staticmethod
+    def get_issue_scan_unavailable_reason(
+        control: Mapping[str, Any] | None,
+        scan_ranges: Iterable[tuple[int, int]] | None = None,
+        markers: Mapping[Any, Any] | None = None,
+        fallback_control: Mapping[str, Any] | None = None,
+    ) -> str | None:
+        if scan_ranges is None:
+            if VideoProcessor._issue_scan_vr180_enabled(control) or (
+                fallback_control is not control
+                and VideoProcessor._issue_scan_vr180_enabled(fallback_control)
+            ):
+                return "Issue scans are not supported while VR180 mode is enabled."
+            return None
+
+        if not isinstance(markers, Mapping):
+            if VideoProcessor._issue_scan_vr180_enabled(control):
+                return "Issue scans are not supported while VR180 mode is enabled."
+            return None
+
+        if not markers:
+            if VideoProcessor._issue_scan_vr180_enabled(control):
+                return "Issue scans are not supported while VR180 mode is enabled."
+            return None
+
+        normalized_marker_frames: list[tuple[Any, int]] = []
+        for raw_key in markers.keys():
+            try:
+                normalized_marker_frames.append((raw_key, int(raw_key)))
+            except (TypeError, ValueError):
+                continue
+        normalized_marker_frames.sort(key=lambda item: item[1])
+
+        for start_frame, end_frame in scan_ranges:
+            if end_frame < start_frame:
+                continue
+
+            if VideoProcessor._issue_scan_vr180_enabled(
+                VideoProcessor._marker_control_data_for_position(
+                    markers, int(start_frame)
+                )
+                or control
+            ):
+                return "Issue scans are not supported while VR180 mode is enabled."
+
+            for raw_key, marker_frame in normalized_marker_frames:
+                if marker_frame < start_frame:
+                    continue
+                if marker_frame > end_frame:
+                    break
+                marker_data = markers.get(raw_key)
+                if not isinstance(marker_data, Mapping):
+                    continue
+                if VideoProcessor._issue_scan_vr180_enabled(
+                    cast(Mapping[str, Any] | None, marker_data.get("control"))
+                ):
+                    return "Issue scans are not supported while VR180 mode is enabled."
+        return None
+
     def _run_sequential_detection(
         self,
         frame_rgb: numpy.ndarray,
         local_control_for_worker: dict,
         local_params_for_worker: dict | None = None,
         frame_tensor: torch.Tensor | None = None,
+        detector_control_override: dict | None = None,
     ):
         """
         Runs face detection sequentially in the feeder thread to guarantee
@@ -562,6 +739,7 @@ class VideoProcessor(QObject):
                 use_mean_eyes=local_control_for_worker.get(
                     "LandmarkMeanEyesToggle", False
                 ),
+                control_override=detector_control_override,
             )
 
             # 2. Smart Double-Scan for 203 points
@@ -604,6 +782,7 @@ class VideoProcessor(QObject):
                                 "LandmarkMeanEyesToggle", False
                             ),
                             bypass_bytetrack=True,  # Prevent double-incrementing the object tracker
+                            control_override=detector_control_override,
                         )
                     )
 
@@ -743,20 +922,47 @@ class VideoProcessor(QObject):
                 valid_kpss = cast(numpy.ndarray, kpss)
                 valid_kpss_203 = cast(numpy.ndarray, kpss_203)
 
-                has_dense_kps = isinstance(kpss, numpy.ndarray) and kpss.shape[0] > 0
+                dense_kps_count = (
+                    int(kpss.shape[0]) if isinstance(kpss, numpy.ndarray) else 0
+                )
+                has_dense_kps = dense_kps_count > 0
                 if has_dense_kps:
                     valid_kpss = valid_kpss.copy()
                     kpss = valid_kpss
 
-                has_dense_kps_203 = (
-                    isinstance(kpss_203, numpy.ndarray) and kpss_203.shape[0] > 0
+                dense_kps_203_count = (
+                    int(kpss_203.shape[0]) if isinstance(kpss_203, numpy.ndarray) else 0
                 )
+                has_dense_kps_203 = dense_kps_203_count > 0
                 if has_dense_kps_203:
                     valid_kpss_203 = valid_kpss_203.copy()
                     kpss_203 = valid_kpss_203
 
+                frame_number_for_warning = int(
+                    getattr(self, "current_frame_number", -1)
+                )
+                if isinstance(kpss, numpy.ndarray) and dense_kps_count != n_faces:
+                    print(
+                        f"[WARN] Dense KPS count mismatch on frame {frame_number_for_warning}: "
+                        f"kpss_5={n_faces}, dense_kps={dense_kps_count}. "
+                        "Skipping dense smoothing for missing faces."
+                    )
+                if (
+                    isinstance(kpss_203, numpy.ndarray)
+                    and dense_kps_203_count != n_faces
+                ):
+                    print(
+                        f"[WARN] Dense KPS_203 count mismatch on frame {frame_number_for_warning}: "
+                        f"kpss_5={n_faces}, dense_kps_203={dense_kps_203_count}. "
+                        "Skipping dense 203 smoothing for missing faces."
+                    )
+
                 for _i in range(n_faces):
                     _raw = kpss_5[_i]
+                    dense_kps_available = has_dense_kps and _i < dense_kps_count
+                    dense_kps_203_available = (
+                        has_dense_kps_203 and _i < dense_kps_203_count
+                    )
 
                     if (
                         _raw is None
@@ -806,7 +1012,7 @@ class VideoProcessor(QObject):
                         del self._smoothed_kps[_best_match_key]
 
                         # Smoothing on Dense KPS
-                        if has_dense_kps:
+                        if dense_kps_available:
                             if _best_match_key in self._smoothed_dense_kps:
                                 new_smoothed_dense_kps[_i] = (
                                     dynamic_alpha * valid_kpss[_i]
@@ -819,8 +1025,7 @@ class VideoProcessor(QObject):
 
                         # Smoothing on Dense KPS 203
                         if has_dense_kps_203:
-                            # check if kpss_5 has more shapes than valid_kpss_203
-                            if _i < valid_kpss_203.shape[0]:
+                            if dense_kps_203_available:
                                 if _best_match_key in self._smoothed_dense_kps_203:
                                     new_smoothed_dense_kps_203[_i] = (
                                         dynamic_alpha * valid_kpss_203[_i]
@@ -832,37 +1037,23 @@ class VideoProcessor(QObject):
                                     new_smoothed_dense_kps_203[_i] = valid_kpss_203[
                                         _i
                                     ].copy()
-                            else:
-                                print(
-                                    f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found."
-                                )
 
                     else:
                         new_smoothed_kps[_i] = _raw.copy()
-                        if has_dense_kps:
+                        if dense_kps_available:
                             new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
                         if has_dense_kps_203:
-                            # check if kpss_5 has more shapes than valid_kpss_203
-                            if _i < valid_kpss_203.shape[0]:
+                            if dense_kps_203_available:
                                 new_smoothed_dense_kps_203[_i] = valid_kpss_203[
                                     _i
                                 ].copy()
-                            else:
-                                print(
-                                    f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found."
-                                )
 
                     kpss_5[_i] = new_smoothed_kps[_i]
-                    if has_dense_kps:
+                    if dense_kps_available:
                         valid_kpss[_i] = new_smoothed_dense_kps[_i]
                     if has_dense_kps_203:
-                        # check if kpss_5 has more shapes than valid_kpss_203
-                        if _i < valid_kpss_203.shape[0]:
+                        if dense_kps_203_available:
                             valid_kpss_203[_i] = new_smoothed_dense_kps_203[_i]
-                        else:
-                            print(
-                                f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found."
-                            )
 
                 self._smoothed_kps = new_smoothed_kps
                 self._smoothed_dense_kps = new_smoothed_dense_kps
@@ -2935,6 +3126,20 @@ class VideoProcessor(QObject):
             previous_frame = frame_number
         return longest_issue_run
 
+    def _get_issue_scan_bytetrack_config(
+        self,
+        control: Mapping[str, Any] | None,
+    ) -> tuple[bool, int, int, int]:
+        if not isinstance(control, Mapping):
+            return (False, 40, 80, 30)
+
+        return (
+            bool(control.get("FaceTrackingEnableToggle", False)),
+            int(control.get("ByteTrackTrackThreshSlider", 40)),
+            int(control.get("ByteTrackMatchThreshSlider", 80)),
+            int(control.get("ByteTrackTrackBufferSlider", 30)),
+        )
+
     def _resolve_scan_state_for_frame(
         self,
         frame_number: int,
@@ -2954,28 +3159,32 @@ class VideoProcessor(QObject):
         )
         if not marker_data:
             return (
-                cast(ControlTypes, copy.deepcopy(base_control)),
-                cast(FacesParametersTypes, copy.deepcopy(base_params)),
+                self._filter_scan_control(copy.deepcopy(base_control)),
+                self._filter_scan_face_params(copy.deepcopy(base_params)),
             )
 
-        local_params = cast(
-            FacesParametersTypes, copy.deepcopy(marker_data.get("parameters", {}))
+        local_params = self._filter_scan_face_params(
+            cast(FacesParametersTypes, copy.deepcopy(marker_data.get("parameters", {})))
         )
         local_control: ControlTypes = cast(ControlTypes, {})
         local_control.update(
-            cast(
-                ControlTypes,
-                copy.deepcopy(
-                    control_defaults_snapshot
-                    if control_defaults_snapshot is not None
-                    else {}
-                ),
+            self._filter_scan_control(
+                cast(
+                    ControlTypes,
+                    copy.deepcopy(
+                        control_defaults_snapshot
+                        if control_defaults_snapshot is not None
+                        else {}
+                    ),
+                )
             )
         )
 
         control_data = marker_data.get("control")
         if isinstance(control_data, dict):
-            local_control.update(cast(ControlTypes, control_data).copy())
+            local_control.update(
+                self._filter_scan_control(cast(ControlTypes, control_data).copy())
+            )
 
         # Mirror the playback helper behavior by ensuring every current target
         # face has a parameter dict, falling back to defaults when missing.
@@ -2984,15 +3193,23 @@ class VideoProcessor(QObject):
             if target_faces_snapshot is not None
             else self.main_window.target_faces
         )
+        default_scan_face_params = cast(
+            ParametersTypes,
+            self._filter_scan_face_params(
+                {"__default__": self.main_window.default_parameters.data}
+            ).get("__default__", {}),
+        )
         for face_id in active_target_faces.keys():
             face_id_str = str(face_id)
             if face_id_str not in local_params:
                 local_params[face_id_str] = cast(
                     ParametersTypes,
-                    copy.deepcopy(self.main_window.default_parameters.data),
+                    copy.deepcopy(default_scan_face_params),
                 )
 
-        return local_control, local_params
+        return self._filter_scan_control(local_control), self._filter_scan_face_params(
+            local_params, active_target_faces.keys()
+        )
 
     def _build_issue_scan_state_segments(
         self,
@@ -3216,33 +3433,50 @@ class VideoProcessor(QObject):
         reset_frame_number: Optional[int] = None,
     ) -> Optional[dict]:
         """Run a full-frame detection scan and return issue-frame results."""
+        scan_ranges = scan_ranges or self._get_issue_scan_ranges()
+        unsupported_reason = self.get_issue_scan_unavailable_reason(
+            base_control if base_control is not None else self.main_window.control,
+            scan_ranges=scan_ranges,
+            markers=getattr(self.main_window, "markers", None),
+            fallback_control=getattr(self.main_window, "control", None),
+        )
+        if unsupported_reason:
+            raise RuntimeError(unsupported_reason)
+
         capture = cv2.VideoCapture(self.media_path)
         if not capture or not capture.isOpened():
             raise RuntimeError("Could not open the selected video for scanning.")
 
-        scan_ranges = scan_ranges or self._get_issue_scan_ranges()
         dropped_frames_snapshot = {
             int(frame) for frame in getattr(self.main_window, "dropped_frames", set())
         }
         total_frames = misc_helpers.count_issue_scan_frames(
             scan_ranges, dropped_frames_snapshot
         )
-        target_height = (
-            target_height
-            if target_height is not None
-            else self._get_target_input_height()
-        )
         base_control = cast(
             ControlTypes,
-            copy.deepcopy(
-                base_control if base_control is not None else self.main_window.control
+            self._filter_scan_control(
+                copy.deepcopy(
+                    base_control
+                    if base_control is not None
+                    else self.main_window.control
+                )
             ),
         )
         base_params = cast(
             FacesParametersTypes,
-            copy.deepcopy(
-                base_params if base_params is not None else self.main_window.parameters
+            self._filter_scan_face_params(
+                copy.deepcopy(
+                    base_params
+                    if base_params is not None
+                    else self.main_window.parameters
+                )
             ),
+        )
+        initial_target_height = (
+            target_height
+            if target_height is not None
+            else self._get_target_input_height_for_control(base_control)
         )
         if target_faces_snapshot is None:
             target_faces_snapshot = self.prepare_issue_scan_target_faces_snapshot(
@@ -3288,6 +3522,7 @@ class VideoProcessor(QObject):
             if tracking_enabled:
                 self.main_window.models_processor.face_detectors.reset_tracker()
             previous_segment_tracking_enabled: Optional[bool] = None
+            previous_segment_bytetrack_config = None
 
             def emit_progress(frame_number: int) -> None:
                 if progress_callback:
@@ -3318,12 +3553,35 @@ class VideoProcessor(QObject):
                 }
 
             for start_frame, end_frame, local_control, local_params in scan_segments:
+                segment_has_resize_state = any(
+                    key in local_control
+                    for key in (
+                        "GlobalInputResizeToggle",
+                        "GlobalInputResizeSizeSelection",
+                    )
+                )
+                segment_target_height = (
+                    self._get_target_input_height_for_control(local_control)
+                    if segment_has_resize_state
+                    else None
+                )
+                if not segment_has_resize_state and segment_target_height is None:
+                    segment_target_height = initial_target_height
                 current_segment_tracking_enabled = bool(
                     local_control.get("FaceTrackingEnableToggle", False)
+                )
+                current_segment_bytetrack_config = (
+                    self._get_issue_scan_bytetrack_config(local_control)
                 )
                 if (
                     current_segment_tracking_enabled
                     and previous_segment_tracking_enabled is False
+                ) or (
+                    current_segment_tracking_enabled
+                    and previous_segment_bytetrack_config is not None
+                    and previous_segment_bytetrack_config[0]
+                    and current_segment_bytetrack_config
+                    != previous_segment_bytetrack_config
                 ):
                     self.main_window.models_processor.face_detectors.reset_tracker()
                     self._reset_issue_scan_sequential_state()
@@ -3352,7 +3610,7 @@ class VideoProcessor(QObject):
                     ret, frame_bgr = misc_helpers.read_frame(
                         capture,
                         self.media_rotation,
-                        preview_target_height=target_height,
+                        preview_target_height=segment_target_height,
                     )
                     if not ret or not isinstance(frame_bgr, numpy.ndarray):
                         for face_id in issue_frames_by_face:
@@ -3381,6 +3639,7 @@ class VideoProcessor(QObject):
                         local_control,
                         local_params,
                         frame_tensor=frame_tensor,
+                        detector_control_override=local_control,
                     )
                     detected_embeddings: list[numpy.ndarray] = []
                     if (
@@ -3432,6 +3691,7 @@ class VideoProcessor(QObject):
                     emit_progress(frame_number)
                     frame_number += 1
                 previous_segment_tracking_enabled = current_segment_tracking_enabled
+                previous_segment_bytetrack_config = current_segment_bytetrack_config
 
             return build_result(False)
         finally:
@@ -4099,32 +4359,13 @@ class VideoProcessor(QObject):
                     use_job_name,
                     output_file_name,
                 )
-                
-                output_folder = self.main_window.control["OutputMediaFolder"]
-                if self.main_window.control.get("ClusterOutputBySourceToggle", False):
-                    target_face_button = getattr(
-                        self.main_window, "cur_selected_target_face_button", None
-                    )
-                    assigned_embeddings = (
-                        getattr(target_face_button, "assigned_merged_embeddings", None)
-                        if target_face_button
-                        else None
-                    )
-                    embedding_id = (
-                        next(iter(assigned_embeddings), None) if assigned_embeddings else None
-                    )
-                    embedding_button = (
-                        self.main_window.merged_embeddings.get(embedding_id)
-                        if embedding_id is not None
-                        else None
-                    )
-                    embedding_name = (
-                        str(getattr(embedding_button, "embedding_name", "")).strip()
-                        if embedding_button is not None
-                        else ""
-                    )
-                    if embedding_name:
-                        output_folder = os.path.join(str(output_folder), embedding_name)
+
+                output_folder = (
+                    str(getattr(self, "active_output_folder", "") or "").strip()
+                    or str(
+                        self.main_window.control.get("OutputMediaFolder", "")
+                    ).strip()
+                )
 
                 final_file_path = misc_helpers.get_output_file_path(
                     self.media_path,
@@ -4292,33 +4533,12 @@ class VideoProcessor(QObject):
 
             # AutoSave workspace if enabled
             if self.main_window.control.get("AutoSaveWorkspaceToggle"):
-                
-                output_folder = self.main_window.control["OutputMediaFolder"]
-                if self.main_window.control.get("ClusterOutputBySourceToggle", False):
-                    target_face_button = getattr(
-                        self.main_window, "cur_selected_target_face_button", None
-                    )
-                    assigned_embeddings = (
-                        getattr(target_face_button, "assigned_merged_embeddings", None)
-                        if target_face_button
-                        else None
-                    )
-                    embedding_id = (
-                        next(iter(assigned_embeddings), None) if assigned_embeddings else None
-                    )
-                    embedding_button = (
-                        self.main_window.merged_embeddings.get(embedding_id)
-                        if embedding_id is not None
-                        else None
-                    )
-                    embedding_name = (
-                        str(getattr(embedding_button, "embedding_name", "")).strip()
-                        if embedding_button is not None
-                        else ""
-                    )
-                    if embedding_name:
-                        output_folder = os.path.join(str(output_folder), embedding_name)
-                        
+                output_folder = (
+                    str(getattr(self, "active_output_folder", "") or "").strip()
+                    or str(
+                        self.main_window.control.get("OutputMediaFolder", "")
+                    ).strip()
+                )
                 json_file_path = misc_helpers.get_output_file_path(
                     self.media_path, output_folder
                 )

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -638,10 +638,11 @@ def add_scan_review_controls(main_window: "MainWindow"):
 
     run_scan_button = QtWidgets.QPushButton("Scan for Issues")
     run_scan_button.setToolTip(
-        "Scans the current render range using your current settings.\n"
+        "Predicts detect/match misses using your current render-time settings.\n"
         "If record start/end markers exist, only those ranges are scanned.\n"
         "Saved settings markers are applied during the scan.\n"
-        "Flags detection or similarity misses for the selected target face.\n"
+        "Honors detection, tracking, KPS smoothing, recognition, and threshold settings.\n"
+        "Flags detection or similarity misses for the loaded target faces.\n"
         "Single-frame preview may differ from playback on borderline frames."
     )
     run_scan_button.setSizePolicy(
@@ -1184,10 +1185,11 @@ def _restore_issue_scan_ui(main_window: "MainWindow") -> None:
     if run_button is not None:
         run_button.setText("Scan for Issues")
         run_button.setToolTip(
-            "Scans the current render range using your current settings.\n"
+            "Predicts detect/match misses using your current render-time settings.\n"
             "If record start/end markers exist, only those ranges are scanned.\n"
             "Saved settings markers are applied during the scan.\n"
-            "Flags detection or similarity misses for the selected target face.\n"
+            "Honors detection, tracking, KPS smoothing, recognition, and threshold settings.\n"
+            "Flags detection or similarity misses for the loaded target faces.\n"
             "Single-frame preview may differ from playback on borderline frames."
         )
 
@@ -1352,6 +1354,24 @@ def run_issue_scan(main_window: "MainWindow"):
             main_window,
             "Scan Not Available",
             "The selected video could not be found on disk.",
+            main_window.videoSeekSlider,
+        )
+        return
+    scan_ranges = (
+        video_processor._get_issue_scan_ranges()
+        if hasattr(video_processor, "_get_issue_scan_ranges")
+        else None
+    )
+    unsupported_reason = video_processor.get_issue_scan_unavailable_reason(
+        getattr(main_window, "control", None),
+        scan_ranges=scan_ranges,
+        markers=getattr(main_window, "markers", None),
+    )
+    if unsupported_reason:
+        common_widget_actions.create_and_show_messagebox(
+            main_window,
+            "Scan Not Available",
+            unsupported_reason,
             main_window.videoSeekSlider,
         )
         return

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -177,16 +177,25 @@ class IssueScanWorker(qtc.QThread):
         self._scan_scope_text = main_window.video_processor.describe_issue_scan_scope(
             self._scan_ranges
         )
-        self._target_height = main_window.video_processor._get_target_input_height()
-        self._base_control = main_window.control.copy()
-        self._base_params = {
-            face_id: params.copy() for face_id, params in main_window.parameters.items()
-        }
-        self._control_defaults_snapshot = {
-            widget_name: widget.default_value
-            for widget_name, widget in main_window.parameter_widgets.items()
-            if widget_name in main_window.control
-        }
+        self._base_control = main_window.video_processor._filter_scan_control(
+            main_window.control.copy()
+        )
+        self._base_params = main_window.video_processor._filter_scan_face_params(
+            {
+                face_id: params.copy()
+                for face_id, params in main_window.parameters.items()
+            },
+            getattr(main_window, "target_faces", {}).keys(),
+        )
+        self._control_defaults_snapshot = (
+            main_window.video_processor._filter_scan_control(
+                {
+                    widget_name: widget.default_value
+                    for widget_name, widget in main_window.parameter_widgets.items()
+                    if widget_name in main_window.control
+                }
+            )
+        )
         self._target_faces_snapshot = (
             main_window.video_processor.prepare_issue_scan_target_faces_snapshot(
                 self._scan_ranges,
@@ -227,7 +236,6 @@ class IssueScanWorker(qtc.QThread):
                 issue_found_callback=issue_found_callback,
                 is_cancelled=self._cancel_event.is_set,
                 scan_ranges=self._scan_ranges,
-                target_height=self._target_height,
                 base_control=self._base_control,
                 base_params=self._base_params,
                 target_faces_snapshot=self._target_faces_snapshot,

--- a/tests/unit/processors/test_video_processor_audio.py
+++ b/tests/unit/processors/test_video_processor_audio.py
@@ -346,3 +346,156 @@ def test_finalize_default_style_recording_uses_rebuilt_audio_when_frames_skipped
     assert str(temp_file) in final_mux_call
     assert "-ss" not in final_mux_call
     assert dummy.temp_file == ""
+
+
+def _make_finalize_default_style_recording_dummy(
+    tmp_path,
+    *,
+    active_output_folder="",
+    auto_save=False,
+    total_skipped_frames=0,
+):
+    temp_file = tmp_path / "temp_output.mp4"
+    temp_file.write_bytes(b"temp-video")
+    return SimpleNamespace(
+        feeder_thread=None,
+        frames_to_display=[],
+        frame_queue=queue.Queue(),
+        join_and_clear_threads=lambda: None,
+        gpu_memory_update_timer=SimpleNamespace(stop=lambda: None),
+        preroll_timer=SimpleNamespace(stop=lambda: None),
+        stop_live_sound=lambda: None,
+        media_capture=None,
+        recording_sp=None,
+        recording=True,
+        processing=True,
+        is_processing_segments=False,
+        next_frame_to_display=31,
+        max_frame_number=100,
+        frames_written=30,
+        fps=30.0,
+        play_start_time=0.0,
+        play_end_time=0.0,
+        total_skipped_frames=total_skipped_frames,
+        manual_dropped_skip_count=0,
+        read_error_skip_count=0,
+        temp_file=str(temp_file),
+        media_path=str(tmp_path / "input.mkv"),
+        stopped_by_error_limit=False,
+        triggered_by_job_manager=False,
+        processing_start_frame=10,
+        last_displayed_frame=29,
+        active_output_folder=active_output_folder,
+        main_window=SimpleNamespace(
+            control={
+                "OutputMediaFolder": str(tmp_path / "fallback-output"),
+                "AutoSaveWorkspaceToggle": auto_save,
+                "OpenOutputToggle": False,
+            }
+        ),
+        _apply_job_timestamp_to_output_name=lambda *args: (None, None),
+        _identify_frame_segments=lambda *_args, **_kwargs: [(10, 29)],
+        _extract_audio_segments=lambda *_args, **_kwargs: (True, []),
+        _concatenate_audio_segments=lambda *_args, **_kwargs: None,
+        _write_video_only_output=lambda *args: True,
+        _log_processing_summary=lambda *args: None,
+        disable_virtualcam=lambda: None,
+        processing_stopped_signal=SimpleNamespace(emit=lambda: None),
+        file_type="image",
+        start_time=0.0,
+    )
+
+
+def test_finalize_default_style_recording_uses_active_output_folder_for_output_and_autosave(
+    tmp_path, monkeypatch
+):
+    resolved_output_folder = str(tmp_path / "clustered" / "Embedding A")
+    dummy = _make_finalize_default_style_recording_dummy(
+        tmp_path,
+        active_output_folder=resolved_output_folder,
+        auto_save=True,
+    )
+    ffmpeg_calls: list[list[str]] = []
+    output_path_calls: list[dict] = []
+    saved_workspaces: list[str] = []
+
+    def fake_run(args, **kwargs):
+        ffmpeg_calls.append(list(args))
+        return _RunResult()
+
+    def fake_get_output_file_path(media_path, output_folder, **kwargs):
+        output_path_calls.append(
+            {
+                "media_path": media_path,
+                "output_folder": output_folder,
+                "kwargs": kwargs,
+            }
+        )
+        return str(Path(output_folder) / "resolved_output.mp4")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.get_output_file_path",
+        fake_get_output_file_path,
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.save_load_actions.save_current_workspace",
+        lambda _main_window, json_path: saved_workspaces.append(json_path),
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.layout_actions.enable_all_parameters_and_control_widget",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.video_control_actions.reset_media_buttons",
+        lambda *args, **kwargs: None,
+    )
+
+    VideoProcessor._finalize_default_style_recording(dummy)
+
+    assert [call["output_folder"] for call in output_path_calls] == [
+        resolved_output_folder,
+        resolved_output_folder,
+    ]
+    assert ffmpeg_calls[-1][-1] == str(
+        Path(resolved_output_folder) / "resolved_output.mp4"
+    )
+    assert saved_workspaces == [
+        str(Path(resolved_output_folder) / "resolved_output.mp4.json")
+    ]
+
+
+def test_finalize_default_style_recording_falls_back_to_output_media_folder_when_active_output_folder_empty(
+    tmp_path, monkeypatch
+):
+    dummy = _make_finalize_default_style_recording_dummy(
+        tmp_path,
+        active_output_folder="",
+        auto_save=False,
+    )
+    output_path_calls: list[str] = []
+
+    def fake_run(args, **kwargs):
+        return _RunResult()
+
+    def fake_get_output_file_path(media_path, output_folder, **kwargs):
+        output_path_calls.append(output_folder)
+        return str(Path(output_folder) / "resolved_output.mp4")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.get_output_file_path",
+        fake_get_output_file_path,
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.layout_actions.enable_all_parameters_and_control_widget",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.video_control_actions.reset_media_buttons",
+        lambda *args, **kwargs: None,
+    )
+
+    VideoProcessor._finalize_default_style_recording(dummy)
+
+    assert output_path_calls == [str(tmp_path / "fallback-output")]

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -1408,6 +1408,216 @@ def test_scan_issue_frames_resets_tracker_when_marker_segment_enables_tracking()
     assert reset_calls == ["reset", "reset", "reset"]
 
 
+@pytest.mark.parametrize(
+    ("changed_key", "first_value", "second_value"),
+    [
+        ("ByteTrackTrackThreshSlider", 40, 55),
+        ("ByteTrackMatchThreshSlider", 80, 65),
+        ("ByteTrackTrackBufferSlider", 30, 45),
+    ],
+)
+def test_scan_issue_frames_resets_tracker_when_bytetrack_config_changes_between_tracking_segments(
+    changed_key, first_value, second_value
+):
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    reset_calls = []
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    local_controls_seen = []
+
+    first_control = {
+        "FaceTrackingEnableToggle": True,
+        "ByteTrackTrackThreshSlider": 40,
+        "ByteTrackMatchThreshSlider": 80,
+        "ByteTrackTrackBufferSlider": 30,
+    }
+    second_control = dict(first_control)
+    second_control[changed_key] = second_value
+
+    processor.main_window = SimpleNamespace(
+        control={"FaceTrackingEnableToggle": False},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(
+            device="cpu",
+            face_detectors=SimpleNamespace(
+                reset_tracker=lambda: reset_calls.append("reset")
+            ),
+        ),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    def fake_run_sequential_detection(
+        _frame_rgb,
+        local_control,
+        _local_params,
+        frame_tensor=None,
+        detector_control_override=None,
+    ):
+        local_controls_seen.append(
+            (
+                dict(local_control),
+                dict(detector_control_override or {}),
+            )
+        )
+        return _empty_scan_detection_result()
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[
+                (0, 0, first_control, {}),
+                (1, 1, second_control, {}),
+            ],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            return_value={
+                "recognition_model": "arcface_128",
+                "similarity_type": "Opal",
+                "prepared_targets": [],
+            },
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            side_effect=fake_run_sequential_detection,
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 1)],
+            base_control={"FaceTrackingEnableToggle": False},
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=0,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 2,
+        "faces_with_issues": 0,
+        "cancelled": False,
+    }
+    assert reset_calls == ["reset", "reset", "reset"]
+    assert local_controls_seen == [
+        (first_control, first_control),
+        (second_control, second_control),
+    ]
+
+
+def test_scan_issue_frames_keeps_tracker_when_bytetrack_config_is_unchanged_between_tracking_segments():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    reset_calls = []
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    shared_control = {
+        "FaceTrackingEnableToggle": True,
+        "ByteTrackTrackThreshSlider": 40,
+        "ByteTrackMatchThreshSlider": 80,
+        "ByteTrackTrackBufferSlider": 30,
+    }
+
+    processor.main_window = SimpleNamespace(
+        control={"FaceTrackingEnableToggle": False},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(
+            device="cpu",
+            face_detectors=SimpleNamespace(
+                reset_tracker=lambda: reset_calls.append("reset")
+            ),
+        ),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[
+                (0, 0, shared_control, {}),
+                (1, 1, dict(shared_control), {}),
+            ],
+        ),
+        patch.object(
+            processor,
+            "_prepare_issue_scan_match_context",
+            return_value={
+                "recognition_model": "arcface_128",
+                "similarity_type": "Opal",
+                "prepared_targets": [],
+            },
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=_empty_scan_detection_result(),
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 1)],
+            base_control={"FaceTrackingEnableToggle": False},
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=0,
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 2,
+        "faces_with_issues": 0,
+        "cancelled": False,
+    }
+    assert reset_calls == ["reset", "reset"]
+
+
 def test_scan_issue_frames_resets_tracker_when_tracking_re_enters_after_disabled_segment():
     processor = VideoProcessor.__new__(VideoProcessor)
     processor.media_path = "dummy.mp4"

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -800,6 +800,189 @@ def test_run_sequential_detection_passes_detector_control_override():
     assert captured["control_override"] == override
 
 
+def test_run_sequential_detection_handles_dense_203_shape_mismatch_with_smoothing_enabled():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    processor.current_frame_number = 12
+
+    bboxes = np.array(
+        [[0.0, 0.0, 10.0, 10.0], [20.0, 20.0, 30.0, 30.0]], dtype=np.float32
+    )
+    kpss_5 = np.array(
+        [
+            [[1, 1], [2, 1], [1.5, 2], [1, 3], [2, 3]],
+            [[21, 21], [22, 21], [21.5, 22], [21, 23], [22, 23]],
+        ],
+        dtype=np.float32,
+    )
+    dense_203 = np.zeros((1, 203, 2), dtype=np.float32)
+    dense_203[0, :, 0] = 1.0
+    dense_203[0, :, 1] = 2.0
+
+    def fake_run_detect(*_args, **_kwargs):
+        return bboxes.copy(), kpss_5.copy(), dense_203.copy()
+
+    processor.main_window = SimpleNamespace(
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        models_processor=SimpleNamespace(device="cpu", run_detect=fake_run_detect),
+    )
+
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+
+    with patch("builtins.print") as mock_print:
+        bboxes_out, kpss_5_out, _kpss_out, kpss_203_out = (
+            processor._run_sequential_detection(
+                frame,
+                {
+                    "DetectorModelSelection": "RetinaFace",
+                    "MaxFacesToDetectSlider": 2,
+                    "DetectorScoreSlider": 50,
+                    "LandmarkDetectToggle": True,
+                    "LandmarkDetectModelSelection": "203",
+                    "LandmarkDetectScoreSlider": 50,
+                    "DetectFromPointsToggle": False,
+                    "AutoRotationToggle": False,
+                    "LandmarkMeanEyesToggle": False,
+                    "KPSSmoothingEnableToggle": True,
+                    "KPSEmaAlphaSlider": 35,
+                },
+                {"face_1": {"FaceExpressionEnableBothToggle": True}},
+            )
+        )
+
+    assert bboxes_out.shape == (2, 4)
+    assert kpss_5_out.shape == (2, 5, 2)
+    assert isinstance(kpss_203_out, np.ndarray)
+    assert kpss_203_out.shape == (1, 203, 2)
+    assert mock_print.call_count == 2
+    mock_print.assert_any_call(
+        "[WARN] Dense KPS count mismatch on frame 12: "
+        "kpss_5=2, dense_kps=1. Skipping dense smoothing for missing faces."
+    )
+    mock_print.assert_any_call(
+        "[WARN] Dense KPS_203 count mismatch on frame 12: "
+        "kpss_5=2, dense_kps_203=1. Skipping dense 203 smoothing for missing faces."
+    )
+
+
+def test_run_sequential_detection_handles_dense_shape_mismatch_with_single_warning():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    processor.current_frame_number = 34
+
+    bboxes = np.array(
+        [[0.0, 0.0, 10.0, 10.0], [20.0, 20.0, 30.0, 30.0]], dtype=np.float32
+    )
+    kpss_5 = np.array(
+        [
+            [[1, 1], [2, 1], [1.5, 2], [1, 3], [2, 3]],
+            [[21, 21], [22, 21], [21.5, 22], [21, 23], [22, 23]],
+        ],
+        dtype=np.float32,
+    )
+    dense_kps = np.zeros((1, 68, 2), dtype=np.float32)
+    dense_kps[0, :, 0] = 3.0
+    dense_kps[0, :, 1] = 4.0
+
+    def fake_run_detect(*_args, **_kwargs):
+        return bboxes.copy(), kpss_5.copy(), dense_kps.copy()
+
+    processor.main_window = SimpleNamespace(
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        models_processor=SimpleNamespace(device="cpu", run_detect=fake_run_detect),
+    )
+
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+
+    with patch("builtins.print") as mock_print:
+        bboxes_out, kpss_5_out, kpss_out, kpss_203_out = (
+            processor._run_sequential_detection(
+                frame,
+                {
+                    "DetectorModelSelection": "RetinaFace",
+                    "MaxFacesToDetectSlider": 2,
+                    "DetectorScoreSlider": 50,
+                    "LandmarkDetectToggle": True,
+                    "LandmarkDetectModelSelection": "68",
+                    "LandmarkDetectScoreSlider": 50,
+                    "DetectFromPointsToggle": False,
+                    "AutoRotationToggle": False,
+                    "LandmarkMeanEyesToggle": False,
+                    "KPSSmoothingEnableToggle": True,
+                    "KPSEmaAlphaSlider": 35,
+                },
+                {},
+            )
+        )
+
+    assert bboxes_out.shape == (2, 4)
+    assert kpss_5_out.shape == (2, 5, 2)
+    assert isinstance(kpss_out, np.ndarray)
+    assert kpss_out.shape == (1, 68, 2)
+    assert kpss_203_out is None
+    mock_print.assert_called_once_with(
+        "[WARN] Dense KPS count mismatch on frame 34: "
+        "kpss_5=2, dense_kps=1. Skipping dense smoothing for missing faces."
+    )
+
+
+def test_run_sequential_detection_does_not_warn_when_dense_counts_match():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    processor.current_frame_number = 56
+
+    bboxes = np.array([[0.0, 0.0, 10.0, 10.0]], dtype=np.float32)
+    kpss_5 = np.array([[[1, 1], [2, 1], [1.5, 2], [1, 3], [2, 3]]], dtype=np.float32)
+    dense_kps = np.zeros((1, 68, 2), dtype=np.float32)
+
+    def fake_run_detect(*_args, **_kwargs):
+        return bboxes.copy(), kpss_5.copy(), dense_kps.copy()
+
+    processor.main_window = SimpleNamespace(
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        models_processor=SimpleNamespace(device="cpu", run_detect=fake_run_detect),
+    )
+
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+
+    with patch("builtins.print") as mock_print:
+        bboxes_out, kpss_5_out, kpss_out, kpss_203_out = (
+            processor._run_sequential_detection(
+                frame,
+                {
+                    "DetectorModelSelection": "RetinaFace",
+                    "MaxFacesToDetectSlider": 1,
+                    "DetectorScoreSlider": 50,
+                    "LandmarkDetectToggle": True,
+                    "LandmarkDetectModelSelection": "68",
+                    "LandmarkDetectScoreSlider": 50,
+                    "DetectFromPointsToggle": False,
+                    "AutoRotationToggle": False,
+                    "LandmarkMeanEyesToggle": False,
+                    "KPSSmoothingEnableToggle": True,
+                    "KPSEmaAlphaSlider": 35,
+                },
+                {},
+            )
+        )
+
+    assert bboxes_out.shape == (1, 4)
+    assert kpss_5_out.shape == (1, 5, 2)
+    assert isinstance(kpss_out, np.ndarray)
+    assert kpss_out.shape == (1, 68, 2)
+    assert kpss_203_out is None
+    mock_print.assert_not_called()
+
+
 def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():
     processor = VideoProcessor.__new__(VideoProcessor)
     processor.media_path = "dummy.mp4"

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from app.processors.video_processor import VideoProcessor
 
@@ -39,6 +40,127 @@ def _make_target_snapshot(face_id, embeddings_by_model=None):
             "embeddings_by_model": embeddings_by_model or {},
         }
     }
+
+
+def test_filter_scan_control_keeps_only_allowlisted_keys():
+    filtered = VideoProcessor._filter_scan_control(
+        {
+            "DetectorScoreSlider": 42,
+            "FaceTrackingEnableToggle": True,
+            "IgnoredControl": "skip",
+        }
+    )
+
+    assert filtered == {
+        "DetectorScoreSlider": 42,
+        "FaceTrackingEnableToggle": True,
+    }
+
+
+def test_filter_scan_face_params_keeps_only_threshold_for_target_faces():
+    filtered = VideoProcessor._filter_scan_face_params(
+        {
+            "face_1": {
+                "SimilarityThresholdSlider": 61,
+                "FaceExpressionEnableBothToggle": True,
+            },
+            "face_2": {"SimilarityThresholdSlider": 75},
+        },
+        ["face_1"],
+    )
+
+    assert filtered == {
+        "face_1": {
+            "SimilarityThresholdSlider": 61,
+        }
+    }
+
+
+def test_get_issue_scan_unavailable_reason_rejects_marker_enabled_vr180_within_range():
+    reason = VideoProcessor.get_issue_scan_unavailable_reason(
+        {"VR180ModeEnableToggle": False},
+        scan_ranges=[(10, 20)],
+        markers={
+            15: {
+                "control": {
+                    "VR180ModeEnableToggle": True,
+                }
+            }
+        },
+    )
+
+    assert reason == "Issue scans are not supported while VR180 mode is enabled."
+
+
+def test_get_issue_scan_unavailable_reason_allows_marker_enabled_vr180_outside_range():
+    reason = VideoProcessor.get_issue_scan_unavailable_reason(
+        {"VR180ModeEnableToggle": False},
+        scan_ranges=[(10, 20)],
+        markers={
+            25: {
+                "control": {
+                    "VR180ModeEnableToggle": True,
+                }
+            }
+        },
+    )
+
+    assert reason is None
+
+
+def test_get_issue_scan_unavailable_reason_rejects_mixed_ranges_when_one_uses_vr180():
+    reason = VideoProcessor.get_issue_scan_unavailable_reason(
+        {"VR180ModeEnableToggle": False},
+        scan_ranges=[(0, 5), (10, 20)],
+        markers={
+            12: {
+                "control": {
+                    "VR180ModeEnableToggle": True,
+                }
+            }
+        },
+    )
+
+    assert reason == "Issue scans are not supported while VR180 mode is enabled."
+
+
+def test_get_issue_scan_unavailable_reason_allows_range_when_start_marker_turns_vr180_off():
+    reason = VideoProcessor.get_issue_scan_unavailable_reason(
+        {"VR180ModeEnableToggle": True},
+        scan_ranges=[(10, 20)],
+        markers={
+            10: {
+                "control": {
+                    "VR180ModeEnableToggle": False,
+                }
+            },
+            30: {
+                "control": {
+                    "VR180ModeEnableToggle": True,
+                }
+            },
+        },
+        fallback_control={"VR180ModeEnableToggle": True},
+    )
+
+    assert reason is None
+
+
+def test_get_issue_scan_unavailable_reason_rejects_live_vr180_when_no_start_marker_override():
+    reason = VideoProcessor.get_issue_scan_unavailable_reason(
+        {"VR180ModeEnableToggle": True},
+        scan_ranges=[(10, 20)],
+        markers={
+            30: {
+                "control": {
+                    "VR180ModeEnableToggle": False,
+                }
+            }
+        },
+        fallback_control={"VR180ModeEnableToggle": True},
+    )
+
+    assert reason == "Issue scans are not supported while VR180 mode is enabled."
 
 
 def test_scan_issue_frames_restores_dense_smoothing_state():
@@ -95,6 +217,35 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
     )
     assert processor.last_detected_faces == [{"id": 1}]
     assert processor.current_frame_number == 3
+
+
+def test_scan_issue_frames_rejects_when_marker_enables_vr180():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    processor.main_window = SimpleNamespace(
+        control={"VR180ModeEnableToggle": False},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={10: {"control": {"VR180ModeEnableToggle": True}}},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+    )
+
+    with pytest.raises(RuntimeError, match="Issue scans are not supported"):
+        processor.scan_issue_frames(
+            scan_ranges=[(0, 15)],
+            base_control={},
+            base_params={},
+            target_faces_snapshot={},
+            reset_frame_number=0,
+        )
 
 
 def test_describe_issue_scan_scope_uses_normalized_effective_ranges():
@@ -157,7 +308,7 @@ def test_resolve_scan_state_uses_control_defaults_snapshot_not_live_widgets():
     processor.main_window = SimpleNamespace(
         markers={},
         parameter_widgets=_FailingWidgets(),
-        control={"ControlA": "live"},
+        control={"DetectorModelSelection": "live"},
         default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
         target_faces={},
     )
@@ -166,21 +317,27 @@ def test_resolve_scan_state_uses_control_defaults_snapshot_not_live_widgets():
         "app.processors.video_processor.video_control_actions._get_marker_data_for_position",
         return_value={
             "parameters": {},
-            "control": {"ControlA": "marker", "ControlB": "marker-only"},
+            "control": {
+                "DetectorModelSelection": "marker",
+                "IgnoredControl": "marker-only",
+            },
         },
     ):
         local_control, local_params = processor._resolve_scan_state_for_frame(
             10,
-            {"ControlA": "base"},
+            {"DetectorModelSelection": "base"},
             {},
             {},
-            {"ControlA": "default", "ControlC": "default-only"},
+            {
+                "DetectorModelSelection": "default",
+                "DetectorScoreSlider": 33,
+                "IgnoredDefault": "skip",
+            },
         )
 
     assert local_control == {
-        "ControlA": "marker",
-        "ControlB": "marker-only",
-        "ControlC": "default-only",
+        "DetectorModelSelection": "marker",
+        "DetectorScoreSlider": 33,
     }
     assert local_params == {}
 
@@ -207,6 +364,46 @@ def test_resolve_scan_state_respects_explicitly_empty_target_faces_snapshot():
         )
 
     assert local_params == {}
+
+
+def test_resolve_scan_state_filters_non_scan_face_params_and_fills_defaults():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.main_window = SimpleNamespace(
+        markers={},
+        target_faces={"live-face": object()},
+        default_parameters=SimpleNamespace(
+            data={
+                "SimilarityThresholdSlider": 50,
+                "FaceExpressionEnableBothToggle": True,
+            }
+        ),
+    )
+
+    with patch(
+        "app.processors.video_processor.video_control_actions._get_marker_data_for_position",
+        return_value={
+            "parameters": {
+                "face_1": {
+                    "SimilarityThresholdSlider": 72,
+                    "FaceExpressionEnableBothToggle": True,
+                }
+            },
+            "control": {"IgnoredControl": "skip"},
+        },
+    ):
+        local_control, local_params = processor._resolve_scan_state_for_frame(
+            10,
+            {"DetectorScoreSlider": 41, "IgnoredBase": "skip"},
+            {"face_2": {"SimilarityThresholdSlider": 63}},
+            {"face_1": {}, "face_2": {}},
+            {"DetectorModelSelection": "SCRFD", "IgnoredDefault": "skip"},
+        )
+
+    assert local_control == {"DetectorModelSelection": "SCRFD"}
+    assert local_params == {
+        "face_1": {"SimilarityThresholdSlider": 72},
+        "face_2": {"SimilarityThresholdSlider": 50},
+    }
 
 
 def test_prepare_issue_scan_match_context_uses_snapshot_embeddings_for_segment_settings():
@@ -315,6 +512,292 @@ def test_prepare_issue_scan_target_faces_snapshot_uses_segment_recognition_setti
         snapshot["face_1"]["embeddings_by_model"]["arcface_128"]["Pearl"],
         np.array([2.0], dtype=np.float32),
     )
+
+
+def test_scan_issue_frames_filters_scan_state_before_detection():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    captured = {}
+
+    processor.main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(device="cpu"),
+    )
+    processor._get_target_input_height = lambda: 256
+
+    def fake_run_sequential_detection(
+        _frame_rgb,
+        local_control,
+        local_params,
+        frame_tensor=None,
+        detector_control_override=None,
+    ):
+        captured["local_control"] = local_control
+        captured["local_params"] = local_params
+        captured["detector_control_override"] = detector_control_override
+        return _empty_scan_detection_result()
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            return_value=(True, frame.copy()),
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            side_effect=fake_run_sequential_detection,
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 0)],
+            base_control={
+                "DetectorScoreSlider": 42,
+                "KPSSmoothingEnableToggle": False,
+                "FaceEditorEnableToggle": True,
+            },
+            base_params={
+                "face_1": {
+                    "SimilarityThresholdSlider": 77,
+                    "FaceExpressionEnableBothToggle": True,
+                }
+            },
+            target_faces_snapshot={},
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 1,
+        "faces_with_issues": 0,
+        "cancelled": False,
+    }
+    assert captured["local_control"] == {
+        "DetectorScoreSlider": 42,
+        "KPSSmoothingEnableToggle": False,
+    }
+    assert captured["local_params"] == {"face_1": {"SimilarityThresholdSlider": 77}}
+    assert captured["detector_control_override"] == captured["local_control"]
+
+
+def test_scan_issue_frames_uses_marker_resolved_resize_per_segment():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    preview_heights = []
+
+    processor.main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(device="cpu"),
+    )
+
+    def fake_read_frame(_capture, _rotation, preview_target_height=None):
+        preview_heights.append(preview_target_height)
+        return True, frame.copy()
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            side_effect=fake_read_frame,
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[
+                (0, 0, {"DetectorScoreSlider": 40}, {}),
+                (
+                    1,
+                    1,
+                    {
+                        "GlobalInputResizeToggle": True,
+                        "GlobalInputResizeSizeSelection": "720p",
+                    },
+                    {},
+                ),
+                (
+                    2,
+                    2,
+                    {
+                        "GlobalInputResizeToggle": True,
+                        "GlobalInputResizeSizeSelection": "1080p",
+                    },
+                    {},
+                ),
+                (
+                    3,
+                    3,
+                    {
+                        "GlobalInputResizeToggle": False,
+                        "GlobalInputResizeSizeSelection": "720p",
+                    },
+                    {},
+                ),
+            ],
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=_empty_scan_detection_result(),
+        ),
+    ):
+        result = processor.scan_issue_frames(
+            scan_ranges=[(0, 3)],
+            base_control={},
+            base_params={},
+            target_faces_snapshot={},
+        )
+
+    assert result == {
+        "issue_frames_by_face": {},
+        "frames_scanned": 4,
+        "faces_with_issues": 0,
+        "cancelled": False,
+    }
+    assert preview_heights == [None, 720, 1080, None]
+
+
+def test_scan_issue_frames_uses_explicit_target_height_when_segment_has_no_resize_state():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.media_path = "dummy.mp4"
+    processor.media_rotation = 0
+    processor.fps = 30.0
+    processor.current_frame_number = 0
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    preview_heights = []
+
+    processor.main_window = SimpleNamespace(
+        control={},
+        parameters={},
+        target_faces={},
+        dropped_frames=set(),
+        markers={},
+        videoSeekSlider=SimpleNamespace(value=lambda: 0),
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
+        models_processor=SimpleNamespace(device="cpu"),
+    )
+
+    def fake_read_frame(_capture, _rotation, preview_target_height=None):
+        preview_heights.append(preview_target_height)
+        return True, frame.copy()
+
+    with (
+        patch(
+            "app.processors.video_processor.cv2.VideoCapture",
+            return_value=_DummyCapture(),
+        ),
+        patch(
+            "app.processors.video_processor.misc_helpers.read_frame",
+            side_effect=fake_read_frame,
+        ),
+        patch("app.processors.video_processor.misc_helpers.seek_frame"),
+        patch("app.processors.video_processor.misc_helpers.release_capture"),
+        patch.object(
+            processor,
+            "_build_issue_scan_state_segments",
+            return_value=[(0, 0, {"DetectorScoreSlider": 40}, {})],
+        ),
+        patch.object(
+            processor,
+            "_run_sequential_detection",
+            return_value=_empty_scan_detection_result(),
+        ),
+    ):
+        processor.scan_issue_frames(
+            scan_ranges=[(0, 0)],
+            target_height=256,
+            base_control={},
+            base_params={},
+            target_faces_snapshot={},
+        )
+
+    assert preview_heights == [256]
+
+
+def test_run_sequential_detection_passes_detector_control_override():
+    processor = VideoProcessor.__new__(VideoProcessor)
+    processor.last_detected_faces = []
+    processor._smoothed_kps = {}
+    processor._smoothed_dense_kps = {}
+    processor._smoothed_dense_kps_203 = {}
+    captured = {}
+
+    def fake_run_detect(*_args, **kwargs):
+        captured["control_override"] = kwargs.get("control_override")
+        return _empty_scan_detection_result()[:3]
+
+    processor.main_window = SimpleNamespace(
+        editFacesButton=SimpleNamespace(isChecked=lambda: False),
+        models_processor=SimpleNamespace(device="cpu", run_detect=fake_run_detect),
+    )
+
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+    override = {"FaceTrackingEnableToggle": True, "DetectorScoreSlider": 35}
+
+    result = processor._run_sequential_detection(
+        frame,
+        {
+            "DetectorModelSelection": "RetinaFace",
+            "MaxFacesToDetectSlider": 1,
+            "DetectorScoreSlider": 35,
+            "LandmarkDetectToggle": False,
+            "DetectFromPointsToggle": False,
+            "AutoRotationToggle": False,
+            "LandmarkMeanEyesToggle": False,
+            "KPSSmoothingEnableToggle": False,
+        },
+        {},
+        detector_control_override=override,
+    )
+
+    assert result[0].shape == (0, 4)
+    assert result[1].shape == (0, 5, 2)
+    assert result[2].shape == (0, 68, 2)
+    assert result[3] is None
+    assert captured["control_override"] == override
 
 
 def test_scan_issue_frames_reports_progress_per_frame_and_skips_dropped_runs():

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -4,6 +4,7 @@ from app.ui.widgets.actions import common_actions
 from app.ui.widgets.actions import card_actions, job_manager_actions, list_view_actions
 from app.ui.widgets.actions import save_load_actions
 from app.ui.widgets import event_filters
+from app.processors.video_processor import VideoProcessor
 from app.ui.widgets.actions.video_control_actions import (
     _handle_issue_scan_cancelled,
     _handle_issue_scan_completed,
@@ -164,6 +165,8 @@ def _make_worker_main_window():
             _get_issue_scan_ranges=lambda: [(0, 2)],
             describe_issue_scan_scope=lambda _ranges: "Scanning 1 marked range",
             _get_target_input_height=lambda: 256,
+            _filter_scan_control=VideoProcessor._filter_scan_control,
+            _filter_scan_face_params=VideoProcessor._filter_scan_face_params,
             prepare_issue_scan_target_faces_snapshot=lambda *_args, **_kwargs: {},
             scan_issue_frames=None,
         ),
@@ -242,6 +245,8 @@ def _make_scan_main_window(keep_controls=False):
         current_frame=None,
         stop_processing=lambda: False,
         process_current_frame=lambda: None,
+        _get_issue_scan_ranges=lambda: [(0, 24)],
+        get_issue_scan_unavailable_reason=VideoProcessor.get_issue_scan_unavailable_reason,
     )
     return main_window
 
@@ -339,9 +344,12 @@ def test_issue_scan_worker_prepares_target_snapshot_during_construction():
 def test_issue_scan_worker_passes_control_defaults_snapshot():
     control_widget = SimpleNamespace(default_value="default-control")
     main_window = _make_worker_main_window()
-    main_window.control = {"ControlA": "live-control"}
+    main_window.control = {
+        "DetectorModelSelection": "SCRFD",
+        "IgnoredControl": "live-control",
+    }
     main_window.parameter_widgets = {
-        "ControlA": control_widget,
+        "DetectorModelSelection": control_widget,
         "IgnoredWidget": control_widget,
     }
     captured = {}
@@ -360,7 +368,9 @@ def test_issue_scan_worker_passes_control_defaults_snapshot():
     worker = IssueScanWorker(main_window)
     worker.run()
 
-    assert captured["control_defaults_snapshot"] == {"ControlA": "default-control"}
+    assert captured["control_defaults_snapshot"] == {
+        "DetectorModelSelection": "default-control"
+    }
 
 
 def test_issue_scan_worker_preserves_explicitly_empty_snapshots():
@@ -419,9 +429,12 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
         }
 
     main_window = _make_worker_main_window()
-    main_window.control = {"ControlA": "live-control"}
+    main_window.control = {
+        "DetectorModelSelection": "SCRFD",
+        "IgnoredControl": "live-control",
+    }
     main_window.target_faces = {"face_1": _TargetFaceWithoutEmbeddingAccess()}
-    main_window.parameter_widgets = {"ControlA": control_widget}
+    main_window.parameter_widgets = {"DetectorModelSelection": control_widget}
     main_window.video_processor.prepare_issue_scan_target_faces_snapshot = (
         fake_prepare_issue_scan_target_faces_snapshot
     )
@@ -450,6 +463,70 @@ def test_issue_scan_worker_passes_plain_target_face_snapshot_without_widget_meth
             },
         }
     }
+
+
+def test_issue_scan_worker_filters_snapshot_control_and_params():
+    main_window = _make_worker_main_window()
+    main_window.control = {
+        "DetectorScoreSlider": 42,
+        "FaceTrackingEnableToggle": True,
+        "IgnoredControl": "skip",
+    }
+    main_window.parameters = {
+        "face_1": {
+            "SimilarityThresholdSlider": 77,
+            "FaceExpressionEnableBothToggle": True,
+        },
+        "face_2": {
+            "SimilarityThresholdSlider": 61,
+        },
+    }
+    main_window.target_faces = {"face_1": object()}
+    captured = {}
+
+    def fake_scan_issue_frames(**kwargs):
+        captured["base_control"] = kwargs["base_control"]
+        captured["base_params"] = kwargs["base_params"]
+        return {
+            "issue_frames_by_face": {},
+            "frames_scanned": 1,
+            "faces_with_issues": 0,
+            "cancelled": False,
+        }
+
+    main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
+
+    worker = IssueScanWorker(main_window)
+    worker.run()
+
+    assert captured["base_control"] == {
+        "DetectorScoreSlider": 42,
+        "FaceTrackingEnableToggle": True,
+    }
+    assert captured["base_params"] == {
+        "face_1": {"SimilarityThresholdSlider": 77},
+    }
+
+
+def test_issue_scan_worker_does_not_pass_fixed_target_height():
+    main_window = _make_worker_main_window()
+    captured = {}
+
+    def fake_scan_issue_frames(**kwargs):
+        captured.update(kwargs)
+        return {
+            "issue_frames_by_face": {},
+            "frames_scanned": 1,
+            "faces_with_issues": 0,
+            "cancelled": False,
+        }
+
+    main_window.video_processor.scan_issue_frames = fake_scan_issue_frames
+
+    worker = IssueScanWorker(main_window)
+    worker.run()
+
+    assert "target_height" not in captured
 
 
 def test_handle_issue_scan_progress_moves_slider_and_updates_abort_button(monkeypatch):
@@ -742,6 +819,65 @@ def test_run_issue_scan_does_not_start_twice(monkeypatch):
 
     assert worker_calls == []
     assert main_window.scan_issue_worker is existing_worker
+
+
+def test_run_issue_scan_blocks_vr180_mode(monkeypatch):
+    main_window = _make_scan_main_window()
+    main_window.control["VR180ModeEnableToggle"] = True
+    messagebox_calls = []
+    worker_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_messagebox",
+        lambda *_args, **_kwargs: messagebox_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.ui_workers.IssueScanWorker",
+        lambda _main_window: worker_calls.append("created"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.Path.is_file",
+        lambda self: True,
+    )
+
+    run_issue_scan(main_window)
+
+    assert worker_calls == []
+    assert messagebox_calls[0][0][1] == "Scan Not Available"
+    assert (
+        messagebox_calls[0][0][2]
+        == "Issue scans are not supported while VR180 mode is enabled."
+    )
+
+
+def test_run_issue_scan_blocks_marker_enabled_vr180_mode(monkeypatch):
+    main_window = _make_scan_main_window()
+    main_window.markers = {12: {"control": {"VR180ModeEnableToggle": True}}}
+    main_window.video_processor._get_issue_scan_ranges = lambda: [(0, 24)]
+    messagebox_calls = []
+    worker_calls = []
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.common_widget_actions.create_and_show_messagebox",
+        lambda *_args, **_kwargs: messagebox_calls.append((_args, _kwargs)),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.ui_workers.IssueScanWorker",
+        lambda _main_window: worker_calls.append("created"),
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.Path.is_file",
+        lambda self: True,
+    )
+
+    run_issue_scan(main_window)
+
+    assert worker_calls == []
+    assert messagebox_calls[0][0][1] == "Scan Not Available"
+    assert (
+        messagebox_calls[0][0][2]
+        == "Issue scans are not supported while VR180 mode is enabled."
+    )
 
 
 def test_run_issue_scan_reports_construction_failures_without_clearing_results(


### PR DESCRIPTION
## Summary
This PR follows up the recent issue-scan crash fix from mr-szgz and tightens issue scan so it better matches the real marker-resolved render-time detect/match pipeline. It keeps the KPS smoothing crash fix in place, improves dense-landmark mismatch handling, and limits scan state to an allowlisted set of render-predictive controls.

## What changed

- added a scan-only allowlist for control and per-face settings
- filtered scan state at worker snapshot time, scan entry, and marker-resolved frame-state resolution
- added detector control override support so scan uses scan-local control instead of live UI state for tracking / ByteTrack reads
- kept scan render-predictive for detection, tracking / ByteTrack, KPS smoothing, recognition model, similarity type / threshold, and marker-resolved settings
- removed unrelated downstream edit/expression/makeup-style params from scan influence
- made issue scan resolve input resize per marker-stable segment instead of once at startup
- added VR180 preflight rejection based on effective state inside the scanned ranges, including marker-driven VR180
- cleaned up dense landmark smoothing mismatch handling so warnings fire once per frame / mismatch type instead of repeating
- reset ByteTrack during scan when marker changes alter ByteTrack config across tracking-enabled segments

## Why

Issue scan is meant to flag frames likely to miss detection or matching in the final render path. Before this PR, scan could drift from real render behavior because it could:

- read live UI state instead of scan-local marker-resolved state
- be influenced by unrelated downstream feature toggles
- freeze input resize for the whole scan
- miss marker-driven VR180 and ByteTrack config transitions
- spam repeated dense landmark smoothing warnings

## Not changed

- no VR180 scan support was added - scan is still intentionally blocked when any scanned segment would use VR180
- playback/render behavior outside issue scan was not changed
- the separate marker-seek ByteTrack UI restore issue is not addressed here

## Testing

- `pre-commit run --all-files`
- `.venv\Scripts\python -m pytest tests`

## Result

- 446 passed