### PR TITLE
Add theatre fullscreen mode and recording stop confirmation setting

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -818,7 +818,7 @@ class VideoProcessor(QObject):
                                 new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
 
                         # Smoothing on Dense KPS 203
-                        if (has_dense_kps_203):
+                        if has_dense_kps_203:
                             # check if kpss_5 has more shapes than valid_kpss_203
                             if _i < valid_kpss_203.shape[0]:
                                 if _best_match_key in self._smoothed_dense_kps_203:
@@ -833,31 +833,36 @@ class VideoProcessor(QObject):
                                         _i
                                     ].copy()
                             else:
-                                print(f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found.")
+                                print(
+                                    f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found."
+                                )
 
                     else:
                         new_smoothed_kps[_i] = _raw.copy()
                         if has_dense_kps:
                             new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
-                        if (has_dense_kps_203):
+                        if has_dense_kps_203:
                             # check if kpss_5 has more shapes than valid_kpss_203
                             if _i < valid_kpss_203.shape[0]:
                                 new_smoothed_dense_kps_203[_i] = valid_kpss_203[
                                     _i
                                 ].copy()
                             else:
-                                print(f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found.")
-
+                                print(
+                                    f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found."
+                                )
 
                     kpss_5[_i] = new_smoothed_kps[_i]
                     if has_dense_kps:
                         valid_kpss[_i] = new_smoothed_dense_kps[_i]
-                    if (has_dense_kps_203):
+                    if has_dense_kps_203:
                         # check if kpss_5 has more shapes than valid_kpss_203
                         if _i < valid_kpss_203.shape[0]:
                             valid_kpss_203[_i] = new_smoothed_dense_kps_203[_i]
                         else:
-                            print(f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found.")
+                            print(
+                                f"[WARN] Skipping Smoothing. Dense KPS_203 face {_i} not found."
+                            )
 
                 self._smoothed_kps = new_smoothed_kps
                 self._smoothed_dense_kps = new_smoothed_dense_kps
@@ -1559,7 +1564,7 @@ class VideoProcessor(QObject):
                     output_folder = os.path.join(output_folder, embedding_name)
                 else:
                     print(
-                        f"[WARN] ClusterOutputBySourceToggle enabled but embedding_name is falsy"
+                        "[WARN] ClusterOutputBySourceToggle enabled but embedding_name is falsy"
                     )
             self.active_output_folder = output_folder
             # Disable UI elements

--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -120,6 +120,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self._theatre_mode_panel_states: dict[str, bool] | None = None
         self._fullscreen_restore_was_maximized = False
         self._fullscreen_restore_geometry = None
+        self._theatre_forced_fullscreen = False
         self.panel_visibility_state: dict[str, bool] = {
             "target_media": True,
             "input_faces": True,
@@ -859,6 +860,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             return
 
         if self.isFullScreen():
+            if getattr(self, "_theatre_forced_fullscreen", False):
+                return
             restore_geometry = getattr(self, "_fullscreen_restore_geometry", None)
             self._was_custom_fullscreen = True
             self._was_maximized = False
@@ -908,7 +911,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     def keyPressEvent(self, event):
         match event.key():
             case QtCore.Qt.Key_Escape:
-                if self.isFullScreen():
+                if getattr(self, "is_theatre_mode", False) and self.control.get(
+                    "TheatreModeUsesFullscreenToggle", False
+                ):
+                    video_control_actions.toggle_theatre_mode(self)
+                elif self.isFullScreen():
                     video_control_actions.view_fullscreen(self)
                 elif getattr(self, "is_theatre_mode", False):
                     video_control_actions.toggle_theatre_mode(self)

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -3002,11 +3002,19 @@ def toggle_theatre_mode(main_window: "MainWindow"):
     if not is_theatre:
         # --- ENTER THEATRE MODE ---
         main_window.is_theatre_mode = True
+        use_fullscreen_with_theatre = bool(
+            getattr(main_window, "control", {}).get(
+                "TheatreModeUsesFullscreenToggle", False
+            )
+        )
 
         # 0. Save the exact state of all docks and toolbars (sizes, proportions, splitters)
         main_window._saved_window_state = main_window.saveState()
         main_window._was_maximized = main_window.isMaximized()
         main_window._was_custom_fullscreen = main_window.isFullScreen()
+        main_window._theatre_forced_fullscreen = bool(
+            use_fullscreen_with_theatre and not main_window._was_custom_fullscreen
+        )
         if main_window.isMaximized() or main_window.isFullScreen():
             main_window._was_normal_geometry = main_window.normalGeometry()
         else:
@@ -3086,8 +3094,17 @@ def toggle_theatre_mode(main_window: "MainWindow"):
             QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
         )
 
-        # 6. Preserve the base window mode; only remain fullscreen if already fullscreen.
-        if main_window._was_custom_fullscreen:
+        # 6. Preserve the base window mode; optionally enter fullscreen with theatre.
+        if main_window._was_custom_fullscreen or main_window._theatre_forced_fullscreen:
+            if main_window._theatre_forced_fullscreen:
+                main_window._fullscreen_restore_was_maximized = (
+                    main_window._was_maximized
+                )
+                main_window._fullscreen_restore_geometry = (
+                    None
+                    if main_window._was_maximized
+                    else main_window._was_normal_geometry
+                )
             main_window.setWindowState(QtCore.Qt.WindowState.WindowFullScreen)
             main_window.showFullScreen()
             QtWidgets.QApplication.processEvents()
@@ -3188,6 +3205,7 @@ def toggle_theatre_mode(main_window: "MainWindow"):
         was_custom_fullscreen = getattr(main_window, "_was_custom_fullscreen", False)
         was_maximized = getattr(main_window, "_was_maximized", False)
         saved_normal_geometry = getattr(main_window, "_was_normal_geometry", None)
+        main_window._theatre_forced_fullscreen = False
 
         _restore_window_base_mode(
             main_window,

--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -1963,16 +1963,21 @@ def record_video(main_window: "MainWindow", checked: bool):
         # callers.
         #
         # Do NOT prompt when this stop was initiated programmatically by Job Manager.
+        should_confirm_stop = bool(
+            main_window.control.get("ConfirmBeforeStoppingRecordingToggle", True)
+        )
         if (
-            video_processor.is_processing_segments or video_processor.recording
-        ) and not job_mgr_flag:
+            (video_processor.is_processing_segments or video_processor.recording)
+            and not job_mgr_flag
+            and should_confirm_stop
+        ):
             try:
                 box = QtWidgets.QMessageBox(main_window)
                 box.setIcon(QtWidgets.QMessageBox.Warning)
                 box.setWindowTitle("Confirm stop")
-                box.setText("Stop multi-segment recording?")
+                box.setText("Stop recording?")
                 box.setInformativeText(
-                    "Segment recording will stop immediately. Output may be incomplete."
+                    "Recording will stop immediately. Output may be incomplete."
                 )
                 box.setStandardButtons(
                     QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -155,6 +155,12 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
             "default": False,
             "help": "Auto start over when video playing to the end.(Not work for recording)",
         },
+        "TheatreModeUsesFullscreenToggle": {
+            "level": 1,
+            "label": "Theatre Mode Uses Fullscreen",
+            "default": False,
+            "help": "When enabled, entering Theatre Mode also switches the window to fullscreen and restores the previous window state when Theatre Mode is turned off.",
+        },
         "FrameSkipStepSlider": {
             "level": 1,
             "label": "Frame Skip Step",

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -194,6 +194,12 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
         },
     },
     "Video Recording Settings": {
+        "ConfirmBeforeStoppingRecordingToggle": {
+            "level": 1,
+            "label": "Confirm Before Stopping Recording",
+            "default": True,
+            "help": "Show a confirmation prompt before manually stopping a recording.",
+        },
         "FrameEnhancerDownToggle": {
             "level": 1,
             "label": "Frame resize to 1920*1080",

--- a/tests/unit/ui/test_main_ui_keypress.py
+++ b/tests/unit/ui/test_main_ui_keypress.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _module(name: str, **attrs) -> ModuleType:
+    mod = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _load_main_ui_module():
+    qt_widgets = _module(
+        "PySide6.QtWidgets",
+        QMainWindow=type("QMainWindow", (), {}),
+        QListWidget=type("QListWidget", (), {}),
+        QWidget=type("QWidget", (), {}),
+    )
+    qt_widgets.__getattr__ = lambda attr: type(attr, (), {})
+    qt_core = _module(
+        "PySide6.QtCore",
+        Qt=SimpleNamespace(
+            Key_Escape=1,
+            Key_F11=2,
+            Key_T=3,
+            Key_V=4,
+            Key_C=5,
+            Key_D=6,
+            Key_A=7,
+            Key_Z=8,
+            Key_Space=9,
+        ),
+        Signal=lambda *args, **kwargs: object(),
+        Slot=lambda *args, **kwargs: lambda func: func,
+    )
+    qt_core.__getattr__ = lambda attr: type(attr, (), {})
+    qt_gui = _module("PySide6.QtGui")
+    qt_gui.__getattr__ = lambda attr: type(attr, (), {})
+    pyside6 = _module(
+        "PySide6",
+        QtWidgets=qt_widgets,
+        QtCore=qt_core,
+        QtGui=qt_gui,
+    )
+
+    widget_components = _module(
+        "app.ui.widgets.widget_components",
+        ToggleButton=type("ToggleButton", (), {}),
+        SelectionBox=type("SelectionBox", (), {}),
+        ParameterDecimalSlider=type("ParameterDecimalSlider", (), {}),
+        ParameterSlider=type("ParameterSlider", (), {}),
+        ParameterLineEdit=type("ParameterLineEdit", (), {}),
+        TargetFaceCardButton=type("TargetFaceCardButton", (), {}),
+        InputFaceCardButton=type("InputFaceCardButton", (), {}),
+        EmbeddingCardButton=type("EmbeddingCardButton", (), {}),
+        TargetMediaCardButton=type("TargetMediaCardButton", (), {}),
+    )
+    widget_components.__getattr__ = lambda attr: type(attr, (), {})
+
+    stub_modules = {
+        "PySide6": pyside6,
+        "PySide6.QtWidgets": qt_widgets,
+        "PySide6.QtCore": qt_core,
+        "PySide6.QtGui": qt_gui,
+        "torch": _module("torch"),
+        "app.ui.core.main_window": _module(
+            "app.ui.core.main_window", Ui_MainWindow=type("Ui_MainWindow", (), {})
+        ),
+        "app.ui.widgets.actions.common_actions": _module(
+            "app.ui.widgets.actions.common_actions"
+        ),
+        "app.ui.widgets.actions.card_actions": _module(
+            "app.ui.widgets.actions.card_actions"
+        ),
+        "app.ui.widgets.actions.layout_actions": _module(
+            "app.ui.widgets.actions.layout_actions"
+        ),
+        "app.ui.widgets.actions.video_control_actions": _module(
+            "app.ui.widgets.actions.video_control_actions",
+            view_fullscreen=MagicMock(),
+            toggle_theatre_mode=MagicMock(),
+            advance_video_slider_by_n_frames=MagicMock(),
+            rewind_video_slider_by_n_frames=MagicMock(),
+        ),
+        "app.ui.widgets.actions.filter_actions": _module(
+            "app.ui.widgets.actions.filter_actions"
+        ),
+        "app.ui.widgets.actions.save_load_actions": _module(
+            "app.ui.widgets.actions.save_load_actions"
+        ),
+        "app.ui.widgets.actions.list_view_actions": _module(
+            "app.ui.widgets.actions.list_view_actions"
+        ),
+        "app.ui.widgets.actions.graphics_view_actions": _module(
+            "app.ui.widgets.actions.graphics_view_actions"
+        ),
+        "app.ui.widgets.actions.job_manager_actions": _module(
+            "app.ui.widgets.actions.job_manager_actions"
+        ),
+        "app.ui.widgets.actions.preset_actions": _module(
+            "app.ui.widgets.actions.preset_actions"
+        ),
+        "app.ui.widgets.advanced_embedding_editor": _module(
+            "app.ui.widgets.advanced_embedding_editor",
+            EmbeddingGUI=type("EmbeddingGUI", (), {}),
+        ),
+        "app.ui.widgets.actions.control_actions": _module(
+            "app.ui.widgets.actions.control_actions"
+        ),
+        "app.processors.video_processor": _module(
+            "app.processors.video_processor",
+            VideoProcessor=type("VideoProcessor", (), {}),
+        ),
+        "app.processors.models_processor": _module(
+            "app.processors.models_processor",
+            ModelsProcessor=type("ModelsProcessor", (), {}),
+        ),
+        "app.ui.widgets.widget_components": widget_components,
+        "app.ui.widgets.event_filters": _module(
+            "app.ui.widgets.event_filters",
+            GraphicsViewEventFilter=type("GraphicsViewEventFilter", (), {}),
+            VideoSeekSliderEventFilter=type("VideoSeekSliderEventFilter", (), {}),
+            videoSeekSliderLineEditEventFilter=type(
+                "videoSeekSliderLineEditEventFilter", (), {}
+            ),
+            ListWidgetEventFilter=type("ListWidgetEventFilter", (), {}),
+        ),
+        "app.ui.widgets.ui_workers": _module("app.ui.widgets.ui_workers"),
+        "app.ui.widgets.common_layout_data": _module(
+            "app.ui.widgets.common_layout_data", COMMON_LAYOUT_DATA={}
+        ),
+        "app.ui.widgets.denoiser_layout_data": _module(
+            "app.ui.widgets.denoiser_layout_data", DENOISER_LAYOUT_DATA={}
+        ),
+        "app.ui.widgets.swapper_layout_data": _module(
+            "app.ui.widgets.swapper_layout_data",
+            SWAPPER_LAYOUT_DATA={},
+            MASK_SHOW_DEFAULT="default",
+            MASK_SHOW_OPTIONS=[],
+        ),
+        "app.ui.widgets.settings_layout_data": _module(
+            "app.ui.widgets.settings_layout_data", SETTINGS_LAYOUT_DATA={}
+        ),
+        "app.ui.widgets.face_editor_layout_data": _module(
+            "app.ui.widgets.face_editor_layout_data", FACE_EDITOR_LAYOUT_DATA={}
+        ),
+        "app.helpers.app_metadata": _module(
+            "app.helpers.app_metadata",
+            get_app_display_metadata=lambda *_args, **_kwargs: SimpleNamespace(
+                window_title="VisoMaster"
+            ),
+        ),
+        "app.helpers.miscellaneous": _module(
+            "app.helpers.miscellaneous",
+            DFMModelManager=type("DFMModelManager", (), {}),
+            ParametersDict=dict,
+            ThumbnailManager=type("ThumbnailManager", (), {}),
+        ),
+        "app.helpers.typing_helper": _module(
+            "app.helpers.typing_helper",
+            FacesParametersTypes=dict,
+            ParametersTypes=dict,
+            ControlTypes=dict,
+            MarkerTypes=dict,
+        ),
+        "app.processors.models_data": _module(
+            "app.processors.models_data", models_dir="models"
+        ),
+    }
+
+    saved_modules = {
+        name: sys.modules.get(name) for name in [*stub_modules, "app.ui.main_ui"]
+    }
+
+    try:
+        for name, module in stub_modules.items():
+            sys.modules[name] = module
+        sys.modules.pop("app.ui.main_ui", None)
+        return importlib.import_module("app.ui.main_ui")
+    finally:
+        for name, original in saved_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def test_escape_exits_theatre_mode_directly_when_combined_mode_is_enabled():
+    main_ui = _load_main_ui_module()
+    theatre_toggle = MagicMock()
+    fullscreen_toggle = MagicMock()
+    main_ui.video_control_actions.toggle_theatre_mode = theatre_toggle
+    main_ui.video_control_actions.view_fullscreen = fullscreen_toggle
+
+    main_window = SimpleNamespace(
+        control={"TheatreModeUsesFullscreenToggle": True},
+        is_theatre_mode=True,
+        isFullScreen=lambda: True,
+    )
+    event = SimpleNamespace(key=lambda: main_ui.QtCore.Qt.Key_Escape)
+
+    main_ui.MainWindow.keyPressEvent(main_window, event)
+
+    theatre_toggle.assert_called_once_with(main_window)
+    fullscreen_toggle.assert_not_called()
+
+
+def test_escape_keeps_existing_fullscreen_behavior_when_combined_mode_is_disabled():
+    main_ui = _load_main_ui_module()
+    theatre_toggle = MagicMock()
+    fullscreen_toggle = MagicMock()
+    main_ui.video_control_actions.toggle_theatre_mode = theatre_toggle
+    main_ui.video_control_actions.view_fullscreen = fullscreen_toggle
+
+    main_window = SimpleNamespace(
+        control={"TheatreModeUsesFullscreenToggle": False},
+        is_theatre_mode=True,
+        isFullScreen=lambda: True,
+    )
+    event = SimpleNamespace(key=lambda: main_ui.QtCore.Qt.Key_Escape)
+
+    main_ui.MainWindow.keyPressEvent(main_window, event)
+
+    fullscreen_toggle.assert_called_once_with(main_window)
+    theatre_toggle.assert_not_called()

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -461,7 +461,10 @@ def _make_workspace_main_window(
     mw._fullscreen_restore_was_maximized = False
     mw._fullscreen_restore_geometry = fullscreen_restore_geometry
     mw._saved_window_state = _FakeByteArray(saved_window_state)
-    mw.control = {"TheatreModeUsesFullscreenToggle": False}
+    mw.control = {
+        "TheatreModeUsesFullscreenToggle": False,
+        "ConfirmBeforeStoppingRecordingToggle": True,
+    }
     mw.target_videos = {}
     mw.input_faces = {}
     mw.target_faces = {}
@@ -722,6 +725,22 @@ def test_save_workspace_persists_theatre_fullscreen_setting_in_control(tmp_path)
 
     saved = _read_saved_workspace(save_path)
     assert saved["control"]["TheatreModeUsesFullscreenToggle"] is True
+
+
+def test_save_workspace_persists_stop_recording_confirmation_setting(tmp_path):
+    save_path = tmp_path / "workspace.json"
+    main_window = _make_workspace_main_window(
+        tmp_path,
+        is_theatre_mode=False,
+        is_full_screen=False,
+        is_maximized=False,
+    )
+    main_window.control["ConfirmBeforeStoppingRecordingToggle"] = False
+
+    save_current_workspace(main_window, str(save_path))
+
+    saved = _read_saved_workspace(save_path)
+    assert saved["control"]["ConfirmBeforeStoppingRecordingToggle"] is False
 
 
 def test_apply_workspace_window_state_fullscreen_seeds_restore_geometry(monkeypatch):

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -444,6 +444,7 @@ def _make_workspace_main_window(
     was_custom_fullscreen: bool = False,
     was_maximized: bool = False,
     fullscreen_restore_geometry: _FakeGeometry | None = None,
+    theatre_forced_fullscreen: bool = False,
 ):
     default_params_data = {"brightness": 1.0, "contrast": 0.8}
     geometry = geometry or _FakeGeometry(10, 20, 1280, 720)
@@ -454,12 +455,13 @@ def _make_workspace_main_window(
     mw.is_theatre_mode = is_theatre_mode
     mw.is_full_screen = is_full_screen
     mw._was_custom_fullscreen = was_custom_fullscreen
+    mw._theatre_forced_fullscreen = theatre_forced_fullscreen
     mw._was_maximized = was_maximized
     mw._was_normal_geometry = normal_geometry
     mw._fullscreen_restore_was_maximized = False
     mw._fullscreen_restore_geometry = fullscreen_restore_geometry
     mw._saved_window_state = _FakeByteArray(saved_window_state)
-    mw.control = {}
+    mw.control = {"TheatreModeUsesFullscreenToggle": False}
     mw.target_videos = {}
     mw.input_faces = {}
     mw.target_faces = {}
@@ -631,6 +633,40 @@ def test_save_workspace_theatre_from_normal_uses_live_window_state(tmp_path):
     )
 
 
+def test_save_workspace_theatre_forced_fullscreen_uses_pre_theatre_window_state(
+    tmp_path,
+):
+    save_path = tmp_path / "workspace.json"
+    base_geometry = _FakeGeometry(444, 555, 1200, 800)
+    main_window = _make_workspace_main_window(
+        tmp_path,
+        is_theatre_mode=True,
+        is_full_screen=True,
+        is_maximized=False,
+        geometry=_FakeGeometry(0, 0, 1920, 1080),
+        normal_geometry=base_geometry,
+        saved_window_state="pre-theatre-layout",
+        was_custom_fullscreen=False,
+        was_maximized=False,
+        theatre_forced_fullscreen=True,
+    )
+
+    save_current_workspace(main_window, str(save_path))
+
+    saved = _read_saved_workspace(save_path)
+    assert saved["control"]["TheatreModeUsesFullscreenToggle"] is False
+    saved_window = saved["window_state_data"]
+    assert saved_window["isFullScreen"] is False
+    assert saved_window["isMaximized"] is False
+    assert saved_window["dock_state"] == "pre-theatre-layout"
+    assert (
+        saved_window["x"],
+        saved_window["y"],
+        saved_window["width"],
+        saved_window["height"],
+    ) == (444, 555, 1200, 800)
+
+
 def test_save_workspace_theatre_uses_latest_fullscreen_base_toggle(tmp_path):
     save_path = tmp_path / "workspace.json"
     main_window = _make_workspace_main_window(
@@ -670,6 +706,22 @@ def test_save_workspace_theatre_uses_latest_fullscreen_base_toggle(tmp_path):
         1110,
         720,
     )
+
+
+def test_save_workspace_persists_theatre_fullscreen_setting_in_control(tmp_path):
+    save_path = tmp_path / "workspace.json"
+    main_window = _make_workspace_main_window(
+        tmp_path,
+        is_theatre_mode=False,
+        is_full_screen=False,
+        is_maximized=False,
+    )
+    main_window.control["TheatreModeUsesFullscreenToggle"] = True
+
+    save_current_workspace(main_window, str(save_path))
+
+    saved = _read_saved_workspace(save_path)
+    assert saved["control"]["TheatreModeUsesFullscreenToggle"] is True
 
 
 def test_apply_workspace_window_state_fullscreen_seeds_restore_geometry(monkeypatch):

--- a/tests/unit/ui/test_settings_layout_data.py
+++ b/tests/unit/ui/test_settings_layout_data.py
@@ -199,3 +199,11 @@ def test_parent_toggle_references_exist():
             assert parent in all_keys, (
                 f"{cat}/{name}.parentToggle='{parent}' does not exist as a widget key"
             )
+
+
+def test_theatre_mode_uses_fullscreen_toggle_exists_in_video_playback_settings():
+    entry = SETTINGS_LAYOUT_DATA["Video Playback Settings"][
+        "TheatreModeUsesFullscreenToggle"
+    ]
+    assert entry["label"] == "Theatre Mode Uses Fullscreen"
+    assert entry["default"] is False

--- a/tests/unit/ui/test_settings_layout_data.py
+++ b/tests/unit/ui/test_settings_layout_data.py
@@ -207,3 +207,11 @@ def test_theatre_mode_uses_fullscreen_toggle_exists_in_video_playback_settings()
     ]
     assert entry["label"] == "Theatre Mode Uses Fullscreen"
     assert entry["default"] is False
+
+
+def test_confirm_before_stopping_recording_toggle_exists_in_video_recording_settings():
+    entry = SETTINGS_LAYOUT_DATA["Video Recording Settings"][
+        "ConfirmBeforeStoppingRecordingToggle"
+    ]
+    assert entry["label"] == "Confirm Before Stopping Recording"
+    assert entry["default"] is True

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -205,6 +205,7 @@ class _StatefulFullscreenWindow:
         state: str = "normal",
         geometry: _FakeGeometry | None = None,
         is_theatre_mode: bool = False,
+        theatre_forced_fullscreen: bool = False,
     ):
         self._state = state
         self._geometry = geometry or _FakeGeometry()
@@ -216,6 +217,7 @@ class _StatefulFullscreenWindow:
         self._was_maximized = state == "maximized"
         self._was_custom_fullscreen = False
         self._was_normal_geometry = self._normal_geometry
+        self._theatre_forced_fullscreen = theatre_forced_fullscreen
         self._sync_calls: list[bool] = []
         self._theatre_snapshot_sync_calls = 0
         self.showFullScreen = MagicMock(side_effect=self._show_fullscreen)
@@ -260,6 +262,8 @@ class _StatefulFullscreenWindow:
             return
 
         if self.isFullScreen():
+            if self._theatre_forced_fullscreen:
+                return
             self._was_custom_fullscreen = True
             self._was_maximized = False
             self._was_normal_geometry = (
@@ -453,12 +457,32 @@ class _FakeGraphicsViewFrame:
         return None
 
 
-def _make_theatre_entry_window(*, is_fullscreen: bool, is_maximized: bool = False):
+def _make_theatre_entry_window(
+    *,
+    is_fullscreen: bool,
+    is_maximized: bool = False,
+    theatre_uses_fullscreen: bool = False,
+):
     menu_bar = _FakeMenuBar()
+    state = "fullscreen" if is_fullscreen else "maximized" if is_maximized else "normal"
+
+    def _show_fullscreen():
+        nonlocal state
+        state = "fullscreen"
+
+    def _show_normal():
+        nonlocal state
+        state = "normal"
+
+    def _show_maximized():
+        nonlocal state
+        state = "maximized"
+
     return SimpleNamespace(
         is_theatre_mode=False,
         is_full_screen=False,
         _saved_window_state=None,
+        _theatre_forced_fullscreen=False,
         input_Target_DockWidget=_FakeWidget(),
         input_Faces_DockWidget=_FakeWidget(),
         jobManagerDockWidget=_FakeWidget(),
@@ -471,12 +495,16 @@ def _make_theatre_entry_window(*, is_fullscreen: bool, is_maximized: bool = Fals
         panelVisibilityCheckBoxLayout=_FakeLayout(),
         graphicsViewFrame=_FakeGraphicsViewFrame(),
         saveState=lambda: "window-state",
-        isMaximized=lambda: is_maximized,
-        isFullScreen=lambda: is_fullscreen,
+        isMaximized=lambda: state == "maximized",
+        isFullScreen=lambda: state == "fullscreen",
         normalGeometry=lambda: "normal-geometry",
         geometry=lambda: "live-geometry",
+        control={"TheatreModeUsesFullscreenToggle": theatre_uses_fullscreen},
         setWindowState=MagicMock(),
-        showFullScreen=MagicMock(),
+        showFullScreen=MagicMock(side_effect=_show_fullscreen),
+        showNormal=MagicMock(side_effect=_show_normal),
+        showMaximized=MagicMock(side_effect=_show_maximized),
+        setGeometry=MagicMock(),
     )
 
 
@@ -535,6 +563,128 @@ def test_toggle_theatre_mode_keeps_maximized_window_when_base_mode_is_maximized(
     assert main_window.is_full_screen is False
 
 
+def test_toggle_theatre_mode_enters_fullscreen_from_windowed_state_when_enabled(
+    monkeypatch, video_actions_env
+):
+    monkeypatch.setattr(
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(
+        is_fullscreen=False,
+        is_maximized=False,
+        theatre_uses_fullscreen=True,
+    )
+
+    video_actions_env.toggle_theatre_mode(main_window)
+
+    assert main_window._was_custom_fullscreen is False
+    assert main_window._theatre_forced_fullscreen is True
+    assert main_window._was_maximized is False
+    assert main_window._was_normal_geometry == "live-geometry"
+    main_window.setWindowState.assert_called_once_with(
+        video_actions_env.module.QtCore.Qt.WindowState.WindowFullScreen
+    )
+    main_window.showFullScreen.assert_called_once()
+    assert main_window.is_full_screen is True
+
+
+def test_toggle_theatre_mode_enters_fullscreen_from_maximized_state_when_enabled(
+    monkeypatch, video_actions_env
+):
+    monkeypatch.setattr(
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(
+        is_fullscreen=False,
+        is_maximized=True,
+        theatre_uses_fullscreen=True,
+    )
+
+    video_actions_env.toggle_theatre_mode(main_window)
+
+    assert main_window._was_custom_fullscreen is False
+    assert main_window._theatre_forced_fullscreen is True
+    assert main_window._was_maximized is True
+    assert main_window._was_normal_geometry == "normal-geometry"
+    main_window.setWindowState.assert_called_once_with(
+        video_actions_env.module.QtCore.Qt.WindowState.WindowFullScreen
+    )
+    main_window.showFullScreen.assert_called_once()
+    assert main_window.is_full_screen is True
+
+
+def test_toggle_theatre_mode_keeps_existing_fullscreen_when_setting_enabled(
+    monkeypatch, video_actions_env
+):
+    monkeypatch.setattr(
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(
+        is_fullscreen=True,
+        theatre_uses_fullscreen=True,
+    )
+
+    video_actions_env.toggle_theatre_mode(main_window)
+
+    assert main_window._was_custom_fullscreen is True
+    assert main_window._theatre_forced_fullscreen is False
+    assert main_window._was_normal_geometry == "normal-geometry"
+    main_window.setWindowState.assert_called_once_with(
+        video_actions_env.module.QtCore.Qt.WindowState.WindowFullScreen
+    )
+    main_window.showFullScreen.assert_called_once()
+    assert main_window.is_full_screen is True
+
+
+def test_toggle_theatre_mode_seeds_fullscreen_restore_geometry_when_forced(
+    monkeypatch, video_actions_env
+):
+    monkeypatch.setattr(
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(
+        is_fullscreen=False,
+        is_maximized=False,
+        theatre_uses_fullscreen=True,
+    )
+
+    video_actions_env.toggle_theatre_mode(main_window)
+    video_actions_env.view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is None
+    main_window.showNormal.assert_called_once()
+    assert main_window.setGeometry.call_args_list[-1].args == ("live-geometry",)
+
+
+def test_toggle_theatre_mode_seeds_fullscreen_restore_maximized_when_forced(
+    monkeypatch, video_actions_env
+):
+    monkeypatch.setattr(
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
+    main_window = _make_theatre_entry_window(
+        is_fullscreen=False,
+        is_maximized=True,
+        theatre_uses_fullscreen=True,
+    )
+
+    video_actions_env.toggle_theatre_mode(main_window)
+    video_actions_env.view_fullscreen(main_window)
+
+    assert main_window.is_theatre_mode is True
+    assert main_window._fullscreen_restore_was_maximized is False
+    assert main_window._fullscreen_restore_geometry is None
+    main_window.showMaximized.assert_called_once()
+    main_window.showNormal.assert_not_called()
+
+
 def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(
     monkeypatch, video_actions_env
 ):
@@ -554,6 +704,7 @@ def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(
     main_window = SimpleNamespace(
         is_theatre_mode=True,
         _was_custom_fullscreen=False,
+        _theatre_forced_fullscreen=True,
         _was_maximized=False,
         _was_normal_geometry=saved_geometry,
         _saved_window_state="window-state",
@@ -595,6 +746,7 @@ def test_toggle_theatre_mode_restores_saved_normal_geometry_on_exit(
         (False,),
         (True,),
     ]
+    assert main_window._theatre_forced_fullscreen is False
     assert main_window.is_full_screen is False
 
 
@@ -610,6 +762,7 @@ def test_toggle_theatre_mode_restores_maximized_state_on_exit(
     main_window = SimpleNamespace(
         is_theatre_mode=True,
         _was_custom_fullscreen=False,
+        _theatre_forced_fullscreen=True,
         _was_maximized=True,
         _was_normal_geometry="normal-geometry",
         _saved_window_state="window-state",
@@ -652,7 +805,66 @@ def test_toggle_theatre_mode_restores_maximized_state_on_exit(
         (False,),
         (True,),
     ]
+    assert main_window._theatre_forced_fullscreen is False
     assert main_window.is_full_screen is False
+
+
+def test_toggle_theatre_mode_restores_existing_fullscreen_state_on_exit(
+    monkeypatch, video_actions_env
+):
+    monkeypatch.setattr(
+        video_actions_env.module, "_set_media_controls_visible", lambda *_args: None
+    )
+    video_actions_env.module.layout_actions.fit_image_to_view_onchange.reset_mock()
+
+    menu_bar = _FakeMenuBar()
+    main_window = SimpleNamespace(
+        is_theatre_mode=True,
+        _was_custom_fullscreen=True,
+        _theatre_forced_fullscreen=False,
+        _was_maximized=False,
+        _was_normal_geometry="normal-geometry",
+        _saved_window_state="window-state",
+        _saved_dock_states={},
+        _saved_layout_props={},
+        _main_v_spacers=[],
+        _top_bar_spacers=[],
+        _top_bar_widgets_state={},
+        input_Target_DockWidget=_FakeWidget(False),
+        input_Faces_DockWidget=_FakeWidget(False),
+        jobManagerDockWidget=_FakeWidget(False),
+        controlOptionsDockWidget=_FakeWidget(False),
+        facesPanelGroupBox=_FakeWidget(False),
+        menuBar=lambda: menu_bar,
+        horizontalLayout=_FakeLayout(),
+        verticalLayout=_FakeLayout(),
+        verticalLayoutMediaControls=_FakeLayout(),
+        panelVisibilityCheckBoxLayout=_FakeLayout(),
+        graphicsViewFrame=_FakeGraphicsViewFrame(),
+        isFullScreen=lambda: True,
+        isMaximized=lambda: False,
+        normalGeometry=lambda: "normal-geometry",
+        geometry=lambda: "live-geometry",
+        showFullScreen=MagicMock(),
+        showMaximized=MagicMock(),
+        showNormal=MagicMock(),
+        setWindowState=MagicMock(),
+        setGeometry=MagicMock(),
+        restoreState=MagicMock(),
+        setUpdatesEnabled=MagicMock(),
+    )
+
+    video_actions_env.toggle_theatre_mode(main_window)
+
+    main_window.setWindowState.assert_called_once_with(
+        video_actions_env.module.QtCore.Qt.WindowState.WindowFullScreen
+    )
+    main_window.showFullScreen.assert_not_called()
+    main_window.showMaximized.assert_not_called()
+    main_window.showNormal.assert_not_called()
+    main_window.restoreState.assert_called_once_with("window-state")
+    assert main_window._theatre_forced_fullscreen is False
+    assert main_window.is_full_screen is True
 
 
 def test_disable_compare_preview_modes_for_recording_disables_both_and_toasts(

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -101,6 +101,7 @@ def video_actions_env():
             common_widget_actions=common_widget_actions,
             view_fullscreen=video_control_actions.view_fullscreen,
             toggle_theatre_mode=video_control_actions.toggle_theatre_mode,
+            record_video=video_control_actions.record_video,
             disable_compare_preview_modes_for_recording=(
                 video_control_actions._disable_compare_preview_modes_for_recording
             ),
@@ -899,3 +900,176 @@ def test_disable_compare_preview_modes_for_recording_is_noop_when_already_off(
 
     assert calls == []
     video_actions_env.common_widget_actions.create_and_show_toast_message.assert_not_called()
+
+
+class _FakeRecordButton:
+    def __init__(self):
+        self.checked_states = []
+        self.block_calls = []
+
+    def blockSignals(self, value):
+        self.block_calls.append(value)
+
+    def setChecked(self, value):
+        self.checked_states.append(value)
+
+    def setIcon(self, *_args):
+        return None
+
+    def setToolTip(self, *_args):
+        return None
+
+
+class _FakePromptBox:
+    Warning = "warning"
+    Yes = 1
+    No = 2
+    next_result = Yes
+    instances: list["_FakePromptBox"] = []
+
+    def __init__(self, _parent):
+        self.window_title = None
+        self.text = None
+        self.informative_text = None
+        self.standard_buttons = None
+        self.default_button = None
+        _FakePromptBox.instances.append(self)
+
+    def setIcon(self, _icon):
+        return None
+
+    def setWindowTitle(self, value):
+        self.window_title = value
+
+    def setText(self, value):
+        self.text = value
+
+    def setInformativeText(self, value):
+        self.informative_text = value
+
+    def setStandardButtons(self, value):
+        self.standard_buttons = value
+
+    def setDefaultButton(self, value):
+        self.default_button = value
+
+    def exec(self):
+        return _FakePromptBox.next_result
+
+
+def _make_record_stop_window(
+    *,
+    confirm_before_stop: bool = True,
+    recording: bool = False,
+    is_processing_segments: bool = False,
+    job_manager_initiated_record: bool = False,
+):
+    return SimpleNamespace(
+        control={"ConfirmBeforeStoppingRecordingToggle": confirm_before_stop},
+        video_processor=SimpleNamespace(
+            file_type="video",
+            recording=recording,
+            is_processing_segments=is_processing_segments,
+            finalize_segment_concatenation=MagicMock(),
+            _finalize_default_style_recording=MagicMock(),
+        ),
+        buttonMediaRecord=_FakeRecordButton(),
+        buttonMediaPlay=SimpleNamespace(setEnabled=MagicMock()),
+        job_manager_initiated_record=job_manager_initiated_record,
+    )
+
+
+def test_record_video_prompts_before_manual_stop_when_setting_enabled(
+    monkeypatch, video_actions_env
+):
+    _FakePromptBox.instances = []
+    _FakePromptBox.next_result = _FakePromptBox.Yes
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets, "QMessageBox", _FakePromptBox
+    )
+    main_window = _make_record_stop_window(recording=True, confirm_before_stop=True)
+
+    video_actions_env.record_video(main_window, checked=False)
+
+    assert len(_FakePromptBox.instances) == 1
+    prompt = _FakePromptBox.instances[0]
+    assert prompt.window_title == "Confirm stop"
+    assert prompt.text == "Stop recording?"
+    assert (
+        prompt.informative_text
+        == "Recording will stop immediately. Output may be incomplete."
+    )
+    main_window.video_processor._finalize_default_style_recording.assert_called_once()
+
+
+def test_record_video_skips_prompt_before_manual_stop_when_setting_disabled(
+    monkeypatch, video_actions_env
+):
+    _FakePromptBox.instances = []
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets, "QMessageBox", _FakePromptBox
+    )
+    main_window = _make_record_stop_window(recording=True, confirm_before_stop=False)
+
+    video_actions_env.record_video(main_window, checked=False)
+
+    assert _FakePromptBox.instances == []
+    main_window.video_processor._finalize_default_style_recording.assert_called_once()
+
+
+def test_record_video_skips_prompt_for_job_manager_stop_even_when_enabled(
+    monkeypatch, video_actions_env
+):
+    _FakePromptBox.instances = []
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets, "QMessageBox", _FakePromptBox
+    )
+    main_window = _make_record_stop_window(
+        recording=True,
+        confirm_before_stop=True,
+        job_manager_initiated_record=True,
+    )
+
+    video_actions_env.record_video(main_window, checked=False)
+
+    assert _FakePromptBox.instances == []
+    main_window.video_processor._finalize_default_style_recording.assert_called_once()
+
+
+def test_record_video_rearms_toggle_when_stop_is_cancelled(
+    monkeypatch, video_actions_env
+):
+    _FakePromptBox.instances = []
+    _FakePromptBox.next_result = _FakePromptBox.No
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets, "QMessageBox", _FakePromptBox
+    )
+    main_window = _make_record_stop_window(recording=True, confirm_before_stop=True)
+
+    video_actions_env.record_video(main_window, checked=False)
+
+    assert len(_FakePromptBox.instances) == 1
+    assert main_window.buttonMediaRecord.block_calls == [True, False]
+    assert main_window.buttonMediaRecord.checked_states == [True]
+    main_window.video_processor._finalize_default_style_recording.assert_not_called()
+    main_window.video_processor.finalize_segment_concatenation.assert_not_called()
+
+
+def test_record_video_finalizes_segment_recording_after_confirmation(
+    monkeypatch, video_actions_env
+):
+    _FakePromptBox.instances = []
+    _FakePromptBox.next_result = _FakePromptBox.Yes
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets, "QMessageBox", _FakePromptBox
+    )
+    main_window = _make_record_stop_window(
+        is_processing_segments=True,
+        confirm_before_stop=True,
+    )
+
+    video_actions_env.record_video(main_window, checked=False)
+
+    assert len(_FakePromptBox.instances) == 1
+    main_window.video_processor.finalize_segment_concatenation.assert_called_once()
+    main_window.video_processor._finalize_default_style_recording.assert_not_called()


### PR DESCRIPTION
## Summary
This PR adds two new user-facing settings:

1. `Theatre Mode Uses Fullscreen`  
Allows theatre mode to also enter fullscreen, then restores the previous window state when theatre mode exits.

2. `Confirm Before Stopping Recording`  
Allows users to disable the confirmation prompt when manually stopping a recording.

## Changes
- Added `Theatre Mode Uses Fullscreen` to `Video Playback Settings`
- Added `Confirm Before Stopping Recording` to `Video Recording Settings`
- Updated theatre mode enter/exit handling so combined theatre + fullscreen restores correctly, `Esc` exits in one step when applicable, and `F11` continues to work as expected during theatre mode
- Updated manual recording stop confirmation to respect the new setting, keep the existing Job Manager bypass, and use shared prompt handling for normal and multi-segment recording

## Verification
- Manual testing for theatre/fullscreen enter and restore behavior, `Esc`/`F11` handling during theatre mode, recording stop confirmation enabled/disabled paths, and workspace persistence for both new settings
- `.\.venv\Scripts\python.exe -m pytest`
- `.\.venv\Scripts\python.exe -m pre_commit run --all-files`

Both passed locally.