### PR TITLE
Feat/panel clear actions and test fixes

### DIFF
--- a/app/ui/widgets/actions/list_view_actions.py
+++ b/app/ui/widgets/actions/list_view_actions.py
@@ -246,6 +246,11 @@ def initialize_media_list_widgets(main_window: "MainWindow"):
         listWidget.setFlow(QtWidgets.QListView.LeftToRight)
         listWidget.setResizeMode(QtWidgets.QListView.Adjust)
 
+    _set_up_panel_context_menu(
+        main_window, main_window.targetVideosList, "target_media"
+    )
+    _set_up_panel_context_menu(main_window, main_window.inputFacesList, "input_faces")
+
 
 def initialize_embeddings_list_widget(main_window: "MainWindow"):
     """One-time configuration for the inputEmbeddingsList widget."""
@@ -279,6 +284,7 @@ def initialize_embeddings_list_widget(main_window: "MainWindow"):
 
     inputEmbeddingsList.setLayoutDirection(QtCore.Qt.LeftToRight)
     inputEmbeddingsList.setLayoutMode(QtWidgets.QListView.Batched)
+    _set_up_panel_context_menu(main_window, inputEmbeddingsList, "embeddings")
 
 
 def create_and_add_embed_button_to_list(
@@ -305,16 +311,18 @@ def create_and_add_embed_button_to_list(
     main_window.merged_embeddings[embed_button.embedding_id] = embed_button
 
 
-def clear_stop_loading_target_media(main_window: "MainWindow"):
+def clear_stop_loading_target_media(main_window: "MainWindow", clear_list: bool = True):
     if main_window.video_loader_worker is not None:
         worker = main_window.video_loader_worker
+        worker.blockSignals(True)
         worker._running = False
         worker.quit()
         if not worker.wait(_WORKER_STOP_TIMEOUT_MS):
             worker.terminate()
             worker.wait()
         main_window.video_loader_worker = None
-        main_window.targetVideosList.clear()
+        if clear_list:
+            main_window.targetVideosList.clear()
 
 
 @QtCore.Slot()
@@ -413,16 +421,175 @@ def load_target_webcams(
         main_window.placeholder_update_signal.emit(main_window.targetVideosList, False)
 
 
-def clear_stop_loading_input_media(main_window: "MainWindow"):
+def clear_stop_loading_input_media(main_window: "MainWindow", clear_list: bool = True):
     if main_window.input_faces_loader_worker is not None:
         worker = main_window.input_faces_loader_worker
+        worker.blockSignals(True)
         worker._running = False
         worker.quit()
         if not worker.wait(_WORKER_STOP_TIMEOUT_MS):
             worker.terminate()
             worker.wait()
         main_window.input_faces_loader_worker = None
-        main_window.inputFacesList.clear()
+        if clear_list:
+            main_window.inputFacesList.clear()
+
+
+def _set_path_line_edit_value(line_edit: QtWidgets.QLineEdit, path: str) -> None:
+    line_edit.setText(path)
+    line_edit.setToolTip(path)
+
+
+def _confirm_panel_clear(main_window: "MainWindow", title: str, message: str) -> bool:
+    reply = QtWidgets.QMessageBox.question(
+        main_window,
+        title,
+        message,
+        QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+        QtWidgets.QMessageBox.No,
+    )
+    return reply == QtWidgets.QMessageBox.Yes
+
+
+def clear_all_target_media(main_window: "MainWindow") -> bool:
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(main_window, "clear all media"):
+        return False
+
+    if not main_window.target_videos:
+        return False
+
+    confirmed = _confirm_panel_clear(
+        main_window,
+        "Clear All Media",
+        "This will remove all target media, including webcams, and reset the "
+        "Target Media panel.\n\nFiles on disk will not be deleted.",
+    )
+    if not confirmed:
+        return False
+
+    clear_stop_loading_target_media(main_window, clear_list=False)
+
+    for target_media_button in list(main_window.target_videos.values()):
+        target_media_button.remove_target_media_from_list()
+
+    if main_window.target_faces:
+        card_actions.clear_target_faces(main_window, refresh_frame=False)
+
+    main_window.target_videos.clear()
+    main_window.selected_video_button = None
+    _set_path_line_edit_value(main_window.targetVideosPathLineEdit, "")
+    main_window.last_target_media_folder_path = ""
+    main_window.placeholder_update_signal.emit(main_window.targetVideosList, False)
+    return True
+
+
+def clear_all_input_faces(main_window: "MainWindow") -> bool:
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(main_window, "clear all faces"):
+        return False
+
+    if not main_window.input_faces:
+        return False
+
+    confirmed = _confirm_panel_clear(
+        main_window,
+        "Clear All Faces",
+        "This will remove all input faces and reset the Input Faces panel.\n\n"
+        "Files on disk will not be deleted.",
+    )
+    if not confirmed:
+        return False
+
+    clear_stop_loading_input_media(main_window, clear_list=False)
+
+    for input_face_button in list(main_window.input_faces.values()):
+        input_face_button.remove_kv_data_file()
+        input_face_button._remove_face_from_lists()
+        input_face_button.deleteLater()
+
+    common_widget_actions.refresh_frame(main_window)
+    _set_path_line_edit_value(main_window.inputFacesPathLineEdit, "")
+    main_window.last_input_media_folder_path = ""
+    main_window.placeholder_update_signal.emit(main_window.inputFacesList, False)
+    return True
+
+
+def clear_all_embeddings(main_window: "MainWindow") -> bool:
+    from app.ui.widgets.actions import video_control_actions
+
+    if video_control_actions.block_if_issue_scan_active(
+        main_window, "clear all embeddings"
+    ):
+        return False
+
+    if not main_window.merged_embeddings:
+        return False
+
+    confirmed = _confirm_panel_clear(
+        main_window,
+        "Clear All Embeddings",
+        "This will remove all embeddings and reset the Embeddings panel.\n\n"
+        "Files on disk will not be deleted.",
+    )
+    if not confirmed:
+        return False
+
+    card_actions.clear_merged_embeddings(main_window)
+    return True
+
+
+def _build_panel_context_menu(
+    main_window: "MainWindow",
+    list_widget: QtWidgets.QListWidget,
+    panel_type: str,
+) -> QtWidgets.QMenu:
+    from app.ui.widgets.actions import video_control_actions
+
+    scan_active = video_control_actions.is_issue_scan_active(main_window)
+    menu = QtWidgets.QMenu(list_widget)
+
+    if panel_type == "target_media":
+        clear_action = QtGui.QAction("Clear All Media", menu)
+        clear_action.setEnabled(bool(main_window.target_videos) and not scan_active)
+        clear_action.triggered.connect(partial(clear_all_target_media, main_window))
+    elif panel_type == "input_faces":
+        clear_action = QtGui.QAction("Clear All Faces", menu)
+        clear_action.setEnabled(bool(main_window.input_faces) and not scan_active)
+        clear_action.triggered.connect(partial(clear_all_input_faces, main_window))
+    else:
+        clear_action = QtGui.QAction("Clear All Embeddings", menu)
+        clear_action.setEnabled(bool(main_window.merged_embeddings) and not scan_active)
+        clear_action.triggered.connect(partial(clear_all_embeddings, main_window))
+
+    menu.addAction(clear_action)
+    return menu
+
+
+def _show_panel_context_menu(
+    main_window: "MainWindow",
+    list_widget: QtWidgets.QListWidget,
+    panel_type: str,
+    position: QtCore.QPoint,
+) -> None:
+    if list_widget.itemAt(position) is not None:
+        return
+
+    menu = _build_panel_context_menu(main_window, list_widget, panel_type)
+    menu.exec(list_widget.viewport().mapToGlobal(position))
+
+
+def _set_up_panel_context_menu(
+    main_window: "MainWindow",
+    list_widget: QtWidgets.QListWidget,
+    panel_type: str,
+) -> None:
+    list_widget.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+    list_widget.customContextMenuRequested.connect(
+        partial(_show_panel_context_menu, main_window, list_widget, panel_type)
+    )
 
 
 @QtCore.Slot()

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -531,6 +531,8 @@ class TargetMediaCardButton(CardButton):
                 subprocess.run(["xdg-open", directory])
 
     def create_context_menu(self):
+        from app.ui.widgets.actions import list_view_actions
+
         self.popMenu = QtWidgets.QMenu(self)
         self.remove_action = QtGui.QAction("Remove from list", self)
         self.remove_action.triggered.connect(self.remove_target_media_from_list)
@@ -543,12 +545,22 @@ class TargetMediaCardButton(CardButton):
         self.open_path_action = QtGui.QAction("Open file location", self)
         self.open_path_action.triggered.connect(self.open_target_path_by_explorer)
         self.popMenu.addAction(self.open_path_action)
+        self.popMenu.addSeparator()
+
+        self.clear_all_media_action = QtGui.QAction("Clear All Media", self)
+        self.clear_all_media_action.triggered.connect(
+            partial(list_view_actions.clear_all_target_media, self.main_window)
+        )
+        self.popMenu.addAction(self.clear_all_media_action)
 
     def on_context_menu(self, point):
         # show context menu
         scan_active = video_control_actions.is_issue_scan_active(self.main_window)
         self.remove_action.setEnabled(not scan_active)
         self.delete_action.setEnabled(not scan_active)
+        self.clear_all_media_action.setEnabled(
+            bool(self.main_window.target_videos) and not scan_active
+        )
         self.popMenu.exec_(self.mapToGlobal(point))
 
 
@@ -1414,6 +1426,13 @@ class InputFaceCardButton(CardButton):
             )
         )
         self.popMenu.addAction(self.large_thumbnails_action)
+        self.popMenu.addSeparator()
+
+        self.clear_all_faces_action = QtGui.QAction("Clear All Faces", self)
+        self.clear_all_faces_action.triggered.connect(
+            partial(list_view_actions.clear_all_input_faces, self.main_window)
+        )
+        self.popMenu.addAction(self.clear_all_faces_action)
 
     def on_context_menu(self, point):
         # show context menu
@@ -1426,6 +1445,9 @@ class InputFaceCardButton(CardButton):
         self.delete_action.setEnabled(not scan_active)
         self.small_thumbnails_action.setChecked(current_face_size == (70, 70))
         self.large_thumbnails_action.setChecked(current_face_size == (96, 96))
+        self.clear_all_faces_action.setEnabled(
+            bool(self.main_window.input_faces) and not scan_active
+        )
         self.popMenu.exec_(self.mapToGlobal(point))
 
     def create_embedding_from_selected_faces(self):
@@ -1562,15 +1584,26 @@ class EmbeddingCardButton(CardButton):
 
     def create_context_menu(self):
         # create context menu
+        from app.ui.widgets.actions import list_view_actions
+
         self.popMenu = QtWidgets.QMenu(self)
         self.remove_action = QtGui.QAction("Remove Embedding", self)
         self.remove_action.triggered.connect(self.remove_embedding_from_list)
         self.popMenu.addAction(self.remove_action)
+        self.popMenu.addSeparator()
+
+        self.clear_all_embeddings_action = QtGui.QAction("Clear All Embeddings", self)
+        self.clear_all_embeddings_action.triggered.connect(
+            partial(list_view_actions.clear_all_embeddings, self.main_window)
+        )
+        self.popMenu.addAction(self.clear_all_embeddings_action)
 
     def on_context_menu(self, point):
         # show context menu
-        self.remove_action.setEnabled(
-            not video_control_actions.is_issue_scan_active(self.main_window)
+        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+        self.remove_action.setEnabled(not scan_active)
+        self.clear_all_embeddings_action.setEnabled(
+            bool(self.main_window.merged_embeddings) and not scan_active
         )
         self.popMenu.exec_(self.mapToGlobal(point))
 

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -47,6 +47,7 @@ def test_filter_scan_control_keeps_only_allowlisted_keys():
         {
             "DetectorScoreSlider": 42,
             "FaceTrackingEnableToggle": True,
+            "SimilarityTypeSelection": "Pearl",
             "IgnoredControl": "skip",
         }
     )
@@ -406,7 +407,7 @@ def test_resolve_scan_state_filters_non_scan_face_params_and_fills_defaults():
     }
 
 
-def test_prepare_issue_scan_match_context_uses_snapshot_embeddings_for_segment_settings():
+def test_prepare_issue_scan_match_context_uses_auto_snapshot_embeddings():
     processor = VideoProcessor.__new__(VideoProcessor)
     processor.main_window = SimpleNamespace(
         default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
@@ -415,6 +416,7 @@ def test_prepare_issue_scan_match_context_uses_snapshot_embeddings_for_segment_s
         "face_1",
         {
             "arcface_128": {
+                "Auto": np.array([3.0], dtype=np.float32),
                 "Opal": np.array([1.0], dtype=np.float32),
                 "Pearl": np.array([2.0], dtype=np.float32),
             }
@@ -430,17 +432,19 @@ def test_prepare_issue_scan_match_context_uses_snapshot_embeddings_for_segment_s
         target_faces_snapshot,
     )
 
+    assert match_context["recognition_model"] == "arcface_128"
+    assert match_context["similarity_type"] == "Auto"
     prepared_targets = match_context["prepared_targets"]
     assert len(prepared_targets) == 1
     assert prepared_targets[0][0] == "face_1"
     assert prepared_targets[0][1] == 65.0
     np.testing.assert_array_equal(
         prepared_targets[0][2],
-        np.array([2.0], dtype=np.float32),
+        np.array([3.0], dtype=np.float32),
     )
 
 
-def test_prepare_issue_scan_target_faces_snapshot_uses_segment_recognition_settings():
+def test_prepare_issue_scan_target_faces_snapshot_uses_auto_similarity_mode():
     processor = VideoProcessor.__new__(VideoProcessor)
     run_recognize_calls = []
 
@@ -456,9 +460,7 @@ def test_prepare_issue_scan_target_faces_snapshot_uses_segment_recognition_setti
 
     def fake_run_recognize_direct(_img, _kps, similarity_type, recognition_model):
         run_recognize_calls.append((recognition_model, similarity_type))
-        if similarity_type == "Pearl":
-            return np.array([2.0], dtype=np.float32), None
-        return np.array([1.0], dtype=np.float32), None
+        return np.array([3.0], dtype=np.float32), None
 
     processor.main_window = SimpleNamespace(
         target_faces={"face_1": _TargetFaceWithoutEmbeddingAccess()},
@@ -500,17 +502,10 @@ def test_prepare_issue_scan_target_faces_snapshot_uses_segment_recognition_setti
             {},
         )
 
-    assert run_recognize_calls == [
-        ("arcface_128", "Opal"),
-        ("arcface_128", "Pearl"),
-    ]
+    assert run_recognize_calls == [("arcface_128", "Auto")]
     np.testing.assert_array_equal(
-        snapshot["face_1"]["embeddings_by_model"]["arcface_128"]["Opal"],
-        np.array([1.0], dtype=np.float32),
-    )
-    np.testing.assert_array_equal(
-        snapshot["face_1"]["embeddings_by_model"]["arcface_128"]["Pearl"],
-        np.array([2.0], dtype=np.float32),
+        snapshot["face_1"]["embeddings_by_model"]["arcface_128"]["Auto"],
+        np.array([3.0], dtype=np.float32),
     )
 
 

--- a/tests/unit/ui/test_list_view_actions.py
+++ b/tests/unit/ui/test_list_view_actions.py
@@ -1,0 +1,383 @@
+from types import SimpleNamespace
+
+from PySide6 import QtWidgets
+
+from app.ui.widgets.actions import list_view_actions
+
+
+class _DummySignal:
+    def __init__(self):
+        self.calls = []
+
+    def emit(self, *args):
+        self.calls.append(args)
+
+
+class _DummyLineEdit:
+    def __init__(self, text=""):
+        self.value = text
+        self.tooltip = text
+
+    def setText(self, text):
+        self.value = str(text)
+
+    def setToolTip(self, tooltip):
+        self.tooltip = str(tooltip)
+
+
+class _DummyListWidget:
+    def __init__(self):
+        self.cleared = 0
+
+    def clear(self):
+        self.cleared += 1
+
+
+class _DummyTargetFace:
+    def __init__(self, input_faces=None, merged_embeddings=None):
+        self.assigned_input_faces = dict(input_faces or {})
+        self.assigned_merged_embeddings = dict(merged_embeddings or {})
+        self.recalculated = 0
+
+    def calculate_assigned_input_embedding(self):
+        self.recalculated += 1
+
+
+class _DummyTargetMediaButton:
+    def __init__(self, main_window, media_id):
+        self.main_window = main_window
+        self.media_id = media_id
+        self.removed = 0
+
+    def remove_target_media_from_list(self):
+        self.removed += 1
+        self.main_window.target_videos.pop(self.media_id, None)
+
+
+class _DummyInputFaceButton:
+    def __init__(self, main_window, face_id):
+        self.main_window = main_window
+        self.face_id = face_id
+        self.kv_removed = 0
+        self.deleted = 0
+
+    def remove_kv_data_file(self):
+        self.kv_removed += 1
+
+    def _remove_face_from_lists(self):
+        self.main_window.input_faces.pop(self.face_id, None)
+        for target_face in self.main_window.target_faces.values():
+            target_face.assigned_input_faces.pop(self.face_id, None)
+            target_face.calculate_assigned_input_embedding()
+
+    def deleteLater(self):
+        self.deleted += 1
+
+
+class _DummyEmbedButton:
+    def __init__(self):
+        self.deleted = 0
+
+    def deleteLater(self):
+        self.deleted += 1
+
+
+def test_clear_all_target_media_cancel_leaves_state_unchanged(monkeypatch):
+    placeholder_signal = _DummySignal()
+    path_line_edit = _DummyLineEdit("E:/media")
+    main_window = SimpleNamespace(
+        target_videos={},
+        target_faces={"face_1": object()},
+        selected_video_button=object(),
+        targetVideosPathLineEdit=path_line_edit,
+        last_target_media_folder_path="E:/media",
+        targetVideosList=_DummyListWidget(),
+        placeholder_update_signal=placeholder_signal,
+        video_loader_worker=None,
+    )
+    button = _DummyTargetMediaButton(main_window, "media_1")
+    main_window.target_videos["media_1"] = button
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.No,
+    )
+
+    assert list_view_actions.clear_all_target_media(main_window) is False
+    assert list(main_window.target_videos) == ["media_1"]
+    assert main_window.selected_video_button is not None
+    assert main_window.targetVideosPathLineEdit.value == "E:/media"
+    assert main_window.last_target_media_folder_path == "E:/media"
+    assert placeholder_signal.calls == []
+    assert button.removed == 0
+
+
+def test_clear_all_target_media_confirm_clears_state(monkeypatch):
+    placeholder_signal = _DummySignal()
+    path_line_edit = _DummyLineEdit("E:/media")
+    clear_target_faces_calls = []
+    main_window = SimpleNamespace(
+        target_videos={},
+        target_faces={"face_1": object()},
+        selected_video_button=object(),
+        targetVideosPathLineEdit=path_line_edit,
+        last_target_media_folder_path="E:/media",
+        targetVideosList=_DummyListWidget(),
+        placeholder_update_signal=placeholder_signal,
+        video_loader_worker=None,
+    )
+    button_a = _DummyTargetMediaButton(main_window, "media_1")
+    button_b = _DummyTargetMediaButton(main_window, "media_2")
+    main_window.target_videos = {
+        "media_1": button_a,
+        "media_2": button_b,
+    }
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.Yes,
+    )
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.card_actions.clear_target_faces",
+        lambda mw, refresh_frame=False: clear_target_faces_calls.append(
+            (mw, refresh_frame)
+        ),
+    )
+
+    assert list_view_actions.clear_all_target_media(main_window) is True
+    assert main_window.target_videos == {}
+    assert main_window.selected_video_button is None
+    assert main_window.targetVideosPathLineEdit.value == ""
+    assert main_window.targetVideosPathLineEdit.tooltip == ""
+    assert main_window.last_target_media_folder_path == ""
+    assert placeholder_signal.calls == [(main_window.targetVideosList, False)]
+    assert button_a.removed == 1
+    assert button_b.removed == 1
+    assert clear_target_faces_calls == [(main_window, False)]
+
+
+def test_clear_all_target_media_blocked_leaves_state_unchanged(monkeypatch):
+    main_window = SimpleNamespace(
+        target_videos={"media_1": object()},
+        target_faces={},
+        selected_video_button=object(),
+        targetVideosPathLineEdit=_DummyLineEdit("E:/media"),
+        last_target_media_folder_path="E:/media",
+        targetVideosList=_DummyListWidget(),
+        placeholder_update_signal=_DummySignal(),
+        video_loader_worker=None,
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: True,
+    )
+
+    assert list_view_actions.clear_all_target_media(main_window) is False
+    assert list(main_window.target_videos) == ["media_1"]
+    assert main_window.selected_video_button is not None
+    assert main_window.targetVideosPathLineEdit.value == "E:/media"
+    assert main_window.last_target_media_folder_path == "E:/media"
+
+
+def test_clear_all_input_faces_cancel_leaves_state_unchanged(monkeypatch):
+    assigned_face = object()
+    target_face = _DummyTargetFace({"face_1": assigned_face})
+    path_line_edit = _DummyLineEdit("E:/faces")
+    main_window = SimpleNamespace(
+        input_faces={},
+        target_faces={"target_1": target_face},
+        inputFacesPathLineEdit=path_line_edit,
+        last_input_media_folder_path="E:/faces",
+        inputFacesList=_DummyListWidget(),
+        placeholder_update_signal=_DummySignal(),
+        input_faces_loader_worker=None,
+    )
+    face_button = _DummyInputFaceButton(main_window, "face_1")
+    main_window.input_faces["face_1"] = face_button
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.No,
+    )
+    refresh_calls = []
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.common_widget_actions.refresh_frame",
+        lambda mw: refresh_calls.append(mw),
+    )
+
+    assert list_view_actions.clear_all_input_faces(main_window) is False
+    assert list(main_window.input_faces) == ["face_1"]
+    assert target_face.assigned_input_faces == {"face_1": assigned_face}
+    assert main_window.inputFacesPathLineEdit.value == "E:/faces"
+    assert main_window.last_input_media_folder_path == "E:/faces"
+    assert refresh_calls == []
+
+
+def test_clear_all_input_faces_confirm_clears_state(monkeypatch):
+    placeholder_signal = _DummySignal()
+    path_line_edit = _DummyLineEdit("E:/faces")
+    target_face = _DummyTargetFace({"face_1": object(), "face_2": object()})
+    main_window = SimpleNamespace(
+        input_faces={},
+        target_faces={"target_1": target_face},
+        inputFacesPathLineEdit=path_line_edit,
+        last_input_media_folder_path="E:/faces",
+        inputFacesList=_DummyListWidget(),
+        placeholder_update_signal=placeholder_signal,
+        input_faces_loader_worker=None,
+    )
+    face_one = _DummyInputFaceButton(main_window, "face_1")
+    face_two = _DummyInputFaceButton(main_window, "face_2")
+    main_window.input_faces = {"face_1": face_one, "face_2": face_two}
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.Yes,
+    )
+    refresh_calls = []
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.list_view_actions.common_widget_actions.refresh_frame",
+        lambda mw: refresh_calls.append(mw),
+    )
+
+    assert list_view_actions.clear_all_input_faces(main_window) is True
+    assert main_window.input_faces == {}
+    assert target_face.assigned_input_faces == {}
+    assert target_face.recalculated == 2
+    assert main_window.inputFacesPathLineEdit.value == ""
+    assert main_window.inputFacesPathLineEdit.tooltip == ""
+    assert main_window.last_input_media_folder_path == ""
+    assert placeholder_signal.calls == [(main_window.inputFacesList, False)]
+    assert refresh_calls == [main_window]
+    assert face_one.kv_removed == 1
+    assert face_two.kv_removed == 1
+    assert face_one.deleted == 1
+    assert face_two.deleted == 1
+
+
+def test_clear_all_input_faces_blocked_leaves_state_unchanged(monkeypatch):
+    main_window = SimpleNamespace(
+        input_faces={"face_1": object()},
+        target_faces={},
+        inputFacesPathLineEdit=_DummyLineEdit("E:/faces"),
+        last_input_media_folder_path="E:/faces",
+        inputFacesList=_DummyListWidget(),
+        placeholder_update_signal=_DummySignal(),
+        input_faces_loader_worker=None,
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: True,
+    )
+
+    assert list_view_actions.clear_all_input_faces(main_window) is False
+    assert list(main_window.input_faces) == ["face_1"]
+    assert main_window.inputFacesPathLineEdit.value == "E:/faces"
+    assert main_window.last_input_media_folder_path == "E:/faces"
+
+
+def test_clear_all_embeddings_cancel_leaves_state_unchanged(monkeypatch):
+    assigned_embedding = object()
+    target_face = _DummyTargetFace(merged_embeddings={"embed_1": assigned_embedding})
+    embed_button = _DummyEmbedButton()
+    main_window = SimpleNamespace(
+        merged_embeddings={"embed_1": embed_button},
+        target_faces={"target_1": target_face},
+        inputEmbeddingsList=_DummyListWidget(),
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.No,
+    )
+    refresh_calls = []
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.card_actions.common_widget_actions.refresh_frame",
+        lambda *args, **kwargs: refresh_calls.append(
+            kwargs.get("main_window", args[0] if args else None)
+        ),
+    )
+
+    assert list_view_actions.clear_all_embeddings(main_window) is False
+    assert list(main_window.merged_embeddings) == ["embed_1"]
+    assert target_face.assigned_merged_embeddings == {"embed_1": assigned_embedding}
+    assert refresh_calls == []
+
+
+def test_clear_all_embeddings_confirm_clears_state(monkeypatch):
+    target_face = _DummyTargetFace(merged_embeddings={"embed_1": object()})
+    embed_button = _DummyEmbedButton()
+    list_widget = _DummyListWidget()
+    main_window = SimpleNamespace(
+        merged_embeddings={"embed_1": embed_button},
+        target_faces={"target_1": target_face},
+        inputEmbeddingsList=list_widget,
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.Yes,
+    )
+    refresh_calls = []
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.card_actions.common_widget_actions.refresh_frame",
+        lambda *args, **kwargs: refresh_calls.append(
+            kwargs.get("main_window", args[0] if args else None)
+        ),
+    )
+
+    assert list_view_actions.clear_all_embeddings(main_window) is True
+    assert main_window.merged_embeddings == {}
+    assert target_face.assigned_merged_embeddings == {}
+    assert target_face.recalculated == 1
+    assert list_widget.cleared == 1
+    assert embed_button.deleted == 1
+    assert refresh_calls == [main_window]
+
+
+def test_clear_all_embeddings_blocked_leaves_state_unchanged(monkeypatch):
+    main_window = SimpleNamespace(
+        merged_embeddings={"embed_1": object()},
+        target_faces={},
+        inputEmbeddingsList=_DummyListWidget(),
+    )
+
+    monkeypatch.setattr(
+        "app.ui.widgets.actions.video_control_actions.block_if_issue_scan_active",
+        lambda *_args, **_kwargs: True,
+    )
+
+    assert list_view_actions.clear_all_embeddings(main_window) is False
+    assert list(main_window.merged_embeddings) == ["embed_1"]


### PR DESCRIPTION
**Summary**  
Adds non-destructive panel-wide clear actions for Target Media, Input Faces, and Embeddings. These are available from both item and empty-space context menus, use confirmation dialogs, and reset panel state without deleting source files.

**What changed**  
- Added **Clear All Media**, **Clear All Faces**, and **Clear All Embeddings** to both item and empty-space panel context menus  
- Added shared reset helpers in `list_view_actions.py` so all clear actions use the same code path  
- Cleared remembered path state for Target Media and Input Faces during full panel reset  
- Added focused unit tests for clear-all helper behavior  
- Updated stale issue-scan tests to match current forced-Auto similarity behavior  

**Behavior**  
- Clear actions are non-destructive and require confirmation  
- Clear actions are unavailable during protected scan and processing states  
- **Target Media** clear removes files and webcams, unloads preview state, clears target faces, and restores the placeholder  
- **Input Faces** clear removes faces, clears assignments, refreshes preview, and restores the placeholder  
- **Embeddings** clear removes embeddings and clears embedding assignments  

**Validation**  
- Manual UI testing passed for all three panels  
- Full test suite passes: **475 passed**  
- Pre-commit hooks pass clean  