### PR TITLE
Feat/confirm embedding save

### DIFF
--- a/app/ui/core/MainWindow.ui
+++ b/app/ui/core/MainWindow.ui
@@ -795,7 +795,7 @@
             <item>
              <widget class="QPushButton" name="saveEmbeddingButton">
               <property name="toolTip">
-               <string>Save Embedding</string>
+               <string>Save all embeddings to the current file</string>
               </property>
               <property name="text">
                <string/>

--- a/app/ui/core/main_window.py
+++ b/app/ui/core/main_window.py
@@ -1074,7 +1074,9 @@ class Ui_MainWindow(object):
         self.openEmbeddingButton.setText("")
         # if QT_CONFIG(tooltip)
         self.saveEmbeddingButton.setToolTip(
-            QCoreApplication.translate("MainWindow", "Save Embedding", None)
+            QCoreApplication.translate(
+                "MainWindow", "Save all embeddings to the current file", None
+            )
         )
         # endif // QT_CONFIG(tooltip)
         self.saveEmbeddingButton.setText("")

--- a/app/ui/widgets/actions/save_load_actions.py
+++ b/app/ui/widgets/actions/save_load_actions.py
@@ -257,6 +257,20 @@ def save_embeddings_to_file(main_window: "MainWindow", save_as=False):
         embedding_filename, _ = QtWidgets.QFileDialog.getSaveFileName(
             main_window, filter="JSON (*.json)"
         )
+    elif (
+        QtWidgets.QMessageBox.question(
+            main_window,
+            "Confirm Save",
+            (
+                "Save all embeddings to the current file?\n\n"
+                f"This will overwrite:\n{embedding_filename}"
+            ),
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+            QtWidgets.QMessageBox.No,
+        )
+        != QtWidgets.QMessageBox.Yes
+    ):
+        return
 
     # Build a list of dicts, each containing the embedding name, embedding_store, and kv_map path
     embeddings_list = []

--- a/tests/unit/ui/test_save_load_actions.py
+++ b/tests/unit/ui/test_save_load_actions.py
@@ -351,6 +351,178 @@ def test_embedding_preserves_shape():
     assert restored.shape == original.shape
 
 
+def _make_embedding_main_window(tmp_path: Path):
+    mw = SimpleNamespace()
+    mw.merged_embeddings = {}
+    mw.loaded_embedding_filename = ""
+    mw.project_root_path = tmp_path
+    return mw
+
+
+def _make_embedding_button(*, name="Embedding 1", kv_map=None):
+    return SimpleNamespace(
+        embedding_name=name,
+        embedding_store={"arcface": np.array([1.0, 2.0], dtype=np.float32)},
+        kv_map=kv_map,
+    )
+
+
+def test_save_embeddings_to_file_cancelled_confirmation_skips_writes(
+    tmp_path, monkeypatch
+):
+    target_file = tmp_path / "embeddings.json"
+    target_file.write_text("original")
+    main_window = _make_embedding_main_window(tmp_path)
+    main_window.loaded_embedding_filename = str(target_file)
+    main_window.merged_embeddings = {
+        "embed_1": _make_embedding_button(kv_map={"cache": "value"})
+    }
+
+    save_load_actions.common_widget_actions.create_and_show_toast_message.reset_mock()
+    save_load_actions.common_widget_actions.create_and_show_messagebox.reset_mock()
+
+    question_mock = MagicMock(return_value=0)
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QMessageBox",
+        SimpleNamespace(Yes=1, No=0, question=question_mock),
+    )
+    get_save_file_name = MagicMock(return_value=(str(tmp_path / "unused.json"), ""))
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QFileDialog",
+        SimpleNamespace(getSaveFileName=get_save_file_name),
+    )
+    torch_save = MagicMock()
+    monkeypatch.setattr(save_load_actions.torch, "save", torch_save)
+
+    save_load_actions.save_embeddings_to_file(main_window)
+
+    question_mock.assert_called_once()
+    get_save_file_name.assert_not_called()
+    torch_save.assert_not_called()
+    assert target_file.read_text() == "original"
+    assert main_window.loaded_embedding_filename == str(target_file)
+    save_load_actions.common_widget_actions.create_and_show_toast_message.assert_not_called()
+    save_load_actions.common_widget_actions.create_and_show_messagebox.assert_not_called()
+
+
+def test_save_embeddings_to_file_confirmed_confirmation_writes_file(
+    tmp_path, monkeypatch
+):
+    target_file = tmp_path / "embeddings.json"
+    target_file.write_text("original")
+    main_window = _make_embedding_main_window(tmp_path)
+    main_window.loaded_embedding_filename = str(target_file)
+    main_window.merged_embeddings = {"embed_1": _make_embedding_button()}
+
+    save_load_actions.common_widget_actions.create_and_show_toast_message.reset_mock()
+    save_load_actions.common_widget_actions.create_and_show_messagebox.reset_mock()
+
+    question_mock = MagicMock(return_value=1)
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QMessageBox",
+        SimpleNamespace(Yes=1, No=0, question=question_mock),
+    )
+    get_save_file_name = MagicMock(return_value=(str(tmp_path / "unused.json"), ""))
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QFileDialog",
+        SimpleNamespace(getSaveFileName=get_save_file_name),
+    )
+    torch_save = MagicMock()
+    monkeypatch.setattr(save_load_actions.torch, "save", torch_save)
+
+    save_load_actions.save_embeddings_to_file(main_window)
+
+    question_mock.assert_called_once()
+    get_save_file_name.assert_not_called()
+    torch_save.assert_not_called()
+    written = json.loads(target_file.read_text())
+    assert written == [
+        {
+            "name": "Embedding 1",
+            "embedding_store": {"arcface": [1.0, 2.0]},
+            "kv_map": None,
+        }
+    ]
+    assert main_window.loaded_embedding_filename == str(target_file)
+    save_load_actions.common_widget_actions.create_and_show_toast_message.assert_called_once()
+    save_load_actions.common_widget_actions.create_and_show_messagebox.assert_not_called()
+
+
+def test_save_embeddings_to_file_save_as_skips_confirmation(tmp_path, monkeypatch):
+    existing_file = tmp_path / "embeddings.json"
+    existing_file.write_text("original")
+    save_as_file = tmp_path / "save_as.json"
+    main_window = _make_embedding_main_window(tmp_path)
+    main_window.loaded_embedding_filename = str(existing_file)
+    main_window.merged_embeddings = {"embed_1": _make_embedding_button()}
+
+    save_load_actions.common_widget_actions.create_and_show_toast_message.reset_mock()
+    save_load_actions.common_widget_actions.create_and_show_messagebox.reset_mock()
+
+    question_mock = MagicMock(return_value=1)
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QMessageBox",
+        SimpleNamespace(Yes=1, No=0, question=question_mock),
+    )
+    get_save_file_name = MagicMock(return_value=(str(save_as_file), ""))
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QFileDialog",
+        SimpleNamespace(getSaveFileName=get_save_file_name),
+    )
+    torch_save = MagicMock()
+    monkeypatch.setattr(save_load_actions.torch, "save", torch_save)
+
+    save_load_actions.save_embeddings_to_file(main_window, save_as=True)
+
+    question_mock.assert_not_called()
+    get_save_file_name.assert_called_once()
+    assert json.loads(save_as_file.read_text()) == [
+        {
+            "name": "Embedding 1",
+            "embedding_store": {"arcface": [1.0, 2.0]},
+            "kv_map": None,
+        }
+    ]
+    assert main_window.loaded_embedding_filename == str(save_as_file)
+    save_load_actions.common_widget_actions.create_and_show_toast_message.assert_called_once()
+    save_load_actions.common_widget_actions.create_and_show_messagebox.assert_not_called()
+
+
+def test_save_embeddings_to_file_with_no_embeddings_shows_existing_messagebox(
+    tmp_path, monkeypatch
+):
+    main_window = _make_embedding_main_window(tmp_path)
+
+    save_load_actions.common_widget_actions.create_and_show_toast_message.reset_mock()
+    save_load_actions.common_widget_actions.create_and_show_messagebox.reset_mock()
+
+    question_mock = MagicMock(return_value=1)
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QMessageBox",
+        SimpleNamespace(Yes=1, No=0, question=question_mock),
+    )
+    get_save_file_name = MagicMock(return_value=(str(tmp_path / "unused.json"), ""))
+    monkeypatch.setattr(
+        save_load_actions.QtWidgets,
+        "QFileDialog",
+        SimpleNamespace(getSaveFileName=get_save_file_name),
+    )
+
+    save_load_actions.save_embeddings_to_file(main_window)
+
+    save_load_actions.common_widget_actions.create_and_show_messagebox.assert_called_once()
+    save_load_actions.common_widget_actions.create_and_show_toast_message.assert_not_called()
+    question_mock.assert_not_called()
+    get_save_file_name.assert_not_called()
+
+
 class _FakeGeometry:
     def __init__(self, x: int, y: int, width: int, height: int):
         self._x = x


### PR DESCRIPTION
## Summary
Adds a confirmation dialog before the standard embeddings save action overwrites the current file. This helps prevent accidental clicks on the toolbar save button and the matching **File -> Save Embeddings** action, while leaving **Save As** unchanged.

## What changed
- Added a confirmation prompt to the shared embeddings save handler used by both the toolbar save button and **File -> Save Embeddings**
- Only shows the prompt for a normal **Save** when a current embeddings file already exists
- Left **Save As** behavior unchanged
- Updated the save icon tooltip to clarify that it saves all embeddings to the current file
- Added focused unit tests for confirm/cancel, **Save As**, and empty-list behavior

## Validation
- Manual UI testing passed
- Pre-commit hooks pass clean
- Targeted save/load tests pass