### PR TITLE
Fix batch progress dialog stop-confirm race

### DIFF
--- a/app/ui/widgets/actions/video_control_actions.py
+++ b/app/ui/widgets/actions/video_control_actions.py
@@ -2860,7 +2860,7 @@ def process_batch_images(main_window: "MainWindow", process_all_faces: bool):
     finally:
         main_window.is_batch_processing = False
         # 8. Close the progress dialog
-        progress_dialog.close()
+        progress_dialog.close_without_confirmation()
 
         # 9. Show completion message
         if progress_dialog.confirmedCanceled():

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -1881,6 +1881,7 @@ class ProgressDialog(QtWidgets.QProgressDialog):
 
         self._confirmed_cancelled = False
         self._confirm_dialog_open = False
+        self._confirmation_disabled = False
 
         # Prevent Qt from auto-closing/resetting the dialog unexpectedly
         try:
@@ -1905,6 +1906,30 @@ class ProgressDialog(QtWidgets.QProgressDialog):
         """Return True only if the user confirmed stopping."""
         return self._confirmed_cancelled
 
+    def close_without_confirmation(self):
+        """
+        Close the dialog for normal teardown without treating it as a user cancel.
+        """
+        self._confirmation_disabled = True
+        blocker = None
+        try:
+            blocker = QtCore.QSignalBlocker(self)
+        except Exception:
+            blocker = None
+
+        try:
+            try:
+                self.reset()
+            except Exception:
+                pass
+
+            try:
+                self.close()
+            except Exception:
+                pass
+        finally:
+            del blocker
+
     def _on_canceled(self):
         """
         Qt has already marked the dialog as canceled and may hide it.
@@ -1912,6 +1937,8 @@ class ProgressDialog(QtWidgets.QProgressDialog):
         - confirm: keep _confirmed_cancelled=True (batch loop will stop)
         - decline: reset & re-show dialog, and keep _confirmed_cancelled=False (batch continues)
         """
+        if self._confirmation_disabled:
+            return
         if self._confirmed_cancelled:
             return
         if self._confirm_dialog_open:
@@ -1921,6 +1948,8 @@ class ProgressDialog(QtWidgets.QProgressDialog):
         QtCore.QTimer.singleShot(0, self._show_confirm_and_apply)
 
     def _show_confirm_and_apply(self):
+        if self._confirmation_disabled:
+            return
         if self._confirmed_cancelled:
             return
         if self._confirm_dialog_open:

--- a/tests/unit/ui/test_progress_dialog.py
+++ b/tests/unit/ui/test_progress_dialog.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6 import QtWidgets, QtCore
+
+
+def _stub(name: str) -> MagicMock:
+    module = MagicMock()
+    module.__name__ = name
+    module.__spec__ = None
+    return module
+
+
+@pytest.fixture(scope="module")
+def progress_dialog_module():
+    stubbed_modules = {
+        "send2trash": _stub("send2trash"),
+        "app.helpers": _stub("app.helpers"),
+        "app.ui.widgets.actions": _stub("app.ui.widgets.actions"),
+        "app.ui.widgets.actions.common_actions": _stub(
+            "app.ui.widgets.actions.common_actions"
+        ),
+        "app.ui.widgets.actions.video_control_actions": _stub(
+            "app.ui.widgets.actions.video_control_actions"
+        ),
+        "app.ui.widgets.actions.graphics_view_actions": _stub(
+            "app.ui.widgets.actions.graphics_view_actions"
+        ),
+        "app.ui.widgets.actions.card_actions": _stub(
+            "app.ui.widgets.actions.card_actions"
+        ),
+        "app.ui.widgets.actions.save_load_actions": _stub(
+            "app.ui.widgets.actions.save_load_actions"
+        ),
+        "app.helpers.miscellaneous": _stub("app.helpers.miscellaneous"),
+    }
+    stubbed_modules["send2trash"].send2trash = MagicMock()
+    stubbed_modules["app.helpers.miscellaneous"].get_video_rotation = MagicMock(
+        return_value=0
+    )
+
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in [*stubbed_modules, "app.ui.widgets.widget_components"]
+    }
+    saved_package_attrs: dict[tuple[str, str], tuple[bool, object | None]] = {}
+
+    for module_name in [*stubbed_modules, "app.ui.widgets.widget_components"]:
+        parent_name, _, attr_name = module_name.rpartition(".")
+        if not parent_name:
+            continue
+        parent_module = sys.modules.get(parent_name)
+        had_attr = parent_module is not None and hasattr(parent_module, attr_name)
+        saved_package_attrs[(parent_name, attr_name)] = (
+            had_attr,
+            getattr(parent_module, attr_name) if had_attr else None,
+        )
+
+    try:
+        for name, module in stubbed_modules.items():
+            sys.modules[name] = module
+
+        for module_name, module in stubbed_modules.items():
+            parent_name, _, attr_name = module_name.rpartition(".")
+            parent_module = sys.modules.get(parent_name)
+            if parent_module is not None and attr_name:
+                setattr(parent_module, attr_name, module)
+
+        sys.modules.pop("app.ui.widgets.widget_components", None)
+        module = importlib.import_module("app.ui.widgets.widget_components")
+        yield module
+    finally:
+        for name, original_module in saved_modules.items():
+            if original_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original_module
+
+        for (parent_name, attr_name), (
+            had_attr,
+            original_value,
+        ) in saved_package_attrs.items():
+            parent_module = sys.modules.get(parent_name)
+            if parent_module is None:
+                continue
+            if had_attr:
+                setattr(parent_module, attr_name, original_value)
+            elif hasattr(parent_module, attr_name):
+                delattr(parent_module, attr_name)
+
+
+@pytest.fixture
+def qapp():
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+class _FakePromptBox:
+    Warning = QtWidgets.QMessageBox.Warning
+    Yes = QtWidgets.QMessageBox.Yes
+    No = QtWidgets.QMessageBox.No
+    next_result = Yes
+    instances: list["_FakePromptBox"] = []
+
+    def __init__(self, _parent=None):
+        self.window_title = None
+        self.text = None
+        self.informative_text = None
+        _FakePromptBox.instances.append(self)
+
+    def setIcon(self, _icon):
+        return None
+
+    def setWindowTitle(self, value):
+        self.window_title = value
+
+    def setText(self, value):
+        self.text = value
+
+    def setInformativeText(self, value):
+        self.informative_text = value
+
+    def setStandardButtons(self, _buttons):
+        return None
+
+    def setDefaultButton(self, _button):
+        return None
+
+    def setWindowFlag(self, *_args):
+        return None
+
+    def exec(self):
+        return _FakePromptBox.next_result
+
+
+def _flush_qt_events(app):
+    app.processEvents()
+    QtCore.QCoreApplication.sendPostedEvents(None, 0)
+    app.processEvents()
+
+
+@pytest.mark.qt
+def test_progress_dialog_close_without_confirmation_skips_prompt(
+    monkeypatch, progress_dialog_module, qapp
+):
+    _FakePromptBox.instances = []
+    monkeypatch.setattr(progress_dialog_module.QtWidgets, "QMessageBox", _FakePromptBox)
+
+    dialog = progress_dialog_module.ProgressDialog("Working", "Cancel", 0, 1)
+    dialog.show()
+    _flush_qt_events(qapp)
+
+    dialog.close_without_confirmation()
+    _flush_qt_events(qapp)
+
+    assert _FakePromptBox.instances == []
+    assert dialog.confirmedCanceled() is False
+    assert dialog.isVisible() is False
+
+
+@pytest.mark.qt
+def test_progress_dialog_queued_cancel_is_ignored_after_programmatic_close(
+    monkeypatch, progress_dialog_module, qapp
+):
+    _FakePromptBox.instances = []
+    monkeypatch.setattr(progress_dialog_module.QtWidgets, "QMessageBox", _FakePromptBox)
+
+    dialog = progress_dialog_module.ProgressDialog("Working", "Cancel", 0, 1)
+    dialog.show()
+    _flush_qt_events(qapp)
+
+    dialog.canceled.emit()
+    dialog.close_without_confirmation()
+    _flush_qt_events(qapp)
+
+    assert _FakePromptBox.instances == []
+    assert dialog.confirmedCanceled() is False
+    assert dialog.isVisible() is False
+
+
+@pytest.mark.qt
+def test_progress_dialog_cancel_confirm_yes_marks_confirmed_cancel(
+    monkeypatch, progress_dialog_module, qapp
+):
+    _FakePromptBox.instances = []
+    _FakePromptBox.next_result = _FakePromptBox.Yes
+    monkeypatch.setattr(progress_dialog_module.QtWidgets, "QMessageBox", _FakePromptBox)
+
+    dialog = progress_dialog_module.ProgressDialog("Working", "Cancel", 0, 1)
+    dialog.show()
+    _flush_qt_events(qapp)
+
+    dialog.canceled.emit()
+    _flush_qt_events(qapp)
+
+    assert len(_FakePromptBox.instances) == 1
+    prompt = _FakePromptBox.instances[0]
+    assert prompt.window_title == "Confirm stop"
+    assert prompt.text == "Stop the current task?"
+    assert (
+        prompt.informative_text
+        == "Processing will stop immediately.\nOutputs may be incomplete."
+    )
+    assert dialog.confirmedCanceled() is True
+
+
+@pytest.mark.qt
+def test_progress_dialog_cancel_confirm_no_restores_dialog(
+    monkeypatch, progress_dialog_module, qapp
+):
+    _FakePromptBox.instances = []
+    _FakePromptBox.next_result = _FakePromptBox.No
+    monkeypatch.setattr(progress_dialog_module.QtWidgets, "QMessageBox", _FakePromptBox)
+
+    dialog = progress_dialog_module.ProgressDialog("Working", "Cancel", 0, 3)
+    dialog.setValue(1)
+    dialog.show()
+    _flush_qt_events(qapp)
+
+    dialog.canceled.emit()
+    _flush_qt_events(qapp)
+
+    assert len(_FakePromptBox.instances) == 1
+    assert dialog.confirmedCanceled() is False
+    assert dialog.isVisible() is True

--- a/tests/unit/ui/test_video_control_actions.py
+++ b/tests/unit/ui/test_video_control_actions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import sys
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -102,6 +103,7 @@ def video_actions_env():
             view_fullscreen=video_control_actions.view_fullscreen,
             toggle_theatre_mode=video_control_actions.toggle_theatre_mode,
             record_video=video_control_actions.record_video,
+            process_batch_images=video_control_actions.process_batch_images,
             disable_compare_preview_modes_for_recording=(
                 video_control_actions._disable_compare_preview_modes_for_recording
             ),
@@ -1073,3 +1075,424 @@ def test_record_video_finalizes_segment_recording_after_confirmation(
     assert len(_FakePromptBox.instances) == 1
     main_window.video_processor.finalize_segment_concatenation.assert_called_once()
     main_window.video_processor._finalize_default_style_recording.assert_not_called()
+
+
+class _FakeBatchFrame:
+    size = 1
+
+    def __getitem__(self, _key):
+        return self
+
+
+class _FakeBatchInputFace:
+    def __init__(self, face_id: str = "face_1", checked: bool = True):
+        self.face_id = face_id
+        self.embedding_store = {"embedding": face_id}
+        self._checked = checked
+
+    def isChecked(self):
+        return self._checked
+
+
+class _FakeBatchTargetFace:
+    def __init__(self, face_id: str = "target_1"):
+        self.face_id = face_id
+        self.assigned_input_faces: dict[str, Any] = {}
+        self.assigned_merged_embeddings: dict[str, Any] = {}
+        self.calculate_assigned_input_embedding = MagicMock()
+
+
+class _FakeBatchMediaWidget:
+    def __init__(self, file_type: str, media_path: str):
+        self.file_type = file_type
+        self.media_path = media_path
+
+
+class _FakeBatchList:
+    def __init__(self, widgets):
+        self._widgets = list(widgets)
+
+    def count(self):
+        return len(self._widgets)
+
+    def item(self, index):
+        return index
+
+    def itemWidget(self, item):
+        return self._widgets[item]
+
+
+class _FakeOutputLineEdit:
+    def __init__(self, value: str):
+        self._value = value
+
+    def text(self):
+        return self._value
+
+
+class _FakeSlider:
+    def __init__(self):
+        self.maximum = None
+        self.value_set = None
+        self.block_calls = []
+
+    def setMaximum(self, value):
+        self.maximum = value
+
+    def blockSignals(self, value):
+        self.block_calls.append(value)
+
+    def setValue(self, value):
+        self.value_set = value
+
+    def value(self):
+        return 0
+
+
+class _FakeCapture:
+    def __init__(self):
+        self.opened = True
+
+    def isOpened(self):
+        return self.opened
+
+    def get(self, prop):
+        if prop == "frame_count":
+            return 10
+        if prop == "fps":
+            return 24
+        return 0
+
+    def set(self, *_args):
+        return True
+
+
+class _FakeProgressDialog:
+    instances: list["_FakeProgressDialog"] = []
+    confirmed_sequence = [False]
+
+    def __init__(self, *_args, **_kwargs):
+        self.value_calls = []
+        self.labels = []
+        self.closed_without_confirmation = 0
+        self.shown = 0
+        self._confirmed_calls = 0
+        _FakeProgressDialog.instances.append(self)
+
+    def setWindowModality(self, *_args):
+        return None
+
+    def setWindowTitle(self, *_args):
+        return None
+
+    def setValue(self, value):
+        self.value_calls.append(value)
+
+    def show(self):
+        self.shown += 1
+
+    def setLabelText(self, value):
+        self.labels.append(value)
+
+    def confirmedCanceled(self):
+        index = min(self._confirmed_calls, len(self.confirmed_sequence) - 1)
+        self._confirmed_calls += 1
+        return self.confirmed_sequence[index]
+
+    def close_without_confirmation(self):
+        self.closed_without_confirmation += 1
+
+
+def _make_batch_main_window(*widgets):
+    frame = _FakeBatchFrame()
+    video_processor = SimpleNamespace(
+        media_path=None,
+        file_type=None,
+        current_frame_number=0,
+        media_capture=None,
+        current_frame=frame,
+        max_frame_number=0,
+        fps=0,
+        processing=False,
+        is_processing_segments=False,
+        process_current_frame=MagicMock(side_effect=lambda synchronous=True: None),
+        stop_processing=MagicMock(side_effect=lambda: None),
+    )
+    return SimpleNamespace(
+        outputFolderLineEdit=_FakeOutputLineEdit("E:/output"),
+        targetVideosList=_FakeBatchList(widgets),
+        current_widget_parameters={"Strength": 50},
+        input_faces={"face_1": _FakeBatchInputFace()},
+        merged_embeddings={},
+        target_faces={"original_face": object()},
+        parameters={},
+        control={
+            "ImageFormatToggle": False,
+            "OutputMediaFolder": "E:/output",
+            "OutputToTargetLocationToggle": False,
+            "ClusterOutputBySourceToggle": False,
+        },
+        video_processor=video_processor,
+        videoSeekSlider=_FakeSlider(),
+        scene=SimpleNamespace(clear=MagicMock()),
+        is_batch_processing=False,
+    )
+
+
+def test_process_batch_images_all_faces_uses_non_confirming_close(
+    monkeypatch, video_actions_env
+):
+    _FakeProgressDialog.instances = []
+    _FakeProgressDialog.confirmed_sequence = [False]
+    main_window = _make_batch_main_window(
+        _FakeBatchMediaWidget("image", "E:/media/image_1.png")
+    )
+
+    monkeypatch.setattr(
+        video_actions_env.module.widget_components,
+        "ProgressDialog",
+        _FakeProgressDialog,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.numpy,
+        "ndarray",
+        _FakeBatchFrame,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: video_actions_env.module.QtWidgets.QMessageBox.Yes,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.os, "makedirs", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "read_image_file",
+        lambda *_args, **_kwargs: _FakeBatchFrame(),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "get_output_file_path",
+        lambda *_args, **_kwargs: "E:/output/image_1.png",
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.card_actions,
+        "clear_target_faces",
+        lambda mw, refresh_frame=False: mw.target_faces.clear(),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.card_actions,
+        "find_target_faces",
+        lambda mw: mw.target_faces.update({"target_1": _FakeBatchTargetFace()}),
+    )
+
+    video_actions_env.process_batch_images(main_window, process_all_faces=True)
+
+    progress_dialog = _FakeProgressDialog.instances[0]
+    assert progress_dialog.closed_without_confirmation == 1
+    video_actions_env.common_widget_actions.create_and_show_messagebox.assert_called()
+    message = (
+        video_actions_env.common_widget_actions.create_and_show_messagebox.call_args[0][
+            2
+        ]
+    )
+    assert "Batch processing complete." in message
+    assert "Successfully processed: 1" in message
+
+
+def test_process_batch_images_mixed_batch_uses_non_confirming_close(
+    monkeypatch, video_actions_env
+):
+    _FakeProgressDialog.instances = []
+    _FakeProgressDialog.confirmed_sequence = [False]
+    main_window = _make_batch_main_window(
+        _FakeBatchMediaWidget("image", "E:/media/image_1.png"),
+        _FakeBatchMediaWidget("video", "E:/media/video_1.mp4"),
+    )
+
+    monkeypatch.setattr(
+        video_actions_env.module.widget_components,
+        "ProgressDialog",
+        _FakeProgressDialog,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.numpy,
+        "ndarray",
+        _FakeBatchFrame,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: video_actions_env.module.QtWidgets.QMessageBox.Yes,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.os, "makedirs", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "read_image_file",
+        lambda *_args, **_kwargs: _FakeBatchFrame(),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "get_output_file_path",
+        lambda *_args, **_kwargs: "E:/output/image_1.png",
+    )
+    monkeypatch.setattr(
+        video_actions_env.module, "get_video_rotation", lambda *_args: 0
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "VideoCapture",
+        lambda *_args, **_kwargs: _FakeCapture(),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "CAP_PROP_ORIENTATION_AUTO",
+        "orientation_auto",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "CAP_PROP_FRAME_COUNT",
+        "frame_count",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "CAP_PROP_FPS",
+        "fps",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "read_frame",
+        lambda *_args, **_kwargs: (True, _FakeBatchFrame()),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "seek_frame",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "release_capture",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module,
+        "record_video",
+        lambda mw, _checked: setattr(mw.video_processor, "processing", False),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.QtCore.QThread, "msleep", lambda *_args: None
+    )
+
+    video_actions_env.process_batch_images(main_window, process_all_faces=False)
+
+    progress_dialog = _FakeProgressDialog.instances[0]
+    assert progress_dialog.closed_without_confirmation == 1
+    message = (
+        video_actions_env.common_widget_actions.create_and_show_messagebox.call_args[0][
+            2
+        ]
+    )
+    assert "Successfully processed: 2" in message
+
+
+def test_process_batch_images_cancelled_video_is_not_counted_completed(
+    monkeypatch, video_actions_env
+):
+    _FakeProgressDialog.instances = []
+    _FakeProgressDialog.confirmed_sequence = [False, True, True]
+    main_window = _make_batch_main_window(
+        _FakeBatchMediaWidget("video", "E:/media/video_1.mp4")
+    )
+
+    def _stop_processing():
+        main_window.video_processor.processing = False
+
+    main_window.video_processor.stop_processing = MagicMock(
+        side_effect=_stop_processing
+    )
+
+    monkeypatch.setattr(
+        video_actions_env.module.widget_components,
+        "ProgressDialog",
+        _FakeProgressDialog,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.numpy,
+        "ndarray",
+        _FakeBatchFrame,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: video_actions_env.module.QtWidgets.QMessageBox.Yes,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module, "get_video_rotation", lambda *_args: 0
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "VideoCapture",
+        lambda *_args, **_kwargs: _FakeCapture(),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "CAP_PROP_ORIENTATION_AUTO",
+        "orientation_auto",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "CAP_PROP_FRAME_COUNT",
+        "frame_count",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.cv2,
+        "CAP_PROP_FPS",
+        "fps",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "read_frame",
+        lambda *_args, **_kwargs: (True, _FakeBatchFrame()),
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "seek_frame",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        video_actions_env.module.misc_helpers,
+        "release_capture",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def _record_video(mw, _checked):
+        mw.video_processor.processing = True
+        mw.video_processor.is_processing_segments = False
+
+    monkeypatch.setattr(video_actions_env.module, "record_video", _record_video)
+    monkeypatch.setattr(
+        video_actions_env.module.QtCore.QThread, "msleep", lambda *_args: None
+    )
+
+    video_actions_env.process_batch_images(main_window, process_all_faces=False)
+
+    main_window.video_processor.stop_processing.assert_called_once()
+    message = (
+        video_actions_env.common_widget_actions.create_and_show_messagebox.call_args[0][
+            2
+        ]
+    )
+    assert "Batch processing cancelled." in message
+    assert "Processed: 0" in message


### PR DESCRIPTION
Fixes a batch-processing UI bug where the stop confirmation dialog could incorrectly appear during normal batch completion.

The issue was caused by the custom `ProgressDialog` treating an internal programmatic close during teardown the same as a user cancel. This change adds a dedicated non-confirming close path and prevents queued cancel confirmation callbacks from firing once shutdown has started.

## Changes
- Added `ProgressDialog.close_without_confirmation()` for internal teardown
- Updated batch processing to use the non-confirming close path
- Made confirmation suppression persist for the remaining dialog lifetime once teardown begins
- Guarded both direct cancel handling and already-queued `_show_confirm_and_apply()` callbacks

## Validation
- `pre-commit run --all-files`
- `pytest -q` in `.venv`