### PR TITLE
fixes

### DIFF
--- a/Start.bat
+++ b/Start.bat
@@ -11,3 +11,13 @@ IF EXIST ".venv" (
 REM Run main.py
 echo Running VisoMaster...
 python main.py
+SET EXIT_CODE=%ERRORLEVEL%
+
+REM Keep the console open after a crash so users can read the error output.
+REM Exit code 0 = clean exit (user closed the window normally).
+IF %EXIT_CODE% NEQ 0 (
+    echo.
+    echo [ERROR] VisoMaster exited with code %EXIT_CODE%.
+    echo         Review the output above for details, then press any key to close.
+    pause >nul
+)

--- a/app/helpers/vr_utils.py
+++ b/app/helpers/vr_utils.py
@@ -28,6 +28,16 @@ _FEATHERED_MASK_CACHE_MAX = 8
 _FEATHERED_MASK_CACHE_LOCK = threading.Lock()
 
 
+def clear_feathered_mask_cache() -> None:
+    """Release all cached feathered VR stitch masks.
+
+    Called by VideoProcessor.join_and_clear_threads() between jobs to prevent
+    CPU RAM accumulation from large equirect-resolution float tensors.
+    """
+    with _FEATHERED_MASK_CACHE_LOCK:
+        _FEATHERED_MASK_CACHE.clear()
+
+
 # Define Sobel kernels once at the module level
 _SOBEL_X_KERNEL = torch.tensor(
     [[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]], dtype=torch.float32

--- a/app/processors/external/Equirec2Perspec_vr.py
+++ b/app/processors/external/Equirec2Perspec_vr.py
@@ -15,6 +15,35 @@ _PERSP_GRID_CACHE_MAX = 16
 _PERSP_GRID_CACHE_LOCK = threading.Lock()
 
 
+def clear_persp_grid_cache() -> None:
+    """Release all cached perspective sampling grids (CPU tensors only).
+
+    Cheap to clear and rebuild — the meshgrid generation is fast.
+    """
+    with _PERSP_GRID_CACHE_LOCK:
+        _PERSP_GRID_CACHE.clear()
+
+
+def clear_rotation_matrix_cache() -> None:
+    """Release all cached rotation matrices (GPU tensors).
+
+    Heavier to rebuild than the perspective grids because each entry triggers
+    cv2.Rodrigues + numpy → GPU transfers, but holds device memory across jobs.
+    """
+    _get_e2p_rotation_matrices_cached.cache_clear()
+
+
+def clear_persp_cache() -> None:
+    """Backwards-compatible umbrella: clear both grid and rotation caches.
+
+    Called by VideoProcessor.join_and_clear_threads() between jobs to prevent
+    accumulation across multiple recording sessions. Callers that only need
+    to drop one cache should use the dedicated clear_*_cache helpers.
+    """
+    clear_persp_grid_cache()
+    clear_rotation_matrix_cache()
+
+
 # E2P-CACHE-02: rotation matrix cache — same pattern as P2E's _get_rotation_matrices_cached.
 # Avoids 2× cv2.Rodrigues + 2× numpy→GPU transfers on EVERY GetPerspective call.
 # With 24 tiles × multiple faces, this was 48+ redundant Rodrigues calls per detection frame.

--- a/app/processors/external/yolox/tracker/byte_tracker.py
+++ b/app/processors/external/yolox/tracker/byte_tracker.py
@@ -140,7 +140,18 @@ class BYTETracker(object):
     def __init__(self, args, frame_rate=30):
         self.tracked_stracks = []  # type: list[STrack]
         self.lost_stracks = []  # type: list[STrack]
-        self.removed_stracks = []  # type: list[STrack]
+        # MEM-FIX: Previously `removed_stracks` was a list of STrack objects
+        # appended unboundedly across the lifetime of the tracker — every track
+        # that ended (occlusion, scene cut, end-of-life) added another ~1 KB
+        # STrack instance that was never pruned. For long videos with crowd
+        # scenes this grew into many MB of dead Python objects, contributing to
+        # the user-reported "rendering slows to a crawl after a while" symptom.
+        #
+        # The list is only consumed internally to filter `lost_stracks` against
+        # already-removed track IDs; only `track.track_id` is ever accessed from
+        # the items. We therefore retain just the integer track IDs in a set,
+        # which is O(1) for membership testing and orders of magnitude smaller.
+        self._removed_track_ids: set = set()
 
         self.frame_id = 0
         self.args = args
@@ -149,6 +160,15 @@ class BYTETracker(object):
         self.buffer_size = int(frame_rate / 30.0 * args.track_buffer)
         self.max_time_lost = self.buffer_size
         self.kalman_filter = KalmanFilter()
+
+    @property
+    def removed_stracks(self):
+        """Backwards-compat shim for any external code that reads this attribute.
+
+        Returns an empty list — the full STrack objects are no longer retained.
+        Internal lookups go through `_removed_track_ids` instead.
+        """
+        return []
 
     def update(self, output_results, img_info, img_size):
         self.frame_id += 1
@@ -276,8 +296,15 @@ class BYTETracker(object):
         self.tracked_stracks = joint_stracks(self.tracked_stracks, refind_stracks)
         self.lost_stracks = sub_stracks(self.lost_stracks, self.tracked_stracks)
         self.lost_stracks.extend(lost_stracks)
-        self.lost_stracks = sub_stracks(self.lost_stracks, self.removed_stracks)
-        self.removed_stracks.extend(removed_stracks)
+        # MEM-FIX: Use the integer-id set instead of a list of STrack objects.
+        # The previous code retained every removed STrack forever; we only need
+        # to know which IDs are dead so they can be excluded from lost_stracks.
+        self.lost_stracks = [
+            t for t in self.lost_stracks
+            if t.track_id not in self._removed_track_ids
+        ]
+        for _t in removed_stracks:
+            self._removed_track_ids.add(_t.track_id)
         self.tracked_stracks, self.lost_stracks = remove_duplicate_stracks(self.tracked_stracks, self.lost_stracks)
         # get scores of lost tracks
         output_stracks = [track for track in self.tracked_stracks if track.is_activated]

--- a/app/processors/face_landmark_detectors.py
+++ b/app/processors/face_landmark_detectors.py
@@ -13,6 +13,44 @@ from app.processors.models_data import models_dir
 from app.processors.utils import faceutil
 
 
+def _kps5_is_degenerate(kps5) -> bool:
+    """Return True when the 5 keypoints are too collinear to define a stable
+    affine warp.
+
+    With ``from_points=True``, landmark detectors warp the source crop using a
+    5-point similarity transform (``warp_face_by_face_landmark_5``). For full
+    profile / extreme-yaw faces the 5 points (left eye, right eye, nose, two
+    mouth corners) are nearly collinear or have an occluded eye reflected onto
+    the visible side. The resulting warp is degenerate — landmarks come back
+    in wildly wrong positions ("eye sideways, mouth near the ear" symptom).
+
+    Detection: if the height of the triangle (left_eye, right_eye, nose),
+    measured as area÷base, is small relative to the eye-distance (< 10%),
+    treat as degenerate. The caller should fall back to the bbox-based warp
+    path (``from_points=False``).
+
+    Returns True when ``kps5`` is None, has fewer than 5 points, or is
+    geometrically degenerate.
+    """
+    if kps5 is None:
+        return True
+    try:
+        kps5 = np.asarray(kps5, dtype=np.float32)
+    except (ValueError, TypeError):
+        return True
+    if kps5.ndim != 2 or kps5.shape[0] < 5:
+        return True
+    le, re, nose = kps5[0], kps5[1], kps5[2]
+    eye_vec = re - le
+    eye_dist = float(np.linalg.norm(eye_vec))
+    if eye_dist < 1e-3:
+        return True  # both eyes coincide — definitely degenerate
+    # 2× area of triangle (LE, RE, nose) via cross product magnitude
+    cross = abs(eye_vec[0] * (nose[1] - le[1]) - eye_vec[1] * (nose[0] - le[0]))
+    triangle_h = cross / eye_dist  # perpendicular nose-to-eye-line distance
+    return (triangle_h / eye_dist) < 0.10
+
+
 class FaceLandmarkDetectors:
     """
     Manages and executes various face landmark detection models.
@@ -142,9 +180,24 @@ class FaceLandmarkDetectors:
         if detect_mode == "5":
             self._ensure_landmark_5_anchors()
 
+        # FLD-DEGENERATE-1: For extreme-yaw faces (full side angle), the 5-point
+        # similarity transform used by `from_points=True` collapses to a
+        # near-singular matrix and produces wildly wrong landmarks ("eye sideways,
+        # mouth near the ear" symptom from user reports). Detect the degenerate
+        # geometry and force the bbox-based warp path instead — it is less
+        # accurate on aligned faces but produces sane output for side angles
+        # where the keypoint-based warp simply cannot work.
+        effective_from_points = from_points
+        if from_points and _kps5_is_degenerate(det_kpss):
+            effective_from_points = False
+
         # Call the specific detection function with kwargs
         kpss_5, kpss, scores = detection_function(
-            img, bbox=bbox, det_kpss=det_kpss, from_points=from_points, **kwargs
+            img,
+            bbox=bbox,
+            det_kpss=det_kpss,
+            from_points=effective_from_points,
+            **kwargs,
         )
 
         # --- Filtering Logic ---

--- a/app/processors/models_processor.py
+++ b/app/processors/models_processor.py
@@ -10,7 +10,25 @@ from typing import Dict, TYPE_CHECKING, Optional
 from PIL import Image
 from packaging import version
 import numpy as np
-import onnxruntime
+
+try:
+    import onnxruntime
+except ImportError as _ort_err:
+    print("\n" + "=" * 70)
+    print("[FATAL] onnxruntime failed to import.")
+    print(f"  Error: {_ort_err}")
+    print()
+    print("  COMMON FIXES:")
+    print("  1. Install Visual C++ Redistributable 2019 (x64) from Microsoft.")
+    print("     Download: https://aka.ms/vs/17/release/vc_redist.x64.exe")
+    print("  2. Ensure CUDA 12.x runtime DLLs are present (cudart64_12.dll etc.).")
+    print(
+        "     Install CUDA Toolkit 12.x from https://developer.nvidia.com/cuda-downloads"
+    )
+    print("  3. On Windows 10 older than 1903: update Windows or install KB4571756.")
+    print("  4. Portable install: run 'Check / Update Dependencies' in the Launcher.")
+    print("=" * 70 + "\n")
+    raise
 import torch
 import onnx
 from torchvision.transforms import v2

--- a/app/processors/mouth_openness.py
+++ b/app/processors/mouth_openness.py
@@ -77,8 +77,21 @@ class MouthOpennessState:
         ratio: float | None,
         alpha: float,
         threshold: float,
+        *,
+        single_frame_mode: bool = False,
     ) -> tuple[bool, float]:
         """Update EMA and activation state.
+
+        Args:
+            ratio: New lip-open ratio, or None when no detection succeeded.
+            alpha: EMA blending factor (0.0–1.0).
+            threshold: Activation threshold for the lip-open ratio.
+            single_frame_mode: When True, the caller is the FrameWorker servicing
+                a stopped-frame preview (not playback). In that mode every
+                `_apply_auto_mouth` call evaluates the *same* underlying frame, so
+                None-ratios from a transiently bad detection should NOT accumulate
+                an occlusion penalty — otherwise toggling settings on a stopped
+                frame would slowly decay the EMA past the deactivate threshold.
 
         Returns:
             (active, ema) — current activation flag and smoothed EMA value.
@@ -88,7 +101,11 @@ class MouthOpennessState:
 
         with self._lock:
             if ratio is None:
-                # Rule 2: stay; manage occlusion timeout
+                # Rule 2: stay; manage occlusion timeout (playback only).
+                # In single-frame mode we never accrue the penalty: there is no
+                # "missed frame" — the user is just toggling settings.
+                if single_frame_mode:
+                    return self.active, self.ema
                 if self.active:
                     self.none_streak += 1
                     if self.none_streak > OCCLUSION_TIMEOUT_FRAMES:

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -168,6 +168,10 @@ class VideoProcessor(QObject):
         # --- Sequential Detection State ---
         # Initialize the decoupled detector state manager
         self.sequential_detector = SequentialDetector(self.main_window)
+        # Transition flags: reset tracker only when target-face presence changes,
+        # not on every frame — prevents ByteTrack reinitialization per frame (webcam FPS fix).
+        self._video_had_targets: bool = False
+        self._webcam_had_targets: bool = False
 
         # --- Processing State Flags ---
         self.processing = False  # MASTER flag: True if playback, recording, or webcam stream is active
@@ -851,6 +855,7 @@ class VideoProcessor(QObject):
 
                 if len(self.main_window.target_faces) > 0:
                     # If Faces present run detect
+                    self._video_had_targets = True
                     is_master_edit_active = self.main_window.editFacesButton.isChecked()
                     bboxes, kpss_5, kpss, kpss_203 = self.sequential_detector.run(
                         frame_rgb=frame_rgb,
@@ -866,8 +871,12 @@ class VideoProcessor(QObject):
                     kpss = numpy.empty((0, 68, 2), dtype=numpy.float32)
                     kpss_203 = numpy.empty((0, 203, 2), dtype=numpy.float32)
 
-                    # Reset the arrays for clean retargeting via the new manager
-                    self.sequential_detector.reset_state()
+                    # Reset tracker only on the transition from "had targets" → "no targets".
+                    # Calling reset_state() on every frame reinitialised ByteTrack continuously,
+                    # wasting CPU and preventing stable tracking when faces reappeared.
+                    if self._video_had_targets:
+                        self.sequential_detector.reset_state()
+                        self._video_had_targets = False
 
                 # The worker will use the feeder's state *from this exact moment*
                 task = (
@@ -943,6 +952,7 @@ class VideoProcessor(QObject):
 
                 # --- Inject Sequential Detection ---
                 if len(self.main_window.target_faces) > 0:
+                    self._webcam_had_targets = True
                     is_master_edit_active = self.main_window.editFacesButton.isChecked()
                     bboxes, kpss_5, kpss, kpss_203 = self.sequential_detector.run(
                         frame_rgb=frame_rgb,
@@ -958,8 +968,13 @@ class VideoProcessor(QObject):
                     kpss = numpy.empty((0, 68, 2), dtype=numpy.float32)
                     kpss_203 = numpy.empty((0, 203, 2), dtype=numpy.float32)
 
-                    # Reset tracking state securely
-                    self.sequential_detector.reset_state()
+                    # Reset tracker only on the transition from "had targets" → "no targets".
+                    # Resetting ByteTrack on every frame without targets was causing webcam FPS
+                    # degradation by reinitialising the tracker's internal state structures
+                    # on every captured frame.
+                    if self._webcam_had_targets:
+                        self.sequential_detector.reset_state()
+                        self._webcam_had_targets = False
 
                 # Create the 8-tuple task
                 task = (
@@ -1371,8 +1386,12 @@ class VideoProcessor(QObject):
 
         # 6b. START WORKER POOL
         print(f"[INFO] Starting {self.num_threads} persistent worker thread(s)...")
-        # Ensure old workers are cleared (from a previous run)
-        self.join_and_clear_threads()
+        # Ensure old workers are cleared (from a previous run).
+        # Pass clear_module_caches=False so the warm VR caches (perspective grids,
+        # rotation matrices, feathered masks) survive the pool restart — they are
+        # geometric data independent of the previous job and rebuilding them on the
+        # first new frame is wasted work.
+        self.join_and_clear_threads(clear_module_caches=False)
         self.worker_threads = []
         # Clear any stale tasks or poison pills left from the previous session.
         # join_and_clear_threads() returns early when worker_threads is empty,
@@ -2047,11 +2066,18 @@ class VideoProcessor(QObject):
 
         return True  # Processing was stopped
 
-    def join_and_clear_threads(self):
+    def join_and_clear_threads(self, clear_module_caches: bool = True):
         """
         Stops and waits for all pool worker threads to finish.
         This function's *only* job is to set events, send pills, and join.
         It does NOT clear the queue.
+
+        Args:
+            clear_module_caches: When True (default — used at job stop), also clear
+                module-level VR caches (perspective grids, rotation matrices,
+                feathered masks). Pass False at job *start* (`process_video()` calls
+                this before launching a new pool) so the warm caches built up by
+                previous workers survive the pool restart.
         """
         active_threads = self.worker_threads
         if not active_threads:
@@ -2105,6 +2131,40 @@ class VideoProcessor(QObject):
         _gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+
+        # 6. Release module-level VR caches that hold CPU/GPU tensors across jobs.
+        #    Without this, equirect perspective grids and feathered stitch masks
+        #    accumulate in RAM across multiple recording sessions (memory leak).
+        #    Skipped when called from process_video() at session start, so the warm
+        #    caches built up by the previous pool survive the worker-pool restart.
+        if clear_module_caches:
+            try:
+                from app.processors.external.Equirec2Perspec_vr import clear_persp_cache
+                from app.helpers.vr_utils import clear_feathered_mask_cache
+
+                clear_persp_cache()
+                clear_feathered_mask_cache()
+            except Exception:
+                pass  # Non-fatal — VR caches simply persist until next GC cycle
+
+    def _log_hevc_thumbnail_hint_once(self) -> None:
+        """Print a one-time hint about HEVC thumbnail rendering on Windows 10.
+
+        Default recording codec is HEVC (hevc_nvenc / libx265). Windows 10 does
+        not generate File Explorer thumbnails for HEVC files unless the user
+        installs the "HEVC Video Extensions" package from the Microsoft Store.
+        This hint surfaces the workaround so users don't think VisoMaster broke
+        their thumbnails.
+        """
+        if getattr(self, "_hevc_hint_logged", False):
+            return
+        self._hevc_hint_logged = True
+        if os.name == "nt":
+            print(
+                "[INFO] Recording finished as HEVC (H.265). "
+                "Windows Explorer thumbnails for HEVC require the "
+                "'HEVC Video Extensions' from the Microsoft Store."
+            )
 
     def _reopen_video_capture(self, seek_frame: int = 0) -> bool:
         """
@@ -4142,6 +4202,11 @@ class VideoProcessor(QObject):
                         f"[ERROR] Error waiting for FFmpeg subprocess during finalization: {e}"
                     )
                 self.recording_sp = None
+                # VP-HEVC-INFO: Notify the user about Windows Explorer thumbnail
+                # support for HEVC outputs. Default codec is hevc_nvenc / libx265,
+                # both produce H.265 streams that Windows 10 does NOT thumbnail
+                # natively without the "HEVC Video Extensions" Store package.
+                self._log_hevc_thumbnail_hint_once()
 
             # 7. Calculate audio segment times
             end_frame_for_calc = min(

--- a/app/processors/video_utils/sequential_detector.py
+++ b/app/processors/video_utils/sequential_detector.py
@@ -1,5 +1,3 @@
-import contextlib
-import copy
 from typing import Dict, List, Any, Optional, Tuple, cast
 from collections.abc import Mapping
 
@@ -8,11 +6,12 @@ import torch
 
 from app.helpers.miscellaneous import find_best_target_match
 
+
 class SequentialDetector:
     """
     Handles sequential face detection, ByteTrack tracking, and Temporal EMA smoothing.
     Decoupled from the VideoProcessor for thread safety and maintainability.
-    
+
     This class manages its own state for temporal smoothing to ensure that continuous
     video frames are processed reliably without relying on the global UI state.
     """
@@ -20,12 +19,12 @@ class SequentialDetector:
     def __init__(self, main_window):
         """
         Initializes the SequentialDetector.
-        
+
         Args:
             main_window: The main application window instance.
         """
         self.main_window = main_window
-        
+
         # State tracking for sequential frames
         self.last_detected_faces: List[Dict[str, Any]] = []
         self._smoothed_kps: Dict[int, numpy.ndarray] = {}
@@ -34,15 +33,17 @@ class SequentialDetector:
 
     def reset_state(self):
         """
-        Safely clears all temporal smoothing tracking states and resets the 
+        Safely clears all temporal smoothing tracking states and resets the
         underlying ByteTrack tracker. Called when seeking or loading new media.
         """
         self.last_detected_faces.clear()
         self._smoothed_kps.clear()
         self._smoothed_dense_kps.clear()
         self._smoothed_dense_kps_203.clear()
-        
-        if hasattr(self.main_window, 'models_processor') and hasattr(self.main_window.models_processor, 'face_detectors'):
+
+        if hasattr(self.main_window, "models_processor") and hasattr(
+            self.main_window.models_processor, "face_detectors"
+        ):
             self.main_window.models_processor.face_detectors.reset_tracker()
 
     def run(
@@ -53,18 +54,18 @@ class SequentialDetector:
         is_master_edit_active: bool = False,
         frame_tensor: Optional[torch.Tensor] = None,
         detector_control_override: Optional[dict] = None,
-        frame_number: int = -1
+        frame_number: int = -1,
     ) -> Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]:
         """
-        Executes sequential face detection to guarantee flawless Temporal EMA smoothing 
-        and ByteTrack tracking. 
-        
+        Executes sequential face detection to guarantee flawless Temporal EMA smoothing
+        and ByteTrack tracking.
+
         This function implements a highly optimized "Track-and-Filter" pipeline:
         1. Fast Detection: Extracts only bounding boxes and 5-point landmarks for all faces in the frame.
         2. Early-Filtering: Uses ArcFace recognition to immediately discard faces that do not match the UI target(s).
         3. Heavy Detection: Computes complex 68-point or 203-point landmarks ONLY for the matched targets, saving massive GPU resources in crowd scenes.
-        
-        It also includes a rigorous Sanitization Shield to prevent corrupted arrays (NaNs, Inf, bad shapes) 
+
+        It also includes a rigorous Sanitization Shield to prevent corrupted arrays (NaNs, Inf, bad shapes)
         from crashing downstream worker threads.
 
         Args:
@@ -77,7 +78,7 @@ class SequentialDetector:
             frame_number (int): Current frame number (used for debugging and warning logs).
 
         Returns:
-            Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]: 
+            Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]:
                 Sanitized arrays containing (bboxes, kpss_5, kpss_68, kpss_203).
         """
         # VR180 requires specialized spherical detection performed within the FrameWorker.
@@ -85,201 +86,298 @@ class SequentialDetector:
         if local_control_for_worker.get("VR180ModeEnableToggle", False):
             return None, None, None, None
 
-        # VRAM Optimization: Use the current global CUDA stream instead of creating a custom one.
-        # This prevents stream desynchronization issues.
-        local_stream = (
-            torch.cuda.current_stream() if torch.cuda.is_available() else None
-        )
-        stream_context = (
-            torch.cuda.stream(local_stream)
-            if local_stream
-            else contextlib.nullcontext()
-        )
+        # NOTE: No explicit CUDA stream context is used here.
+        # Wrapping detection in torch.cuda.stream(current_stream) caused stream corruption:
+        # the feeder thread and FrameWorker pool both share the default CUDA stream, so
+        # synchronize() in the feeder stalled ALL pending worker GPU ops, causing cascading
+        # CUDA illegal-instruction crashes on TensorRT hardware (PR #176 regression).
+        # ONNX Runtime manages its own internal streams; no wrapper is needed.
+        control = detector_control_override or local_control_for_worker
+        use_landmark = control.get("LandmarkDetectToggle", True)
+        landmark_mode = control.get("LandmarkDetectModelSelection", "203")
+        from_points = control.get("DetectFromPointsToggle", False)
 
-        with stream_context:
-            control = detector_control_override or local_control_for_worker
-            use_landmark = control.get("LandmarkDetectToggle", True)
-            landmark_mode = control.get("LandmarkDetectModelSelection", "203")
-            from_points = control.get("DetectFromPointsToggle", False)
+        # Check if advanced UI features are enabled. Features like LivePortrait, FaceEditor,
+        # or Makeup strictly require the dense 203-point landmark model to function.
+        requires_203 = False
+        if local_params_for_worker:
+            for face_id, face_params in local_params_for_worker.items():
+                if isinstance(face_params, Mapping):
+                    is_face_editor_active = is_master_edit_active and face_params.get(
+                        "FaceEditorEnableToggle", False
+                    )
+                    is_expression_active = face_params.get(
+                        "FaceExpressionEnableBothToggle", False
+                    )
+                    is_auto_mouth_active = face_params.get(
+                        "AutoMouthExpressionEnableToggle", False
+                    )
+                    is_makeup_active = is_master_edit_active and (
+                        face_params.get("FaceMakeupEnableToggle", False)
+                        or face_params.get("HairMakeupEnableToggle", False)
+                        or face_params.get("EyeBrowsMakeupEnableToggle", False)
+                        or face_params.get("LipsMakeupEnableToggle", False)
+                    )
 
-            # Check if advanced UI features are enabled. Features like LivePortrait, FaceEditor, 
-            # or Makeup strictly require the dense 203-point landmark model to function.
-            requires_203 = False
-            if local_params_for_worker:
-                for face_id, face_params in local_params_for_worker.items():
-                    if isinstance(face_params, Mapping):
-                        is_face_editor_active = is_master_edit_active and face_params.get(
-                            "FaceEditorEnableToggle", False
-                        )
-                        is_expression_active = face_params.get(
-                            "FaceExpressionEnableBothToggle", False
-                        )
-                        is_auto_mouth_active = face_params.get(
-                            "AutoMouthExpressionEnableToggle", False
-                        )
-                        is_makeup_active = is_master_edit_active and (
-                            face_params.get("FaceMakeupEnableToggle", False)
-                            or face_params.get("HairMakeupEnableToggle", False)
-                            or face_params.get("EyeBrowsMakeupEnableToggle", False)
-                            or face_params.get("LipsMakeupEnableToggle", False)
-                        )
+                    if (
+                        is_face_editor_active
+                        or is_expression_active
+                        or is_auto_mouth_active
+                        or is_makeup_active
+                    ):
+                        requires_203 = True
+                        break
 
-                        if (
-                            is_face_editor_active
-                            or is_expression_active
-                            or is_auto_mouth_active
-                            or is_makeup_active
-                        ):
-                            requires_203 = True
-                            break
-
-            # Handle the PyTorch tensor allocation
-            device = self.main_window.models_processor.device
-            owns_frame_tensor = frame_tensor is None
-            if frame_tensor is None:
-                frame_tensor = (
-                    torch.from_numpy(frame_rgb)
-                    .to(device, non_blocking=True)
-                    .permute(2, 0, 1)  # Convert [H, W, C] -> [C, H, W]
-                )
-
-            # --- STEP 1: FAST DETECTION (BBoxes and 5-point landmarks ONLY) ---
-            # CRITICAL OPTIMIZATION: Heavy landmark detection (68/203 points) is disabled here 
-            # to rapidly scan the crowd without burning GPU cycles.
-            bboxes, kpss_5, _ = self.main_window.models_processor.run_detect(
-                frame_tensor,
-                control.get("DetectorModelSelection", "RetinaFace"),
-                max_num=int(control.get("MaxFacesToDetectSlider", 20)),
-                score=control.get("DetectorScoreSlider", 50) / 100.0,
-                input_size=(512, 512),
-                use_landmark_detection=False, 
-                from_points=from_points,
-                rotation_angles=[0]
-                if not control.get("AutoRotationToggle", False)
-                else [0, 90, 180, 270],
-                use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
-                control_override=control,
-                bypass_bytetrack=False,
+        # Handle the PyTorch tensor allocation
+        device = self.main_window.models_processor.device
+        owns_frame_tensor = frame_tensor is None
+        if frame_tensor is None:
+            frame_tensor = (
+                torch.from_numpy(frame_rgb)
+                .to(device, non_blocking=True)
+                .permute(2, 0, 1)  # Convert [H, W, C] -> [C, H, W]
             )
 
-            # --- STEP 2: SMART FILTERING (ArcFace Recognition) ---
-            valid_indices = []
-            
-            # Safely copy the target faces dictionary to avoid concurrent access issues from the UI thread.
-            try:
-                target_faces = dict(self.main_window.target_faces)
-            except Exception:
-                target_faces = {}
-                
-            # If detections exist and the user has configured target faces
-            if isinstance(bboxes, numpy.ndarray) and bboxes.shape[0] > 0 and len(target_faces) > 0:
-                rec_model = str(control.get("RecognitionModelSelection", "ArcFace"))
-                default_params = dict(self.main_window.default_parameters.data)
-                
-                for i in range(len(kpss_5)):
-                    # Ultra-fast recognition pass using only the 5 basic keypoints
-                    face_emb, _ = self.main_window.models_processor.run_recognize_direct(
-                        frame_tensor, kpss_5[i], "Auto", rec_model
-                    )
-                    
-                    # Verify if the detected face matches any of our targets
-                    match, _, _ = find_best_target_match(
-                        face_emb,
-                        self.main_window.models_processor,
-                        target_faces,
-                        local_params_for_worker or {},
-                        default_params,
-                        rec_model
-                    )
-                    
-                    # Keep the index only if it's a target face
-                    if match is not None:
-                        valid_indices.append(i)
-            elif isinstance(bboxes, numpy.ndarray) and bboxes.shape[0] > 0:
-                # If no specific targets are configured (e.g., pure FaceTracking mode), keep everyone
-                valid_indices = list(range(len(bboxes)))
+        # --- STEP 1: FAST DETECTION (BBoxes and 5-point landmarks ONLY) ---
+        # CRITICAL OPTIMIZATION: Heavy landmark detection (68/203 points) is disabled here
+        # to rapidly scan the crowd without burning GPU cycles.
+        bboxes, kpss_5, _ = self.main_window.models_processor.run_detect(
+            frame_tensor,
+            control.get("DetectorModelSelection", "RetinaFace"),
+            max_num=int(control.get("MaxFacesToDetectSlider", 20)),
+            score=control.get("DetectorScoreSlider", 50) / 100.0,
+            input_size=(512, 512),
+            use_landmark_detection=False,
+            from_points=from_points,
+            rotation_angles=[0]
+            if not control.get("AutoRotationToggle", False)
+            else [0, 90, 180, 270],
+            use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
+            control_override=control,
+            bypass_bytetrack=False,
+        )
 
-            # Apply the filter to eliminate background extras
-            filtered_bboxes = bboxes[valid_indices] if valid_indices else numpy.empty((0, 4), dtype=numpy.float32)
-            filtered_kpss_5 = kpss_5[valid_indices] if valid_indices else numpy.empty((0, 5, 2), dtype=numpy.float32)
+        # --- STEP 2: SMART FILTERING (ArcFace Recognition) ---
+        valid_indices: list = []
 
-            # --- STEP 3: HEAVY LANDMARK DETECTION (On target faces ONLY) ---
-            filtered_kpss = []
-            filtered_kpss_203 = []
+        # Safely copy the target faces dictionary to avoid concurrent access issues from the UI thread.
+        try:
+            target_faces = dict(self.main_window.target_faces)
+        except Exception:
+            target_faces = {}
 
-            for i in range(len(filtered_bboxes)):
-                current_bbox = filtered_bboxes[i]
-                current_kps5 = filtered_kpss_5[i]
-                
-                # CRITICAL FALLBACK: Instead of appending None on failure, we use valid arrays 
-                # to prevent downstream ".copy()" calls from throwing AttributeError.
-                kps_standard = current_kps5.copy()
+        rec_model = str(control.get("RecognitionModelSelection", "ArcFace"))
+        default_params = dict(self.main_window.default_parameters.data)
 
-                # Extract standard dense landmarks (68 or 203 depending on UI selection)
-                if use_landmark:
-                    _, lm_kpss, _ = self.main_window.models_processor.run_detect_landmark(
-                        frame_tensor,
-                        current_bbox,
-                        current_kps5,
-                        detect_mode=landmark_mode,
-                        score=control.get("LandmarkDetectScoreSlider", 50) / 100.0,
-                        use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
-                        from_points=True
-                    )
-                    if len(lm_kpss) > 0:
-                        kps_standard = lm_kpss
-                
-                filtered_kpss.append(kps_standard)
+        # 2a. Fast-path: skip ArcFace identity verification when the scene contains exactly
+        # one detected face and the user has configured exactly one target face. This saves
+        # one ArcFace inference per frame at ~5-10 ms each — significant headroom on webcam
+        # at 30 fps. The FrameWorker still re-verifies identity per face before swapping,
+        # so a wrong-identity slip-through is corrected downstream.
+        # Toggle name FastPathSingleFaceToggle (default True). Power users can disable.
+        fast_path_enabled = bool(control.get("FastPathSingleFaceToggle", True))
+        used_fast_path = False
+        if (
+            fast_path_enabled
+            and isinstance(bboxes, numpy.ndarray)
+            and bboxes.shape[0] == 1
+            and len(target_faces) == 1
+        ):
+            valid_indices = [0]
+            used_fast_path = True
 
-                # Extract forced 203 landmarks if advanced editing features demand it
-                if requires_203:
-                    kps_203_local = numpy.zeros((203, 2), dtype=numpy.float32)
-                    
-                    # Optimization: If the user already selected 203 as standard, reuse it to save a CUDA call
-                    if use_landmark and landmark_mode == "203" and len(kps_standard) == 203:
-                        kps_203_local = kps_standard.copy() 
+        # 2b. Strict ArcFace pre-filter (multi-face or multi-target case).
+        if (
+            not used_fast_path
+            and isinstance(bboxes, numpy.ndarray)
+            and bboxes.shape[0] > 0
+            and len(target_faces) > 0
+        ):
+            for i in range(len(kpss_5)):
+                # Ultra-fast recognition pass using only the 5 basic keypoints
+                face_emb, _ = self.main_window.models_processor.run_recognize_direct(
+                    frame_tensor, kpss_5[i], "Auto", rec_model
+                )
+
+                # Verify if the detected face matches any of our targets
+                match, _, _ = find_best_target_match(
+                    face_emb,
+                    self.main_window.models_processor,
+                    target_faces,
+                    local_params_for_worker or {},
+                    default_params,
+                    rec_model,
+                )
+
+                # Keep the index only if it's a target face
+                if match is not None:
+                    valid_indices.append(i)
+        elif (
+            not used_fast_path
+            and isinstance(bboxes, numpy.ndarray)
+            and bboxes.shape[0] > 0
+        ):
+            # If no specific targets are configured (e.g., pure FaceTracking mode), keep everyone
+            valid_indices = list(range(len(bboxes)))
+
+        # 2c. Relaxed-threshold ArcFace pass — runs only when the strict pass produced no
+        # matches. ArcFace embeddings degrade on side angles, motion blur, and partial
+        # occlusion: the strict pass would discard the actual target and produce flashing
+        # artefacts. We re-test with the per-target SimilarityThresholdSlider halved (and
+        # floored at 20). The FrameWorker performs its own per-face similarity check before
+        # swapping, so a relaxed match that turns out to be wrong is filtered downstream.
+        if (
+            not used_fast_path
+            and len(valid_indices) == 0
+            and isinstance(bboxes, numpy.ndarray)
+            and bboxes.shape[0] > 0
+            and len(target_faces) > 0
+        ):
+            relaxed_local_params: Dict[str, Any] = {}
+            if local_params_for_worker:
+                for _tgt_id, _per in local_params_for_worker.items():
+                    if isinstance(_per, Mapping):
+                        _per_copy = dict(_per)
+                        if "SimilarityThresholdSlider" in _per_copy:
+                            try:
+                                _orig = float(_per_copy["SimilarityThresholdSlider"])
+                                _per_copy["SimilarityThresholdSlider"] = max(
+                                    20.0, _orig * 0.5
+                                )
+                            except (TypeError, ValueError):
+                                pass
+                        relaxed_local_params[_tgt_id] = _per_copy
                     else:
-                        _, lm_203, _ = self.main_window.models_processor.run_detect_landmark(
+                        relaxed_local_params[_tgt_id] = _per
+            relaxed_default = dict(default_params)
+            if "SimilarityThresholdSlider" in relaxed_default:
+                try:
+                    _orig = float(relaxed_default["SimilarityThresholdSlider"])
+                    relaxed_default["SimilarityThresholdSlider"] = max(
+                        20.0, _orig * 0.5
+                    )
+                except (TypeError, ValueError):
+                    pass
+
+            for i in range(len(kpss_5)):
+                face_emb, _ = self.main_window.models_processor.run_recognize_direct(
+                    frame_tensor, kpss_5[i], "Auto", rec_model
+                )
+                match, _, _ = find_best_target_match(
+                    face_emb,
+                    self.main_window.models_processor,
+                    target_faces,
+                    relaxed_local_params,
+                    relaxed_default,
+                    rec_model,
+                )
+                if match is not None:
+                    valid_indices.append(i)
+
+        # 2d. Last-resort single-face fallback: if both passes filtered everything out
+        # but only one face was detected, allow it through. This catches the rare case
+        # where ArcFace produces a near-zero similarity (severe motion blur, occlusion).
+        # The FrameWorker still performs identity verification before swapping.
+        if (
+            len(valid_indices) == 0
+            and isinstance(bboxes, numpy.ndarray)
+            and bboxes.shape[0] == 1
+            and len(target_faces) > 0
+        ):
+            valid_indices = [0]
+
+        # Apply the filter to eliminate background extras
+        filtered_bboxes = (
+            bboxes[valid_indices]
+            if valid_indices
+            else numpy.empty((0, 4), dtype=numpy.float32)
+        )
+        filtered_kpss_5 = (
+            kpss_5[valid_indices]
+            if valid_indices
+            else numpy.empty((0, 5, 2), dtype=numpy.float32)
+        )
+
+        # --- STEP 3: HEAVY LANDMARK DETECTION (On target faces ONLY) ---
+        filtered_kpss = []
+        filtered_kpss_203 = []
+
+        for i in range(len(filtered_bboxes)):
+            current_bbox = filtered_bboxes[i]
+            current_kps5 = filtered_kpss_5[i]
+
+            # CRITICAL FALLBACK: Instead of appending None on failure, we use valid arrays
+            # to prevent downstream ".copy()" calls from throwing AttributeError.
+            kps_standard = current_kps5.copy()
+
+            # Extract standard dense landmarks (68 or 203 depending on UI selection)
+            if use_landmark:
+                _, lm_kpss, _ = self.main_window.models_processor.run_detect_landmark(
+                    frame_tensor,
+                    current_bbox,
+                    current_kps5,
+                    detect_mode=landmark_mode,
+                    score=control.get("LandmarkDetectScoreSlider", 50) / 100.0,
+                    use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
+                    from_points=True,
+                )
+                if len(lm_kpss) > 0:
+                    kps_standard = lm_kpss
+
+            filtered_kpss.append(kps_standard)
+
+            # Extract forced 203 landmarks if advanced editing features demand it
+            if requires_203:
+                kps_203_local = numpy.zeros((203, 2), dtype=numpy.float32)
+
+                # Optimization: If the user already selected 203 as standard, reuse it to save a CUDA call
+                if use_landmark and landmark_mode == "203" and len(kps_standard) == 203:
+                    kps_203_local = kps_standard.copy()
+                else:
+                    _, lm_203, _ = (
+                        self.main_window.models_processor.run_detect_landmark(
                             frame_tensor,
                             current_bbox,
                             current_kps5,
                             detect_mode="203",
                             score=0.5,
                             use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
-                            from_points=True
+                            from_points=True,
                         )
-                        if len(lm_203) > 0:
-                            kps_203_local = lm_203
-                            
-                    filtered_kpss_203.append(kps_203_local)
+                    )
+                    if len(lm_203) > 0:
+                        kps_203_local = lm_203
 
-            # Reformat output arrays to match the expected pipeline signature (CRITICAL TYPE CASTING)
-            bboxes = numpy.array(filtered_bboxes, dtype=numpy.float32)
-            kpss_5 = numpy.array(filtered_kpss_5, dtype=numpy.float32)
-            
-            if len(filtered_kpss) > 0:
-                kpss = numpy.array(filtered_kpss, dtype=object)
-            else:
-                kpss = numpy.empty((0, 5, 2), dtype=numpy.float32)
-                
-            if requires_203 and len(filtered_kpss_203) > 0:
-                kpss_203 = numpy.array(filtered_kpss_203, dtype=object)
-            else:
-                kpss_203 = numpy.empty((0, 203, 2), dtype=numpy.float32)
+                filtered_kpss_203.append(kps_203_local)
 
-            # Cleanup VRAM
-            if owns_frame_tensor:
-                del frame_tensor
+        # Reformat output arrays to match the expected pipeline signature (CRITICAL TYPE CASTING)
+        bboxes = numpy.array(filtered_bboxes, dtype=numpy.float32)
+        kpss_5 = numpy.array(filtered_kpss_5, dtype=numpy.float32)
 
-            if local_stream:
-                local_stream.synchronize()
+        if len(filtered_kpss) > 0:
+            kpss = numpy.array(filtered_kpss, dtype=object)
+        else:
+            kpss = numpy.empty((0, 5, 2), dtype=numpy.float32)
 
-        # Safely copy arrays before exiting the stream context to prevent 
-        # memory corruption when the arrays are accessed by independent worker threads.
-        if isinstance(bboxes, numpy.ndarray): bboxes = bboxes.copy()
-        if isinstance(kpss_5, numpy.ndarray): kpss_5 = kpss_5.copy()
-        if isinstance(kpss, numpy.ndarray): kpss = kpss.copy()
-        if isinstance(kpss_203, numpy.ndarray): kpss_203 = kpss_203.copy()
+        if requires_203 and len(filtered_kpss_203) > 0:
+            kpss_203 = numpy.array(filtered_kpss_203, dtype=object)
+        else:
+            kpss_203 = numpy.empty((0, 203, 2), dtype=numpy.float32)
+
+        # Cleanup VRAM
+        if owns_frame_tensor:
+            del frame_tensor
+
+        # Safely copy arrays before returning to prevent memory corruption when the
+        # arrays are accessed by independent worker threads.
+        if isinstance(bboxes, numpy.ndarray):
+            bboxes = bboxes.copy()
+        if isinstance(kpss_5, numpy.ndarray):
+            kpss_5 = kpss_5.copy()
+        if isinstance(kpss, numpy.ndarray):
+            kpss = kpss.copy()
+        if isinstance(kpss_203, numpy.ndarray):
+            kpss_203 = kpss_203.copy()
 
         # --- SANITIZATION SHIELD ---
         # Ensures only perfectly formatted data passes through to the FrameWorker.
@@ -295,11 +393,17 @@ class SequentialDetector:
                 valid_mask = numpy.isfinite(bboxes).all(axis=1)
                 if not valid_mask.all():
                     bboxes = bboxes[valid_mask]
-                    if isinstance(kpss_5, numpy.ndarray) and kpss_5.shape[0] == len(valid_mask):
+                    if isinstance(kpss_5, numpy.ndarray) and kpss_5.shape[0] == len(
+                        valid_mask
+                    ):
                         kpss_5 = kpss_5[valid_mask]
-                    if isinstance(kpss, numpy.ndarray) and kpss.shape[0] == len(valid_mask):
+                    if isinstance(kpss, numpy.ndarray) and kpss.shape[0] == len(
+                        valid_mask
+                    ):
                         kpss = kpss[valid_mask]
-                    if isinstance(kpss_203, numpy.ndarray) and kpss_203.shape[0] == len(valid_mask):
+                    if isinstance(kpss_203, numpy.ndarray) and kpss_203.shape[0] == len(
+                        valid_mask
+                    ):
                         kpss_203 = kpss_203[valid_mask]
             else:
                 bboxes = numpy.empty((0, 4), dtype=numpy.float32)
@@ -307,9 +411,12 @@ class SequentialDetector:
             bboxes = numpy.empty((0, 4), dtype=numpy.float32)
 
         if bboxes.shape[0] == 0:
-            if isinstance(kpss_5, numpy.ndarray): kpss_5 = numpy.empty((0, 5, 2), dtype=numpy.float32)
-            if isinstance(kpss, numpy.ndarray): kpss = numpy.empty((0, 68, 2), dtype=numpy.float32)
-            if isinstance(kpss_203, numpy.ndarray): kpss_203 = numpy.empty((0, 203, 2), dtype=numpy.float32)
+            if isinstance(kpss_5, numpy.ndarray):
+                kpss_5 = numpy.empty((0, 5, 2), dtype=numpy.float32)
+            if isinstance(kpss, numpy.ndarray):
+                kpss = numpy.empty((0, 68, 2), dtype=numpy.float32)
+            if isinstance(kpss_203, numpy.ndarray):
+                kpss_203 = numpy.empty((0, 203, 2), dtype=numpy.float32)
 
         # Update global tracker state for UI bounding box rendering
         detected_for_state = []
@@ -318,7 +425,9 @@ class SequentialDetector:
                 detected_for_state.append({"bbox": bboxes[i], "score": 1.0})
         self.last_detected_faces = detected_for_state
 
-        is_smoothing_enabled = local_control_for_worker.get("KPSSmoothingEnableToggle", True)
+        is_smoothing_enabled = local_control_for_worker.get(
+            "KPSSmoothingEnableToggle", True
+        )
 
         # --- TEMPORAL EMA SMOOTHING ---
         # Matches faces between current frame and previous frame based on spatial proximity (centroids).
@@ -329,7 +438,7 @@ class SequentialDetector:
             if isinstance(kpss_5, numpy.ndarray) and kpss_5.shape[0] > 0:
                 kpss_5 = kpss_5.copy()
                 n_faces = kpss_5.shape[0]
-                
+
                 new_smoothed_kps = {}
                 new_smoothed_dense_kps = {}
                 new_smoothed_dense_kps_203 = {}
@@ -337,13 +446,17 @@ class SequentialDetector:
                 valid_kpss = cast(numpy.ndarray, kpss)
                 valid_kpss_203 = cast(numpy.ndarray, kpss_203)
 
-                dense_kps_count = int(kpss.shape[0]) if isinstance(kpss, numpy.ndarray) else 0
+                dense_kps_count = (
+                    int(kpss.shape[0]) if isinstance(kpss, numpy.ndarray) else 0
+                )
                 has_dense_kps = dense_kps_count > 0
                 if has_dense_kps:
                     valid_kpss = valid_kpss.copy()
                     kpss = valid_kpss
 
-                dense_kps_203_count = int(kpss_203.shape[0]) if isinstance(kpss_203, numpy.ndarray) else 0
+                dense_kps_203_count = (
+                    int(kpss_203.shape[0]) if isinstance(kpss_203, numpy.ndarray) else 0
+                )
                 has_dense_kps_203 = dense_kps_203_count > 0
                 if has_dense_kps_203:
                     valid_kpss_203 = valid_kpss_203.copy()
@@ -351,20 +464,35 @@ class SequentialDetector:
 
                 # Log warnings if array lengths misalign (guards against indexing errors below)
                 if has_dense_kps and dense_kps_count != n_faces:
-                    print(f"[WARN] Dense KPS count mismatch on frame {frame_number}: kpss_5={n_faces}, dense_kps={dense_kps_count}. Skipping dense smoothing for missing faces.")
+                    print(
+                        f"[WARN] Dense KPS count mismatch on frame {frame_number}: kpss_5={n_faces}, dense_kps={dense_kps_count}. Skipping dense smoothing for missing faces."
+                    )
                 if has_dense_kps_203 and dense_kps_203_count != n_faces:
-                    print(f"[WARN] Dense KPS_203 count mismatch on frame {frame_number}: kpss_5={n_faces}, dense_kps_203={dense_kps_203_count}. Skipping dense 203 smoothing for missing faces.")
+                    print(
+                        f"[WARN] Dense KPS_203 count mismatch on frame {frame_number}: kpss_5={n_faces}, dense_kps_203={dense_kps_203_count}. Skipping dense 203 smoothing for missing faces."
+                    )
 
                 for _i in range(n_faces):
                     _raw = kpss_5[_i]
                     dense_kps_available = has_dense_kps and _i < dense_kps_count
-                    dense_kps_203_available = has_dense_kps_203 and _i < dense_kps_203_count
+                    dense_kps_203_available = (
+                        has_dense_kps_203 and _i < dense_kps_203_count
+                    )
 
                     # Skip smoothing if data is malformed or out of image bounds
-                    if (_raw is None or _raw.size == 0 or numpy.any(numpy.isnan(_raw)) or numpy.any(numpy.isinf(_raw))):
+                    if (
+                        _raw is None
+                        or _raw.size == 0
+                        or numpy.any(numpy.isnan(_raw))
+                        or numpy.any(numpy.isinf(_raw))
+                    ):
                         continue
-                    if (numpy.any(_raw[:, 0] < 0) or numpy.any(_raw[:, 0] >= img_w_for_kps) or 
-                        numpy.any(_raw[:, 1] < 0) or numpy.any(_raw[:, 1] >= img_h_for_kps)):
+                    if (
+                        numpy.any(_raw[:, 0] < 0)
+                        or numpy.any(_raw[:, 0] >= img_w_for_kps)
+                        or numpy.any(_raw[:, 1] < 0)
+                        or numpy.any(_raw[:, 1] >= img_h_for_kps)
+                    ):
                         continue
 
                     _centroid_raw = numpy.mean(_raw, axis=0)
@@ -387,21 +515,30 @@ class SequentialDetector:
 
                     # If a match is found, apply Exponential Moving Average (EMA)
                     if _best_match_key is not None:
-                        base_alpha = local_control_for_worker.get("KPSEmaAlphaSlider", 35) / 100.0
-                        
+                        base_alpha = (
+                            local_control_for_worker.get("KPSEmaAlphaSlider", 35)
+                            / 100.0
+                        )
+
                         # Dynamic Alpha: Increase responsiveness (less smoothing) during fast movement
                         movement_factor = min(1.0, _min_dist / 15.0)
-                        dynamic_alpha = base_alpha + movement_factor * (1.0 - base_alpha)
+                        dynamic_alpha = base_alpha + movement_factor * (
+                            1.0 - base_alpha
+                        )
 
                         new_smoothed_kps[_i] = (
-                            dynamic_alpha * _raw + (1.0 - dynamic_alpha) * self._smoothed_kps[_best_match_key]
+                            dynamic_alpha * _raw
+                            + (1.0 - dynamic_alpha)
+                            * self._smoothed_kps[_best_match_key]
                         )
                         del self._smoothed_kps[_best_match_key]
 
                         if dense_kps_available:
                             if _best_match_key in self._smoothed_dense_kps:
                                 new_smoothed_dense_kps[_i] = (
-                                    dynamic_alpha * valid_kpss[_i] + (1.0 - dynamic_alpha) * self._smoothed_dense_kps[_best_match_key]
+                                    dynamic_alpha * valid_kpss[_i]
+                                    + (1.0 - dynamic_alpha)
+                                    * self._smoothed_dense_kps[_best_match_key]
                                 )
                                 del self._smoothed_dense_kps[_best_match_key]
                             else:
@@ -413,16 +550,30 @@ class SequentialDetector:
                                 if is_valid_203:
                                     if _best_match_key in self._smoothed_dense_kps_203:
                                         new_smoothed_dense_kps_203[_i] = (
-                                            dynamic_alpha * valid_kpss_203[_i] + (1.0 - dynamic_alpha) * self._smoothed_dense_kps_203[_best_match_key]
+                                            dynamic_alpha * valid_kpss_203[_i]
+                                            + (1.0 - dynamic_alpha)
+                                            * self._smoothed_dense_kps_203[
+                                                _best_match_key
+                                            ]
                                         )
-                                        del self._smoothed_dense_kps_203[_best_match_key]
+                                        del self._smoothed_dense_kps_203[
+                                            _best_match_key
+                                        ]
                                     else:
-                                        new_smoothed_dense_kps_203[_i] = valid_kpss_203[_i].copy()
+                                        new_smoothed_dense_kps_203[_i] = valid_kpss_203[
+                                            _i
+                                        ].copy()
                                 else:
                                     # Fallback: Carry over previous 203 points if current ones are zeroes
                                     if _best_match_key in self._smoothed_dense_kps_203:
-                                        new_smoothed_dense_kps_203[_i] = self._smoothed_dense_kps_203[_best_match_key].copy()
-                                        valid_kpss_203[_i] = new_smoothed_dense_kps_203[_i]
+                                        new_smoothed_dense_kps_203[_i] = (
+                                            self._smoothed_dense_kps_203[
+                                                _best_match_key
+                                            ].copy()
+                                        )
+                                        valid_kpss_203[_i] = new_smoothed_dense_kps_203[
+                                            _i
+                                        ]
 
                     # No previous face found (new face entering frame), initialize state
                     else:
@@ -431,7 +582,9 @@ class SequentialDetector:
                             new_smoothed_dense_kps[_i] = valid_kpss[_i].copy()
                         if has_dense_kps_203:
                             if dense_kps_203_available:
-                                new_smoothed_dense_kps_203[_i] = valid_kpss_203[_i].copy()
+                                new_smoothed_dense_kps_203[_i] = valid_kpss_203[
+                                    _i
+                                ].copy()
 
                     # Write back the smoothed coordinates to the result arrays
                     kpss_5[_i] = new_smoothed_kps[_i]
@@ -445,7 +598,7 @@ class SequentialDetector:
                 self._smoothed_kps = new_smoothed_kps
                 self._smoothed_dense_kps = new_smoothed_dense_kps
                 self._smoothed_dense_kps_203 = new_smoothed_dense_kps_203
-        
+
         # Clear state if smoothing is disabled to prevent stale data buildup
         else:
             self._smoothed_kps.clear()

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -459,7 +459,30 @@ class FrameWorker(threading.Thread):
                 )
 
         except Exception as e:
-            print(f"[ERROR] Error in {self.name} (frame {self.frame_number}): {e}")
+            # FW-CUDA-LOG: Distinguish CUDA / TensorRT errors so they are loud and
+            # actionable, since they typically mean the entire CUDA context is
+            # corrupted and continuing to process will produce more cryptic crashes
+            # downstream. The visible message points users at the launcher's
+            # Update / Maintenance page where they can switch the provider.
+            _err_msg = str(e)
+            _is_cuda_error = (
+                "CUDA" in _err_msg
+                or "cuda" in _err_msg.lower()
+                or "TensorRT" in _err_msg
+                or "tensorrt" in _err_msg.lower()
+                or e.__class__.__name__ == "AcceleratorError"
+            )
+            if _is_cuda_error:
+                print(
+                    f"[FATAL] CUDA error in {self.name} (frame {self.frame_number}): {e}"
+                )
+                print(
+                    "[FATAL] CUDA context may be corrupted. If this persists, open "
+                    "Launcher → Update / Maintenance → switch provider (TensorRT ↔ CUDA) "
+                    "or rebuild the TensorRT engines."
+                )
+            else:
+                print(f"[ERROR] Error in {self.name} (frame {self.frame_number}): {e}")
             traceback.print_exc()
             # Emit the original (unprocessed) frame as a fallback so the recording
             # metronome is never blocked waiting for a frame that will never arrive.
@@ -1494,8 +1517,16 @@ class FrameWorker(threading.Thread):
             # projection: true angular width ≈ equirect_width / cos(phi_radians)
             phi_radians = math.radians(phi)
             cos_phi = math.cos(phi_radians)
-            # Avoid division by near-zero at poles; clamp cos_phi to at least 0.1
-            angular_width_deg_corrected = angular_width_deg / max(cos_phi, 0.1)
+            # Clamp cos_phi to 0.35 (≈70° latitude) to cap the correction at ~2.9×.
+            # The previous clamp of 0.1 allowed up to ×10 amplification near the poles,
+            # which produced extreme FOVs causing landmark coordinates to be garbage
+            # ("eye sideways, mouth near ear") for faces near the top/bottom of the frame.
+            # Secondary cap: never let the correction exceed 2× the raw angular width,
+            # ensuring continuity with non-corrected detection for near-pole detections.
+            angular_width_deg_corrected = angular_width_deg / max(cos_phi, 0.35)
+            angular_width_deg_corrected = min(
+                angular_width_deg_corrected, angular_width_deg * 2.0
+            )
             # Improvement C: use VR180MaxFOVSlider instead of the previous hard-cap of
             # 100°.  Near-camera faces can subtend >100° and were being clipped.
             _vr_max_fov = float(control.get("VR180MaxFOVSlider", 120))
@@ -2409,6 +2440,13 @@ class FrameWorker(threading.Thread):
             ratio_h_down = img_h / new_h
 
             for fface in det_faces_data_for_display:
+                # Idempotency guard: the same fface dict can survive into a follow-up
+                # refresh-frame call (e.g., when the user toggles a setting that
+                # triggers refresh_frame). Re-applying the downscale would
+                # double-shrink the bbox/kps and produce out-of-frame coordinates
+                # that broke auto-mouth detection on stopped frames.
+                if fface.get("_displayspace_rescaled"):
+                    continue
                 if fface.get("bbox") is not None:
                     fface["bbox"][0] *= ratio_w_down
                     fface["bbox"][2] *= ratio_w_down
@@ -2423,6 +2461,7 @@ class FrameWorker(threading.Thread):
                 if fface.get("kps_203") is not None:
                     fface["kps_203"][:, 0] *= ratio_w_down
                     fface["kps_203"][:, 1] *= ratio_h_down
+                fface["_displayspace_rescaled"] = True
 
         processed_tensor_rgb_uint8 = img
 
@@ -3918,6 +3957,30 @@ class FrameWorker(threading.Thread):
             y1 = float(face_bbox[1])
             x2 = float(face_bbox[2])
             y2 = float(face_bbox[3])
+
+            # FW-MOUTH-1: For sub-512px input frames, _process_frame_standard
+            # upscales the working tensor and scales the bboxes UP to match.
+            # `self.frame` is the ORIGINAL (un-upscaled) numpy frame. Using
+            # upscaled-space bbox coordinates against the original frame produces
+            # an out-of-bounds crop → mouth-action detector returns None →
+            # auto-mouth never fires for low-resolution videos.
+            #
+            # Detect the mismatch (bbox extending well past the frame's actual
+            # dimensions) and rescale the bbox back to original-frame space.
+            _bbox_max = max(x2, y2)
+            if _bbox_max > max(fw, fh) + 8 and (fw < 512 or fh < 512):
+                if fw <= fh:
+                    _new_w = 512
+                    _new_h = int(512 * fh / fw)
+                else:
+                    _new_h = 512
+                    _new_w = int(512 * fw / fh)
+                _ratio_w_down = fw / float(_new_w)
+                _ratio_h_down = fh / float(_new_h)
+                x1 *= _ratio_w_down
+                x2 *= _ratio_w_down
+                y1 *= _ratio_h_down
+                y2 *= _ratio_h_down
             cx = (x1 + x2) / 2.0
             cy = (y1 + y2) / 2.0
             half_w = x2 - x1  # 2× scale → full bbox width as half-extent
@@ -3981,7 +4044,16 @@ class FrameWorker(threading.Thread):
             target_fb.mouth_openness_state = MouthOpennessState()
             _state = target_fb.mouth_openness_state
 
-        _auto_active, _ema_value = _state.update(_ratio, _alpha, _threshold)
+        # FW-MOUTH-2: When the worker is servicing a stopped-frame preview
+        # (single-frame mode), every refresh re-evaluates the SAME underlying
+        # frame. None-ratios from transient bbox/setting toggles must not accrue
+        # an occlusion penalty — otherwise toggling color transfer on a stopped
+        # frame slowly decays the EMA past the deactivate threshold and the user
+        # cannot re-enable auto-mouth without resuming playback.
+        _single_frame_mode = bool(getattr(self, "is_single_frame", False))
+        _auto_active, _ema_value = _state.update(
+            _ratio, _alpha, _threshold, single_frame_mode=_single_frame_mode
+        )
 
         if not _auto_active:
             return params

--- a/app/ui/launcher/__main__.py
+++ b/app/ui/launcher/__main__.py
@@ -7,6 +7,17 @@
 # ---------------------------------------------------------------------------
 
 import sys
+from pathlib import Path
+
+# Ensure the repository root (the directory containing the `app/` package) is on
+# sys.path regardless of the working directory the interpreter was launched from.
+# This prevents "ModuleNotFoundError: No module named 'app'" when the portable
+# install script invokes `python -m app.ui.launcher` from the wrong directory.
+_repo_root = (
+    Path(__file__).resolve().parent.parent.parent.parent
+)  # .../VisoMaster-Fusion
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
 
 try:
     from .main import main

--- a/app/ui/launcher/core.py
+++ b/app/ui/launcher/core.py
@@ -76,15 +76,36 @@ def apply_theme_to_app(app: QtWidgets.QApplication):
 # ---------- Subprocess Helpers ----------
 
 
-def run_python(script_path: Path):
-    """Run a Python script using the portable Python interpreter."""
-    subprocess.run(
-        [str(PATHS["PYTHON_EXE"]), str(script_path)], cwd=PATHS["APP_DIR"], shell=False
-    )
+def run_python(script_path: Path, args: list | None = None):
+    """Run a Python script using the portable Python interpreter.
+
+    The working directory is always set to APP_DIR (the repo root) so that
+    `python -m app.ui.launcher` and similar module invocations find the `app/`
+    package regardless of where the caller's cwd is.
+    """
+    cmd = [str(PATHS["PYTHON_EXE"]), str(script_path)] + (args or [])
+    subprocess.run(cmd, cwd=str(PATHS["APP_DIR"]), shell=False)
+
+
+# UV network tuning defaults.
+# These can be overridden by setting environment variables before launching.
+# UV_TIMEOUT: per-request HTTP timeout in seconds (default 120 s).
+#   Increase if large wheels (torch, onnxruntime) time out on slow connections.
+# UV_RETRIES: number of retry attempts on transient network errors (default 5).
+# UV_CONCURRENT_DOWNLOADS: parallel download slots (default 4).
+#   Reduce to 1 on very slow / metered connections to avoid overloading the pipe.
+_UV_TIMEOUT = "120"
+_UV_RETRIES = "5"
+_UV_CONCURRENT_DOWNLOADS = "4"
 
 
 def uv_pip_install():
-    """Run dependency installation using the portable uv executable."""
+    """Run dependency installation using the portable uv executable.
+
+    Passes explicit timeout, retry, and concurrency flags so that slow or
+    unstable connections (common in portable installs) do not abort mid-install
+    with a cryptic timeout error.
+    """
     subprocess.run(
         [
             str(PATHS["UV_EXE"]),
@@ -94,7 +115,13 @@ def uv_pip_install():
             str(PATHS["REQ_FILE"]),
             "--python",
             str(PATHS["PYTHON_EXE"]),
+            "--timeout",
+            _UV_TIMEOUT,
+            "--retries",
+            _UV_RETRIES,
+            "--concurrent-downloads",
+            _UV_CONCURRENT_DOWNLOADS,
         ],
-        cwd=PATHS["APP_DIR"],
+        cwd=str(PATHS["APP_DIR"]),
         shell=False,
     )

--- a/app/ui/widgets/actions/common_actions.py
+++ b/app/ui/widgets/actions/common_actions.py
@@ -591,6 +591,21 @@ def extract_frame_as_image(
             media_file_path
         )
 
+        # Freshness check: if the source file has been modified more recently
+        # than the cached thumbnail (e.g., the user re-recorded over the same
+        # filename), force regeneration. Without this guard a stale thumbnail
+        # is served indefinitely.
+        if thumbnail_path:
+            try:
+                import os as _os
+
+                if _os.path.getmtime(thumbnail_path) < _os.path.getmtime(
+                    media_file_path
+                ):
+                    thumbnail_path = None
+            except OSError:
+                pass  # source file missing — fall through to regeneration
+
         if thumbnail_path:
             frame = misc_helpers.read_image_file(thumbnail_path)
             if frame is not None:
@@ -603,16 +618,34 @@ def extract_frame_as_image(
     elif file_type == "video":
         # Get rotation for thumbnail
         rotation_angle = get_video_rotation(media_file_path)
-        cap = cv2.VideoCapture(media_file_path)
-        if cap.isOpened():
-            # Explicitly enable OpenCV's auto-rotation ---
-            if hasattr(cv2, "CAP_PROP_ORIENTATION_AUTO"):
-                cap.set(cv2.CAP_PROP_ORIENTATION_AUTO, 1)
-            total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-            middle_frame_no = total_frames // 2
-            cap.set(cv2.CAP_PROP_POS_FRAMES, middle_frame_no)
-            ret, frame = misc_helpers.read_frame(cap, rotation_angle)
-            cap.release()
+        # Retry up to 3 times with a 500 ms backoff.  Freshly recorded output files
+        # may still be held open by ffmpeg or the OS write cache when the media panel
+        # first tries to generate a thumbnail, causing cap.isOpened() to fail or
+        # CAP_PROP_FRAME_COUNT to return 0.  This is especially common on Windows 10.
+        import time as _time
+
+        for _attempt in range(3):
+            cap = cv2.VideoCapture(media_file_path)
+            if cap.isOpened():
+                # Explicitly enable OpenCV's auto-rotation
+                if hasattr(cv2, "CAP_PROP_ORIENTATION_AUTO"):
+                    cap.set(cv2.CAP_PROP_ORIENTATION_AUTO, 1)
+                total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                if total_frames > 0:
+                    middle_frame_no = total_frames // 2
+                    cap.set(cv2.CAP_PROP_POS_FRAMES, middle_frame_no)
+                    ret, frame = misc_helpers.read_frame(cap, rotation_angle)
+                    cap.release()
+                    if ret:
+                        break  # success — exit retry loop
+                    cap = None  # mark for next attempt
+                else:
+                    cap.release()
+                    cap = None
+            else:
+                cap = None
+            if _attempt < 2:
+                _time.sleep(0.5)  # wait before retry (file may still be flushed)
     elif file_type == "webcam":
         camera = cv2.VideoCapture(webcam_index, webcam_backend)
         if camera.isOpened():

--- a/app/ui/widgets/common_layout_data.py
+++ b/app/ui/widgets/common_layout_data.py
@@ -686,15 +686,18 @@ COMMON_LAYOUT_DATA: Any = {
             "label": "Confidence Threshold",
             "min_value": "0.01",
             "max_value": "0.99",
-            "default": "0.80",
+            "default": "0.50",
             "decimals": 2,
             "step": 0.01,
             "parentToggle": "AutoMouthExpressionEnableToggle",
             "requiredToggleValue": True,
             "enable_refresh_frame": False,
             "help": (
-                "Minimum detection confidence required to trigger auto-mouth activation. "
-                "Higher values require a more confident detection before activating."
+                "Minimum lip-open ratio required to activate the auto-mouth feature. "
+                "The ratio is vertical_gap / horizontal_span of the mouth. "
+                "Typical conversational values are 0.20–0.50; "
+                "above 0.60 only fires for a very wide-open mouth. "
+                "Lower values are more sensitive; higher values require a larger opening."
             ),
         },
         "AutoMouthEMAAlphaDecimalSlider": {

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -326,8 +326,14 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
         "VR180TileDetectionToggle": {
             "level": 1,
             "label": "VR Tiled Face Detection",
-            "default": False,
-            "help": "Run face detection on a grid of 24 undistorted perspective crops to catch faces missed by standard detection (faces near poles, the ±180° seam, or very close to the camera). OFF by default — adds ~24 extra detector runs per keyframe. Enable only when standard detection misses faces.",
+            # Default flipped to True to address the user-reported "head tilted
+            # back / near pole" detection failures. Tiled detection adds extra
+            # detector runs per keyframe but is the only way to find faces at
+            # high latitudes where equirectangular projection severely compresses
+            # horizontal resolution. Power users can disable for max throughput
+            # in scenes that don't need it.
+            "default": True,
+            "help": "Run face detection on a grid of 24 undistorted perspective crops to catch faces missed by standard detection (faces near poles, the ±180° seam, head tilted back, or very close to the camera). Default ON — recommended for most VR content. Disable only when you are certain the standard detector finds every face you need.",
             "parentToggle": "VR180ModeEnableToggle",
             "requiredToggleValue": True,
         },

--- a/app/ui/widgets/swapper_layout_data.py
+++ b/app/ui/widgets/swapper_layout_data.py
@@ -1249,6 +1249,11 @@ SWAPPER_LAYOUT_DATA: Any = {  # noqa: F811
             "level": 1,
             "label": "AutoColor Transfer",
             "default": False,
+            # Toggling color transfer must NOT trigger a single-frame refresh.
+            # The refresh path mutates det_faces_data_for_display bboxes in place,
+            # which corrupted the bbox passed to _detect_mouth_action_score on the
+            # next refresh and broke the auto-mouth state machine on stopped frames.
+            "enable_refresh_frame": False,
             "help": "Enable AutoColor Transfer: 1. Hans Test without mask, 2. Hans Test with mask, 3. DFL Method without mask, 4. DFL Original Method.",
         },
         "AutoColorTransferTypeSelection": {
@@ -1281,6 +1286,11 @@ SWAPPER_LAYOUT_DATA: Any = {  # noqa: F811
             "level": 1,
             "label": "Enable Ending Color Transfer",
             "default": False,
+            # Toggling color transfer must NOT trigger a single-frame refresh.
+            # See AutoColorEnableToggle above for the same rationale — refresh
+            # corrupted bboxes broke auto-mouth on stopped frames after color
+            # transfer was toggled.
+            "enable_refresh_frame": False,
             "help": "Enables a final color transfer pass after face restoration to match original skin tone.",
         },
         "EndingColorTransferTypeSelection": {

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Launcher shim that works regardless of the caller's working directory.
+
+Use this script as the entry point for the VisoMaster Fusion launcher when the
+caller cannot guarantee the cwd is the repo root:
+
+    python launcher.py
+
+This is the **path-based** equivalent of:
+
+    python -m app.ui.launcher
+
+The `-m` form fails with `ModuleNotFoundError: No module named 'app'` whenever
+Python is invoked from outside the repo root, because Python's `runpy` resolves
+the module before executing any user code (so `sys.path.insert` inside
+`app/ui/launcher/__main__.py` is too late to fix the import).
+
+This shim resolves the repo root from its own `__file__`, prepends it to
+`sys.path`, and then performs a normal import — guaranteed to succeed regardless
+of cwd. Portable installers and post-install steps should call this file by
+absolute path rather than the `-m` form.
+"""
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from app.ui.launcher.main import main
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,11 +1,44 @@
-from app.ui import main_ui
-from PySide6 import QtWidgets
 import sys
+import traceback
+from datetime import datetime
+from pathlib import Path
 
-import qdarktheme
-from app.ui.core.proxy_style import ProxyStyle
 
-if __name__ == "__main__":
+def _write_crash_log(exc: BaseException) -> Path:
+    """Persist a full traceback to disk so the diagnostic survives even if the
+    console window closes before the user can copy it.
+
+    Returns the path of the written log so the caller can print it.
+    """
+    log_dir = Path(__file__).resolve().parent / "crash_logs"
+    log_dir.mkdir(exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_path = log_dir / f"crash_{stamp}.log"
+    with open(log_path, "w", encoding="utf-8") as f:
+        f.write(f"VisoMaster crash report — {datetime.now().isoformat()}\n")
+        f.write("=" * 70 + "\n")
+        try:
+            import platform
+
+            f.write(f"Python:   {sys.version}\n")
+            f.write(f"Platform: {platform.platform()}\n")
+        except Exception:
+            pass
+        f.write("=" * 70 + "\n\n")
+        traceback.print_exception(type(exc), exc, exc.__traceback__, file=f)
+    return log_path
+
+
+def _run_app() -> None:
+    """Boot the Qt app. Imports are inside the function so any startup error is
+    captured by the outer try/except (otherwise a top-level import error would
+    bypass the crash-log writer)."""
+    from app.ui import main_ui
+    from PySide6 import QtWidgets
+
+    import qdarktheme
+    from app.ui.core.proxy_style import ProxyStyle
+
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle(ProxyStyle())
     with open("app/ui/styles/true_dark_styles.qss", "r") as f:
@@ -21,3 +54,21 @@ if __name__ == "__main__":
     window = main_ui.MainWindow()
     window.show()
     app.exec()
+
+
+if __name__ == "__main__":
+    try:
+        _run_app()
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        log_path = _write_crash_log(e)
+        print("\n" + "=" * 70)
+        print("[FATAL] VisoMaster crashed.")
+        print("  Crash log written to:")
+        print(f"    {log_path}")
+        print(f"  Error: {e}")
+        print("=" * 70)
+        print("\nFull traceback:")
+        traceback.print_exc()
+        sys.exit(1)

--- a/tests/unit/processors/test_video_processor_scan.py
+++ b/tests/unit/processors/test_video_processor_scan.py
@@ -5,6 +5,41 @@ import numpy as np
 import pytest
 
 from app.processors.video_processor import VideoProcessor
+from app.processors.video_utils.sequential_detector import SequentialDetector
+
+
+def _setup_sequential_detector(
+    processor,
+    *,
+    last_detected_faces=None,
+    smoothed_kps=None,
+    smoothed_dense_kps=None,
+    smoothed_dense_kps_203=None,
+):
+    """Attach a real SequentialDetector to a bare-constructed processor.
+
+    PR #176 moved the temporal-smoothing state (last_detected_faces /
+    _smoothed_kps / _smoothed_dense_kps / _smoothed_dense_kps_203) and the
+    per-frame detection logic out of VideoProcessor into a dedicated
+    SequentialDetector class. Tests that build their VideoProcessor via
+    __new__() must wire up the corresponding attribute on the processor.
+
+    Returns the attached SequentialDetector so callers can patch its `run`
+    method or read its state in assertions.
+    """
+    sd = SequentialDetector(processor.main_window)
+    sd.last_detected_faces = (
+        list(last_detected_faces) if last_detected_faces is not None else []
+    )
+    sd._smoothed_kps = dict(smoothed_kps) if smoothed_kps is not None else {}
+    sd._smoothed_dense_kps = (
+        dict(smoothed_dense_kps) if smoothed_dense_kps is not None else {}
+    )
+    sd._smoothed_dense_kps_203 = (
+        dict(smoothed_dense_kps_203) if smoothed_dense_kps_203 is not None else {}
+    )
+    processor.sequential_detector = sd
+    return sd
 
 
 class _DummyCapture:
@@ -170,11 +205,6 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
     processor.media_rotation = 0
     processor.fps = 30.0
     processor.current_frame_number = 0
-    processor.last_detected_faces = [{"id": 1}]
-    processor._smoothed_kps = {1: np.array([[1.0, 2.0]], dtype=np.float32)}
-    processor._smoothed_dense_kps = {1: np.array([[3.0, 4.0]], dtype=np.float32)}
-    processor._smoothed_dense_kps_203 = {1: np.array([[5.0, 6.0]], dtype=np.float32)}
-    processor.last_detected_faces = [{"id": 1}]
     processor.main_window = SimpleNamespace(
         control={},
         parameters={},
@@ -182,6 +212,13 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
         dropped_frames=set(),
         markers={},
         videoSeekSlider=SimpleNamespace(value=lambda: 7),
+    )
+    sd = _setup_sequential_detector(
+        processor,
+        last_detected_faces=[{"id": 1}],
+        smoothed_kps={1: np.array([[1.0, 2.0]], dtype=np.float32)},
+        smoothed_dense_kps={1: np.array([[3.0, 4.0]], dtype=np.float32)},
+        smoothed_dense_kps_203={1: np.array([[5.0, 6.0]], dtype=np.float32)},
     )
     processor._get_target_input_height = lambda: 256
 
@@ -207,16 +244,16 @@ def test_scan_issue_frames_restores_dense_smoothing_state():
         "cancelled": False,
     }
     np.testing.assert_array_equal(
-        processor._smoothed_dense_kps[1], np.array([[3.0, 4.0]], dtype=np.float32)
+        sd._smoothed_dense_kps[1], np.array([[3.0, 4.0]], dtype=np.float32)
     )
     np.testing.assert_array_equal(
-        processor._smoothed_kps[1], np.array([[1.0, 2.0]], dtype=np.float32)
+        sd._smoothed_kps[1], np.array([[1.0, 2.0]], dtype=np.float32)
     )
     np.testing.assert_array_equal(
-        processor._smoothed_dense_kps_203[1],
+        sd._smoothed_dense_kps_203[1],
         np.array([[5.0, 6.0]], dtype=np.float32),
     )
-    assert processor.last_detected_faces == [{"id": 1}]
+    assert sd.last_detected_faces == [{"id": 1}]
     assert processor.current_frame_number == 3
 
 
@@ -226,10 +263,6 @@ def test_scan_issue_frames_rejects_when_marker_enables_vr180():
     processor.media_rotation = 0
     processor.fps = 30.0
     processor.current_frame_number = 0
-    processor.last_detected_faces = []
-    processor._smoothed_kps = {}
-    processor._smoothed_dense_kps = {}
-    processor._smoothed_dense_kps_203 = {}
     processor.main_window = SimpleNamespace(
         control={"VR180ModeEnableToggle": False},
         parameters={},
@@ -238,6 +271,7 @@ def test_scan_issue_frames_rejects_when_marker_enables_vr180():
         markers={10: {"control": {"VR180ModeEnableToggle": True}}},
         videoSeekSlider=SimpleNamespace(value=lambda: 0),
     )
+    _setup_sequential_detector(processor)
 
     with pytest.raises(RuntimeError, match="Issue scans are not supported"):
         processor.scan_issue_frames(
@@ -515,10 +549,6 @@ def test_scan_issue_frames_filters_scan_state_before_detection():
     processor.media_rotation = 0
     processor.fps = 30.0
     processor.current_frame_number = 0
-    processor.last_detected_faces = []
-    processor._smoothed_kps = {}
-    processor._smoothed_dense_kps = {}
-    processor._smoothed_dense_kps_203 = {}
     frame = np.zeros((4, 4, 3), dtype=np.uint8)
     captured = {}
 
@@ -533,17 +563,20 @@ def test_scan_issue_frames_filters_scan_state_before_detection():
         default_parameters=SimpleNamespace(data={"SimilarityThresholdSlider": 50}),
         models_processor=SimpleNamespace(device="cpu"),
     )
+    sd = _setup_sequential_detector(processor)
     processor._get_target_input_height = lambda: 256
 
-    def fake_run_sequential_detection(
-        _frame_rgb,
-        local_control,
-        local_params,
+    def fake_run(
+        frame_rgb=None,
+        local_control_for_worker=None,
+        local_params_for_worker=None,
+        is_master_edit_active=False,
         frame_tensor=None,
         detector_control_override=None,
+        frame_number=-1,
     ):
-        captured["local_control"] = local_control
-        captured["local_params"] = local_params
+        captured["local_control"] = local_control_for_worker
+        captured["local_params"] = local_params_for_worker
         captured["detector_control_override"] = detector_control_override
         return _empty_scan_detection_result()
 
@@ -558,11 +591,7 @@ def test_scan_issue_frames_filters_scan_state_before_detection():
         ),
         patch("app.processors.video_processor.misc_helpers.seek_frame"),
         patch("app.processors.video_processor.misc_helpers.release_capture"),
-        patch.object(
-            processor,
-            "_run_sequential_detection",
-            side_effect=fake_run_sequential_detection,
-        ),
+        patch.object(sd, "run", side_effect=fake_run),
     ):
         result = processor.scan_issue_frames(
             scan_ranges=[(0, 0)],


### PR DESCRIPTION
# Memory / cache hygiene

- Equirec2Perspec_vr.py: Split clear_persp_cache() into clear_persp_grid_cache() (cheap) and
clear_rotation_matrix_cache() (heavy, GPU); kept umbrella for back-compat.
- video_processor.py: join_and_clear_threads(clear_module_caches=True) now skips cache wipes when called at session
start (process_video()), preserving warm caches across pool restarts.

# Auto-mouth × color-transfer interaction (Correction 1.4 — actual root cause)

- swapper_layout_data.py: Added enable_refresh_frame: False to both AutoColorEnableToggle and
EndingColorTransferEnableToggle — sidesteps the bbox-corruption chain.
- frame_worker.py: Made det_faces_data_for_display rescale idempotent via _displayspace_rescaled flag.
- mouth_openness.py: Added single_frame_mode kwarg to update() — no occlusion penalty when re-evaluating a stopped
frame.
- frame_worker.py: _apply_auto_mouth now passes single_frame_mode=self.is_single_frame through.

# Auto-mouth on sub-512 px videos

- frame_worker.py _detect_mouth_action_score: detects upscaled-space bbox + un-upscaled self.frame mismatch and
rescales the bbox before cropping.

# Side-angle face landmark corruption

- face_landmark_detectors.py: Added _kps5_is_degenerate() helper; run_detect_landmark now disables from_points when
the 5 keypoints are near-collinear (extreme yaw).

# Sequential-detector ArcFace logic

- sequential_detector.py: New 4-tier filter:
a. Webcam fast-path (FastPathSingleFaceToggle, default True) — skip ArcFace when scene has 1 face + 1 target.
b. Strict ArcFace (existing).
c. Relaxed-threshold ArcFace — re-runs with SimilarityThresholdSlider × 0.5 (floored at 20).
d. Single-face last-resort (existing).

# Portable launcher

- launcher.py (new at repo root): path-based shim that fixes its own sys.path before importing app. Fixes
ModuleNotFoundError: No module named 'app' regardless of cwd. (Release-side start_portable.bat should call this
instead of python -m app.ui.launcher.)


# Thumbnails

- common_actions.py: Thumbnail freshness check via mtime comparison; stale cache forces regeneration.
- video_processor.py: _log_hevc_thumbnail_hint_once() — one-time print after recording finishes pointing at the
Microsoft Store HEVC Video Extensions package for Windows Explorer thumbnails.


# BYTETracker.removed_stracks unbounded list growth (app/processors/external/yolox/tracker/byte_tracker.py).

bug: every track that ended (occlusion, scene cut, end-of-life) was .extend()-ed onto self.removed_stracks as a
full STrack object — and never pruned for the lifetime of the tracker. Each STrack carries a Kalman 8-vector mean, an
8×8 covariance matrix, _tlwh, references back to the kalman_filter, and metadata — roughly 1 KB per dead track. For
long videos with crowds (people entering/leaving frame), this accumulates many MB of dead Python objects across the
job AND makes sub_stracks linear-scans slower over time.

symptoms:
- "renders slow to a crawl after a while" → linear-scan over the growing list inside sub_stracks
- progressive RAM allocation during long jobs → accumulating dead STrack objects

fix: replaced self.removed_stracks: list[STrack] with self._removed_track_ids: set[int]:
- sub_stracks(self.lost_stracks, self.removed_stracks) → inline [t for t in self.lost_stracks if t.track_id not in
self._removed_track_ids]
- self.removed_stracks.extend(removed_stracks) → for _t in removed_stracks: self._removed_track_ids.add(_t.track_id)
- Added a @property removed_stracks that returns [] for any external code that might read the attribute (defensive —
none found in this repo).

VR detection

- settings_layout_data.py: VR180TileDetectionToggle default flipped to True; help text updated. Helps the "head tilted
back / near pole" detection failures.
