### PR TITLE
Landmark fixes in SequentialDetector and FaceDetectors, ensuring that…

### DIFF
--- a/app/processors/face_detectors.py
+++ b/app/processors/face_detectors.py
@@ -420,11 +420,13 @@ class FaceDetectors:
                     landmark_kpss if len(landmark_kpss) > 0 else kpss_5[i]
                 )
                 # If the new landmarks have a higher confidence, replace the old 5-point landmarks.
-                if len(landmark_kpss_5) > 0 and (
-                    len(landmark_scores) == 0
-                    or np.mean(landmark_scores) > np.mean(score_values[i])
-                ):
-                    kpss_5[i] = landmark_kpss_5
+                if len(landmark_kpss_5) > 0:
+                    if (
+                        landmark_detect_mode == "478"
+                        or len(landmark_scores) == 0
+                        or np.mean(landmark_scores) > np.mean(score_values[i])
+                    ):
+                        kpss_5[i] = landmark_kpss_5
             kpss = np.array(refined_kpss, dtype=object)
         return det, kpss_5, kpss, score_values
 

--- a/app/processors/video_utils/sequential_detector.py
+++ b/app/processors/video_utils/sequential_detector.py
@@ -316,18 +316,26 @@ class SequentialDetector:
             has_valid_203 = False
 
             if requires_203:
-                _, lm_203, _ = self.main_window.models_processor.run_detect_landmark(
-                    frame_tensor,
-                    current_bbox,
-                    current_kps5,
-                    detect_mode="203",
-                    score=0.5,
-                    use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
-                    from_points=True,  # STRICTLY REQUIRED FOR INTERNAL ALIGNMENT
+                lm_203_5, lm_203, _ = (
+                    self.main_window.models_processor.run_detect_landmark(
+                        frame_tensor,
+                        current_bbox,
+                        current_kps5,
+                        detect_mode="203",
+                        score=0.5,
+                        use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
+                        from_points=True,  # STRICTLY REQUIRED FOR INTERNAL ALIGNMENT
+                    )
                 )
                 if len(lm_203) > 0:
                     kps_203_local = lm_203
                     has_valid_203 = True
+
+                    # If 203 was extracted for fallback, but the user ALSO selected 203
+                    # as their primary UI model, update the Swapper's 5 points immediately.
+                    if landmark_mode == "203" and len(lm_203_5) > 0:
+                        filtered_kpss_5[i] = lm_203_5
+
                 filtered_kpss_203.append(kps_203_local)
 
             # FW-LOGIC-FIX 2: Extract standard dense landmarks (68, 203 or 478 depending on UI selection)
@@ -342,8 +350,9 @@ class SequentialDetector:
                     and from_points
                 ):
                     kps_standard = kps_203_local.copy()
+                    # (filtered_kpss_5[i] is already updated in the block above)
                 else:
-                    _, lm_kpss, _ = (
+                    lm_std_5, lm_kpss, _ = (
                         self.main_window.models_processor.run_detect_landmark(
                             frame_tensor,
                             current_bbox,
@@ -356,6 +365,9 @@ class SequentialDetector:
                     )
                     if len(lm_kpss) > 0:
                         kps_standard = lm_kpss
+                        # Sync the 5-point array with the refined outputs
+                        if len(lm_std_5) > 0:
+                            filtered_kpss_5[i] = lm_std_5
 
             filtered_kpss.append(kps_standard)
 

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -2101,32 +2101,39 @@ class FrameWorker(threading.Thread):
                         else:
                             # FORCE from_points=True: Strictly required for the geometric
                             # alignment of advanced tools (FaceEditor, Makeup, Expressions).
-                            _, lm_203, _ = self.models_processor.run_detect_landmark(
-                                img,
-                                bboxes[idx],
-                                kpss_5[idx],
-                                detect_mode="203",
-                                score=0.5,
-                                use_mean_eyes=control.get(
-                                    "LandmarkMeanEyesToggle", False
-                                ),
-                                from_points=True,  # STRICTLY REQUIRED HERE
+                            lm_203_5, lm_203, _ = (
+                                self.models_processor.run_detect_landmark(
+                                    img,
+                                    bboxes[idx],
+                                    kpss_5[idx],
+                                    detect_mode="203",
+                                    score=0.5,
+                                    use_mean_eyes=control.get(
+                                        "LandmarkMeanEyesToggle", False
+                                    ),
+                                    from_points=True,  # STRICTLY REQUIRED HERE
+                                )
                             )
                             kps_203_local = (
                                 lm_203
                                 if len(lm_203) > 0
                                 else np.zeros((203, 2), dtype=np.float32)
                             )
+
+                            # If Step 1 failed and user actually requested 203 for the swap,
+                            # ensure we update the Swapper's 5 points right now.
+                            if (
+                                landmark_mode == "203"
+                                and not has_valid_dense_kpss
+                                and len(lm_203_5) > 0
+                            ):
+                                kpss_5[idx] = lm_203_5
+
                         kpss_203_list.append(kps_203_local)
                 kpss_203 = np.array(kpss_203_list, dtype=object)
 
-            # --- STEP 3: Fallback for standard landmarks (UI Display) ---
-            if (
-                use_landmark
-                and not has_valid_dense_kpss
-                and bboxes is not None
-                and len(bboxes) > 0
-            ):
+            # --- STEP 3: Fallback for standard landmarks (UI Display & Swap Alignment) ---
+            if use_landmark and not has_valid_dense_kpss and len(bboxes) > 0:
                 kpss_list = []
                 for idx in range(len(bboxes)):
                     # Smart reuse: If Step 2 just computed 203 landmarks, use them
@@ -2139,7 +2146,7 @@ class FrameWorker(threading.Thread):
                         kpss_list.append(kpss_203[idx])
                     else:
                         # Respects the UI toggle state for standard UI landmarks
-                        _, lm_std, _ = self.models_processor.run_detect_landmark(
+                        lm_std_5, lm_std, _ = self.models_processor.run_detect_landmark(
                             img,
                             bboxes[idx],
                             kpss_5[idx],
@@ -2148,11 +2155,15 @@ class FrameWorker(threading.Thread):
                             use_mean_eyes=control.get("LandmarkMeanEyesToggle", False),
                             from_points=from_points,
                         )
-                        kpss_list.append(
-                            lm_std
-                            if len(lm_std) > 0
-                            else np.zeros((int(landmark_mode), 2), dtype=np.float32)
-                        )
+
+                        if len(lm_std) > 0:
+                            kpss_list.append(lm_std)
+                            if len(lm_std_5) > 0:
+                                kpss_5[idx] = lm_std_5
+                        else:
+                            kpss_list.append(
+                                np.zeros((int(landmark_mode), 2), dtype=np.float32)
+                            )
                 kpss = np.array(kpss_list, dtype=object)
 
         if (


### PR DESCRIPTION
… the 5-point landmarks used for tracking are updated whenever a more detailed landmark detection (203 or 478) is successfully performed. This keeps the tracking aligned with the refined detections and prevents drift over time.