### PR TITLE
Add support for gpu selection for users with multiple gpus

### DIFF
--- a/app/processors/face_detectors.py
+++ b/app/processors/face_detectors.py
@@ -456,9 +456,9 @@ class FaceDetectors:
         try:
             # PRE-INFERENCE SYNC: Ensure PyTorch has finished preparing the memory
             # before ONNX Runtime starts reading from the IOBinding pointers.
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             ort_session.run_with_iobinding(io_binding)
@@ -466,9 +466,9 @@ class FaceDetectors:
             # POST-INFERENCE SYNC : Ensure the GPU has completed all
             # calculations before ONNX Runtime attempts to copy the result back to CPU RAM.
             # Without this, copy_outputs_to_cpu() might grab an incomplete tensor.
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             net_outs = io_binding.copy_outputs_to_cpu()
@@ -809,8 +809,8 @@ class FaceDetectors:
             io_binding = ort_session.io_binding()
             io_binding.bind_input(
                 name="input.1",
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=aimg.size(),
                 buffer_ptr=aimg.data_ptr(),
@@ -826,7 +826,7 @@ class FaceDetectors:
                 "477",
                 "500",
             ]:
-                io_binding.bind_output(i, self.models_processor.device)
+                io_binding.bind_output(i, self.models_processor.device_type, self.models_processor.binding_device_id)
             # Run the model with lazy build handling
             net_outs = self._run_model_with_lazy_build_check(
                 model_name, ort_session, io_binding
@@ -999,14 +999,14 @@ class FaceDetectors:
 
             io_binding.bind_input(
                 name=input_name,
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=aimg.size(),
                 buffer_ptr=aimg.data_ptr(),
             )
             for name in output_names:
-                io_binding.bind_output(name, self.models_processor.device)
+                io_binding.bind_output(name, self.models_processor.device_type, self.models_processor.binding_device_id)
 
             # Run the model with lazy build handling
             net_outs = self._run_model_with_lazy_build_check(
@@ -1182,13 +1182,13 @@ class FaceDetectors:
             io_binding = ort_session.io_binding()
             io_binding.bind_input(
                 name="images",
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=aimg_prepared.size(),  # Use shape of prepared tensor
                 buffer_ptr=aimg_prepared.data_ptr(),  # Use data_ptr of prepared tensor
             )
-            io_binding.bind_output("output0", self.models_processor.device)
+            io_binding.bind_output("output0", self.models_processor.device_type, self.models_processor.binding_device_id)
             # Run the model with lazy build handling
             net_outs = self._run_model_with_lazy_build_check(
                 model_name, ort_session, io_binding
@@ -1350,14 +1350,14 @@ class FaceDetectors:
 
             io_binding.bind_input(
                 name=input_name,
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=aimg_prepared.size(),  # Use shape of prepared tensor
                 buffer_ptr=aimg_prepared.data_ptr(),  # Use data_ptr of prepared tensor
             )
             for name in output_names:
-                io_binding.bind_output(name, self.models_processor.device)
+                io_binding.bind_output(name, self.models_processor.device_type, self.models_processor.binding_device_id)
 
             # Run the model with lazy build handling
             net_outs = self._run_model_with_lazy_build_check(

--- a/app/processors/face_editors.py
+++ b/app/processors/face_editors.py
@@ -155,8 +155,8 @@ class FaceEditors:
         for name, tensor in inputs.items():
             io_binding.bind_input(
                 name=name,
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=tensor.size(),
                 buffer_ptr=tensor.data_ptr(),
@@ -166,8 +166,8 @@ class FaceEditors:
         for name, tensor in output_spec.items():
             io_binding.bind_output(
                 name=name,
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=tensor.size(),
                 buffer_ptr=tensor.data_ptr(),
@@ -185,9 +185,9 @@ class FaceEditors:
         try:
             # PRE-INFERENCE SYNC: Ensure PyTorch has finished preparing the memory
             # before ONNX Runtime starts reading from the IOBinding pointers.
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             model.run_with_iobinding(io_binding)

--- a/app/processors/face_landmark_detectors.py
+++ b/app/processors/face_landmark_detectors.py
@@ -420,8 +420,8 @@ class FaceLandmarkDetectors:
         for name, tensor in input_bindings.items():
             io_binding.bind_input(
                 name=name,
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=tensor.size(),
                 buffer_ptr=tensor.data_ptr(),
@@ -429,7 +429,7 @@ class FaceLandmarkDetectors:
 
         # Bind outputs. The device will allocate memory for them.
         for name in output_names:
-            io_binding.bind_output(name, self.models_processor.device)
+            io_binding.bind_output(name, self.models_processor.device_type, self.models_processor.binding_device_id)
 
         # --- LAZY BUILD CHECK ---
         is_lazy_build = self.models_processor.check_and_clear_pending_build(model_name)
@@ -443,9 +443,9 @@ class FaceLandmarkDetectors:
         try:
             # PRE-INFERENCE SYNC: Ensure PyTorch has finished preparing the memory
             # before ONNX Runtime starts reading from the IOBinding pointers.
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             # Run inference
@@ -454,9 +454,9 @@ class FaceLandmarkDetectors:
             # POST-INFERENCE SYNC : Ensure the GPU has completed all
             # calculations before ONNX Runtime attempts to copy the result back to CPU RAM.
             # Without this, copy_outputs_to_cpu() might grab an incomplete tensor.
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             # Copy results back to CPU safely

--- a/app/processors/face_masks.py
+++ b/app/processors/face_masks.py
@@ -76,16 +76,16 @@ class FaceMasks:
         io = ort_session.io_binding()
         io.bind_input(
             "input",
-            self.models_processor.device,
-            0,
+            self.models_processor.device_type,
+            self.models_processor.binding_device_id,
             np.float32,
             (1, 3, 512, 512),
             x.data_ptr(),
         )
         io.bind_output(
             "output",
-            self.models_processor.device,
-            0,
+            self.models_processor.device_type,
+            self.models_processor.binding_device_id,
             np.float32,
             (1, 19, 512, 512),
             out.data_ptr(),
@@ -101,9 +101,9 @@ class FaceMasks:
 
         try:
             # PRE-INFERENCE SYNC: Ensure PyTorch memory is ready
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             ort_session.run_with_iobinding(io)
@@ -1066,16 +1066,16 @@ class FaceMasks:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="img",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 1, 256, 256),
             buffer_ptr=output.data_ptr(),
@@ -1090,9 +1090,9 @@ class FaceMasks:
 
         try:
             # PRE-INFERENCE SYNC
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             ort_session.run_with_iobinding(io_binding)
@@ -1280,16 +1280,16 @@ class FaceMasks:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="in_face:0",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=image.size(),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="out_mask:0",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 1, 256, 256),
             buffer_ptr=output.data_ptr(),
@@ -1304,9 +1304,9 @@ class FaceMasks:
 
         try:
             # PRE-INFERENCE SYNC
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             ort_session.run_with_iobinding(io_binding)
@@ -1333,16 +1333,16 @@ class FaceMasks:
 
         io_binding.bind_input(
             name=input_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=image_tensor.shape,
             buffer_ptr=image_tensor.data_ptr(),
         )
         io_binding.bind_output(
             name=output_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=output_tensor.shape,
             buffer_ptr=output_tensor.data_ptr(),
@@ -1357,9 +1357,9 @@ class FaceMasks:
 
         try:
             # PRE-INFERENCE SYNC
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 self.models_processor.syncvec.cpu()
 
             sess.run_with_iobinding(io_binding)

--- a/app/processors/face_restorers.py
+++ b/app/processors/face_restorers.py
@@ -77,9 +77,9 @@ class FaceRestorers:
         try:
             # ⚠️ This is a critical synchronization point.
             # PRE-INFERENCE SYNC
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 # This handles synchronization for other execution providers (e.g., DirectML)
                 # by synchronizing with a placeholder vector.
                 self.models_processor.syncvec.cpu()
@@ -335,16 +335,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name=input_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=tuple(image_input_tensor.shape),
             buffer_ptr=image_input_tensor.data_ptr(),
         )
         io_binding.bind_output(
             name=output_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=tuple(output_latent_tensor.shape),
             buffer_ptr=output_latent_tensor.data_ptr(),
@@ -387,16 +387,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name=input_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=tuple(latent_input_tensor.shape),
             buffer_ptr=latent_input_tensor.data_ptr(),
         )
         io_binding.bind_output(
             name=output_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=tuple(output_image_tensor.shape),
             buffer_ptr=output_image_tensor.data_ptr(),
@@ -432,8 +432,9 @@ class FaceRestorers:
         onnx_output_name = "unet_output"
 
         io_binding = ort_session.io_binding()
-        bind_device_type = self.models_processor.device
-        bind_device_id = 0
+        bind_device_type = self.models_processor.device_type
+        bind_device = self.models_processor.device
+        bind_device_id = self.models_processor.binding_device_id
 
         # Bind standard inputs
         io_binding.bind_input(
@@ -494,7 +495,7 @@ class FaceRestorers:
                 ):
                     actual_kv_tensors_for_binding[k_name_onnx] = (
                         k_tensor_original.unsqueeze(0)
-                        .to(device=bind_device_type, dtype=torch.float32)
+                        .to(device=bind_device, dtype=torch.float32)
                         .contiguous()
                     )
 
@@ -504,7 +505,7 @@ class FaceRestorers:
                 ):
                     actual_kv_tensors_for_binding[v_name_onnx] = (
                         v_tensor_original.unsqueeze(0)
-                        .to(device=bind_device_type, dtype=torch.float32)
+                        .to(device=bind_device, dtype=torch.float32)
                         .contiguous()
                     )
 
@@ -519,7 +520,7 @@ class FaceRestorers:
             if tensor_to_bind is None:
                 # Create a zero tensor for missing K/V inputs (e.g., unconditional pass)
                 tensor_to_bind = torch.zeros(
-                    expected_shape, dtype=torch.float32, device=bind_device_type
+                    expected_shape, dtype=torch.float32, device=bind_device
                 ).contiguous()
                 # We MUST store this tensor in a list that persists for the function scope
                 # Otherwise, it might be garbage collected before .run() is called
@@ -556,16 +557,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=output.data_ptr(),
@@ -584,16 +585,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 1024, 1024),
             buffer_ptr=output.data_ptr(),
@@ -612,16 +613,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=output.data_ptr(),
@@ -640,16 +641,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=output.data_ptr(),
@@ -668,16 +669,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 1024, 1024),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 1024, 1024),
             buffer_ptr=output.data_ptr(),
@@ -696,16 +697,16 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 2048, 2048),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 2048, 2048),
             buffer_ptr=output.data_ptr(),
@@ -723,8 +724,8 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="x",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=image.data_ptr(),
@@ -733,8 +734,8 @@ class FaceRestorers:
         io_binding.bind_cpu_input("w", w)
         io_binding.bind_output(
             name="y",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=output.data_ptr(),
@@ -761,27 +762,27 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="x_lq",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=image.size(),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_input(
             name="fidelity_ratio",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=fidelity_ratio.size(),
             buffer_ptr=fidelity_ratio.data_ptr(),
         )
-        io_binding.bind_output("enc_feat", self.models_processor.device)
-        io_binding.bind_output("quant_logit", self.models_processor.device)
-        io_binding.bind_output("texture_dec", self.models_processor.device)
+        io_binding.bind_output("enc_feat", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("quant_logit", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("texture_dec", self.models_processor.device_type, self.models_processor.binding_device_id)
         io_binding.bind_output(
             name="main_dec",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=output.data_ptr(),
@@ -799,34 +800,34 @@ class FaceRestorers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=image.size(),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_output(
             name="2359",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=output.size(),
             buffer_ptr=output.data_ptr(),
         )
-        io_binding.bind_output("1228", self.models_processor.device)
-        io_binding.bind_output("1238", self.models_processor.device)
-        io_binding.bind_output("onnx::MatMul_1198", self.models_processor.device)
-        io_binding.bind_output("onnx::Shape_1184", self.models_processor.device)
-        io_binding.bind_output("onnx::ArgMin_1182", self.models_processor.device)
-        io_binding.bind_output("input.1", self.models_processor.device)
-        io_binding.bind_output("x", self.models_processor.device)
-        io_binding.bind_output("x.3", self.models_processor.device)
-        io_binding.bind_output("x.7", self.models_processor.device)
-        io_binding.bind_output("x.11", self.models_processor.device)
-        io_binding.bind_output("x.15", self.models_processor.device)
-        io_binding.bind_output("input.252", self.models_processor.device)
-        io_binding.bind_output("input.280", self.models_processor.device)
-        io_binding.bind_output("input.288", self.models_processor.device)
+        io_binding.bind_output("1228", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("1238", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("onnx::MatMul_1198", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("onnx::Shape_1184", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("onnx::ArgMin_1182", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("input.1", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("x", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("x.3", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("x.7", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("x.11", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("x.15", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("input.252", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("input.280", self.models_processor.device_type, self.models_processor.binding_device_id)
+        io_binding.bind_output("input.288", self.models_processor.device_type, self.models_processor.binding_device_id)
 
         # Run the model with lazy build handling
         self._run_model_with_lazy_build_check(model_name, ort_session, io_binding)

--- a/app/processors/face_swappers.py
+++ b/app/processors/face_swappers.py
@@ -92,9 +92,9 @@ class FaceSwappers:
         try:
             # ⚠️ This is a critical synchronization point.
             # PRE-INFERENCE SYNC
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
-            elif self.models_processor.device != "cpu":
+            elif self.models_processor.device_type != "cpu":
                 # This handles synchronization for other execution providers (e.g., DirectML)
                 self.models_processor.syncvec.cpu()
 
@@ -218,15 +218,15 @@ class FaceSwappers:
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
             name=input_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=img.size(),
             buffer_ptr=img.data_ptr(),
         )
 
         for name in output_names:
-            io_binding.bind_output(name, self.models_processor.device)
+            io_binding.bind_output(name, self.models_processor.device_type, self.models_processor.binding_device_id)
 
         self._run_model_with_lazy_build_check(arcface_model, ort_session, io_binding)
 
@@ -290,13 +290,13 @@ class FaceSwappers:
 
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=img.size(),
             buffer_ptr=img.data_ptr(),
         )
-        io_binding.bind_output(name="output", device_type=self.models_processor.device)
+        io_binding.bind_output(name="output", device_type=self.models_processor.device_type, device_id=self.models_processor.binding_device_id)
 
         self._run_model_with_lazy_build_check(model_name, model, io_binding)
 
@@ -335,13 +335,13 @@ class FaceSwappers:
 
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=img.size(),
             buffer_ptr=img.data_ptr(),
         )
-        io_binding.bind_output(name="output", device_type=self.models_processor.device)
+        io_binding.bind_output(name="output", device_type=self.models_processor.device_type, device_id=self.models_processor.binding_device_id)
 
         self._run_model_with_lazy_build_check(model_name, model, io_binding)
 
@@ -381,24 +381,24 @@ class FaceSwappers:
         # Hardcoded IO names validated by standard CSCS export
         io_binding.bind_input(
             name="input_1",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_input(
             name="input_2",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 512),
             buffer_ptr=embedding.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=output.data_ptr(),
@@ -464,24 +464,24 @@ class FaceSwappers:
 
         io_binding.bind_input(
             name="target",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 128, 128),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_input(
             name="source",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 512),
             buffer_ptr=embedding.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 128, 128),
             buffer_ptr=output.data_ptr(),
@@ -515,24 +515,24 @@ class FaceSwappers:
             io_binding.clear_binding_outputs()
             io_binding.bind_input(
                 name="target",
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=(1, 3, 128, 128),
                 buffer_ptr=img.data_ptr(),
             )
             io_binding.bind_input(
                 name="source",
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=(1, 512),
                 buffer_ptr=emb.data_ptr(),
             )
             io_binding.bind_output(
                 name="output",
-                device_type=self.models_processor.device,
-                device_id=0,
+                device_type=self.models_processor.device_type,
+                device_id=self.models_processor.binding_device_id,
                 element_type=np.float32,
                 shape=(1, 3, 128, 128),
                 buffer_ptr=out.data_ptr(),
@@ -564,24 +564,24 @@ class FaceSwappers:
         io_binding = model.io_binding()
         io_binding.bind_input(
             name="target",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_input(
             name="source",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 512),
             buffer_ptr=embedding.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=output.data_ptr(),
@@ -606,24 +606,24 @@ class FaceSwappers:
         io_binding = model.io_binding()
         io_binding.bind_input(
             name="input",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_input(
             name="onnx::Gemm_1",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 512),
             buffer_ptr=embedding.data_ptr(),
         )
         io_binding.bind_output(
             name="output",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 512, 512),
             buffer_ptr=output.data_ptr(),
@@ -665,24 +665,24 @@ class FaceSwappers:
         io_binding = ghostfaceswap_model.io_binding()
         io_binding.bind_input(
             name="target",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=image.data_ptr(),
         )
         io_binding.bind_input(
             name="source",
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 512),
             buffer_ptr=embedding.data_ptr(),
         )
         io_binding.bind_output(
             name=output_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=(1, 3, 256, 256),
             buffer_ptr=output.data_ptr(),

--- a/app/processors/frame_enhancers.py
+++ b/app/processors/frame_enhancers.py
@@ -79,12 +79,12 @@ class FrameEnhancers:
             )
 
         try:
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
 
             ort_session.run_with_iobinding(io_binding)
 
-            if self.models_processor.device == "cuda":
+            if self.models_processor.device_type == "cuda":
                 torch.cuda.current_stream().synchronize()
         finally:
             # Always hide the dialog, even if the run fails
@@ -257,8 +257,8 @@ class FrameEnhancers:
         # Bind input tensor
         io_binding.bind_input(
             name=input_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=image.size(),
             buffer_ptr=image.data_ptr(),
@@ -266,8 +266,8 @@ class FrameEnhancers:
         # Bind output tensor
         io_binding.bind_output(
             name=output_name,
-            device_type=self.models_processor.device,
-            device_id=0,
+            device_type=self.models_processor.device_type,
+            device_id=self.models_processor.binding_device_id,
             element_type=np.float32,
             shape=output.size(),
             buffer_ptr=output.data_ptr(),

--- a/app/processors/models_processor.py
+++ b/app/processors/models_processor.py
@@ -117,14 +117,21 @@ def _probe_onnx_model_worker(
                 # Use setattr to configure the SessionOptions object
                 setattr(session_options, key, value)
 
+        # Set the CUDA device to match the TRT provider's device_id
+        gpu_id = trt_options.get("device_id", 0)
+        if gpu_id != 0 and torch.cuda.is_available():
+            torch.cuda.set_device(gpu_id)
+
         # Reconstruct the providers tuple
         providers = []
         for p in providers_list:
-            if p == "TensorrtExecutionProvider":
-                # This worker *must* have trt_options to trigger the build
-                providers.append((p, trt_options))
-            else:
+            name = p[0] if isinstance(p, tuple) else p
+            if name == "TensorrtExecutionProvider":
+                providers.append((name, trt_options))
+            elif isinstance(p, tuple) and len(p) > 1:
                 providers.append(p)
+            else:
+                providers.append(name)
 
         print(f"[ONNX Prober]: Attempting to load {os.path.basename(model_path)}...")
         # This line is the one that triggers the build/cache generation
@@ -200,6 +207,7 @@ class ModelsProcessor(QtCore.QObject):
         """
         super().__init__()
         self.main_window = main_window
+        self.gpu_id = getattr(main_window, "gpu_id", 0)
         self.K = K  # Assign the module-level K to an instance attribute
         self.provider_name = "TensorRT"
         # NOTE: internal_deep_copied_kv_map / internal_kv_map_source_filename were
@@ -213,7 +221,10 @@ class ModelsProcessor(QtCore.QObject):
         self.internal_kv_map_source_filename: str | None = None
         self.kv_extractor: Optional[KVExtractor] = None
         self.kv_extraction_lock = threading.Lock()
-        self.device = device
+        self.device = f"{device}:{self.gpu_id}" if device != "cpu" else device
+        self.device_type = device
+        if self.gpu_id != 0 and device != "cpu":
+            torch.cuda.set_device(self.gpu_id)
         self.model_lock = threading.RLock()  # Reentrant lock for model access
 
         self.cuda_graph_capture_lock = threading.Lock()
@@ -224,7 +235,7 @@ class ModelsProcessor(QtCore.QObject):
 
         try:
             # Get total GPU memory in bytes
-            total_vram = torch.cuda.get_device_properties(0).total_memory
+            total_vram = torch.cuda.get_device_properties(self.gpu_id).total_memory
 
             # Safely allocate 40% of total VRAM for TensorRT workspace
             calculated_workspace = int(total_vram * 0.40)
@@ -237,6 +248,7 @@ class ModelsProcessor(QtCore.QObject):
 
         # Default TensorRT options
         self.trt_ep_options = {
+            "device_id": self.gpu_id,
             "trt_engine_cache_enable": True,
             "trt_engine_cache_path": "tensorrt-engines",
             "trt_timing_cache_enable": True,
@@ -252,7 +264,7 @@ class ModelsProcessor(QtCore.QObject):
         self.models_pending_build: set = set()
         self.providers = [
             ("TensorrtExecutionProvider", self.trt_ep_options),
-            ("CUDAExecutionProvider"),
+            ("CUDAExecutionProvider", {"device_id": self.gpu_id}),
             ("CPUExecutionProvider"),
         ]
         self.syncvec = torch.empty((1, 1), dtype=torch.float32, device=self.device)
@@ -511,6 +523,10 @@ class ModelsProcessor(QtCore.QObject):
         self.rgb_to_linear_rgb_converter = None
         self.linear_rgb_to_rgb_converter = None
 
+    @property
+    def binding_device_id(self) -> int:
+        return self.gpu_id if self.device_type != "cpu" else 0
+
     def _check_tensorrt_cache(self, model_name: str, onnx_path: str) -> bool:
         """
         Checks if a valid TensorRT cache (ctx and engine file) exists for the given model.
@@ -638,11 +654,9 @@ class ModelsProcessor(QtCore.QObject):
 
                                 # Use 'spawn' context for CUDA/TRT safety
                                 ctx = multiprocessing.get_context("spawn")
-                                # Use the 'providers' variable
-                                current_providers_list = [
-                                    p[0] if isinstance(p, tuple) else p
-                                    for p in model_providers
-                                ]
+                                # Pass full providers list (with tuples) so the worker
+                                # can reconstruct them with device_id options.
+                                current_providers_list = list(model_providers)
                                 probe_process = ctx.Process(
                                     target=_probe_onnx_model_worker,
                                     args=(
@@ -865,6 +879,7 @@ class ModelsProcessor(QtCore.QObject):
                     self.main_window.dfm_model_manager.get_models_data()[dfm_model],
                     dfm_providers,
                     self.device,
+                    self.gpu_id,
                 )
             except Exception:
                 print(f"[ERROR] Failed to load DFM model {dfm_model}.")
@@ -1171,10 +1186,11 @@ class ModelsProcessor(QtCore.QObject):
                     raise RuntimeError("TensorRT is not installed.")
                 providers = [
                     ("TensorrtExecutionProvider", self.trt_ep_options),
-                    ("CUDAExecutionProvider"),
+                    ("CUDAExecutionProvider", {"device_id": self.gpu_id}),
                     ("CPUExecutionProvider"),
                 ]
-                self.device = "cuda"
+                self.device = f"cuda:{self.gpu_id}"
+                self.device_type = "cuda"
                 if (
                     version.parse(trt.__version__) < version.parse("10.2.0")
                     and provider_name == "TensorRT-Engine"
@@ -1187,9 +1203,11 @@ class ModelsProcessor(QtCore.QObject):
             case "CPU":
                 providers = [("CPUExecutionProvider")]
                 self.device = "cpu"
+                self.device_type = "cpu"
             case "CUDA":
-                providers = [("CUDAExecutionProvider"), ("CPUExecutionProvider")]
-                self.device = "cuda"
+                providers = [("CUDAExecutionProvider", {"device_id": self.gpu_id}), ("CPUExecutionProvider")]
+                self.device = f"cuda:{self.gpu_id}"
+                self.device_type = "cuda"
             case _:
                 # MP-22: raise on unknown provider name
                 raise ValueError(f"Unknown provider: {provider_name}")
@@ -1217,7 +1235,7 @@ class ModelsProcessor(QtCore.QObject):
         """
         # MP-13: use a single nvidia-smi call for both total and free memory
         try:
-            command = "nvidia-smi --query-gpu=memory.total,memory.free --format=csv,noheader,nounits"
+            command = f"nvidia-smi --id={self.gpu_id} --query-gpu=memory.total,memory.free --format=csv,noheader,nounits"
             output = sp.check_output(command.split()).decode("ascii").strip()
             # Output format: "total, free" (one line per GPU)
             first_line = output.split("\n")[0]
@@ -1229,10 +1247,10 @@ class ModelsProcessor(QtCore.QObject):
         except Exception:
             # Fallback to torch.cuda if nvidia-smi is unavailable
             if torch.cuda.is_available():
-                props = torch.cuda.get_device_properties(0)
+                props = torch.cuda.get_device_properties(self.gpu_id)
                 memory_total_val = props.total_memory // (1024 * 1024)
                 memory_free_val = (
-                    props.total_memory - torch.cuda.memory_reserved(0)
+                    props.total_memory - torch.cuda.memory_reserved(self.gpu_id)
                 ) // (1024 * 1024)
                 memory_used = memory_total_val - memory_free_val
                 return memory_used, memory_total_val

--- a/app/processors/utils/dfm_model.py
+++ b/app/processors/utils/dfm_model.py
@@ -31,10 +31,12 @@ def _load_model_bytes_with_shape_inference(model_path: str) -> bytes:
 
 
 class DFMModel:
-    def __init__(self, model_path: str, providers, device="cuda"):
+    def __init__(self, model_path: str, providers, device="cuda", gpu_id=0):
         self._model_path = model_path
         self.providers = providers
         self.device = device
+        self.device_type = device.split(":")[0]
+        self.gpu_id = gpu_id
         self.syncvec = torch.empty((1, 1), dtype=torch.float32, device=device)
 
         # Run ONNX shape inference before session creation so TensorRT can
@@ -104,6 +106,10 @@ class DFMModel:
             # Add other necessary dtype mappings as needed
         }
 
+    @property
+    def binding_device_id(self) -> int:
+        return self.gpu_id if self.device_type != "cpu" else 0
+
     def get_model_path(self):
         return self._model_path
 
@@ -149,8 +155,8 @@ class DFMModel:
         # Bind input image tensor
         io_binding.bind_input(
             name="in_face:0",
-            device_type=self.device,
-            device_id=0,
+            device_type=self.device_type,
+            device_id=self.binding_device_id,
             element_type=np.float32,
             shape=img.shape,
             buffer_ptr=img.data_ptr(),
@@ -163,8 +169,8 @@ class DFMModel:
             )
             io_binding.bind_input(
                 name="morph_value:0",
-                device_type=self.device,
-                device_id=0,
+                device_type=self.device_type,
+                device_id=self.binding_device_id,
                 element_type=np.float32,
                 shape=morph_factor_t.shape,
                 buffer_ptr=morph_factor_t.data_ptr(),
@@ -190,8 +196,8 @@ class DFMModel:
             # Bind the output using ONNX Runtime's io_binding
             io_binding.bind_output(
                 name=output.name,
-                device_type=self.device,
-                device_id=0,
+                device_type=self.device_type,
+                device_id=self.binding_device_id,
                 element_type=self.onnx_to_numpy_dtype[
                     output.type
                 ],  # Use NumPy dtype for element_type
@@ -199,8 +205,10 @@ class DFMModel:
                 buffer_ptr=binding_outputs[idx].data_ptr(),
             )
 
-        if self.device == "cuda":
+        if self.device_type == "cuda":
             torch.cuda.current_stream().synchronize()
+        elif self.device_type != "cpu":
+            self.syncvec.cpu()
         self._sess.run_with_iobinding(io_binding)
 
         # Process outputs (resize, clip channels, and convert back to original dtype)

--- a/app/processors/utils/faceutil.py
+++ b/app/processors/utils/faceutil.py
@@ -127,8 +127,6 @@ arcface_src_cuda = torch.tensor(
     ],
     dtype=torch.float32,
 )  # Shape: (5, 2)
-if torch.cuda.is_available():
-    arcface_src_cuda = arcface_src_cuda.to("cuda")
 
 # F-09: module-level constant matrices for color-space conversions (avoid re-allocating per call)
 _RGB_TO_YUV = torch.tensor(

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -240,7 +240,7 @@ class FrameWorker(threading.Thread):
         self.kernel_sobel_y = self.kernel_sobel_x.transpose(2, 3)
 
         # Do not use local streams here ! Onnxruntime handles independent streams internally for each worker (fixes VRAM explosion)
-        self.worker_stream = None  # (torch.cuda.Stream() if self.models_processor.device == "cuda" else None)
+        self.worker_stream = None  # (torch.cuda.Stream() if self.models_processor.device_type == "cuda" else None)
 
     def set_scaling_transforms(self, control_params):
         """Initializes the torchvision transforms based on user interpolation settings."""
@@ -3416,7 +3416,7 @@ class FrameWorker(threading.Thread):
                         batch_input, latent, batch_output
                     )
 
-                    if self.models_processor.device == "cuda":
+                    if self.models_processor.device_type == "cuda":
                         torch.cuda.current_stream().synchronize()
 
                     # Replace any near-zero output tile with the input tile
@@ -3480,7 +3480,7 @@ class FrameWorker(threading.Thread):
                                 tile_inputs[idx], latent, tile_outputs[idx]
                             )
 
-                    if self.models_processor.device == "cuda":
+                    if self.models_processor.device_type == "cuda":
                         torch.cuda.current_stream().synchronize()
 
                     # --- MODE 2 ---
@@ -3560,7 +3560,7 @@ class FrameWorker(threading.Thread):
                             tile_inputs[idx], latent, tile_outputs[idx], version
                         )
 
-                if self.models_processor.device == "cuda":
+                if self.models_processor.device_type == "cuda":
                     torch.cuda.current_stream().synchronize()
 
                 # --- MODE 2 ---
@@ -3625,7 +3625,7 @@ class FrameWorker(threading.Thread):
                     input_face_disc, latent, swapper_output
                 )
 
-                if self.models_processor.device == "cuda":
+                if self.models_processor.device_type == "cuda":
                     torch.cuda.current_stream().synchronize()
 
                 # FW-BUG-08: use abs().max() instead of sum() for zero-face heuristic
@@ -3679,7 +3679,7 @@ class FrameWorker(threading.Thread):
                     input_face_disc, latent, swapper_output, swapper_model
                 )
 
-                if self.models_processor.device == "cuda":
+                if self.models_processor.device_type == "cuda":
                     torch.cuda.current_stream().synchronize()
 
                 swapper_output = swapper_output[0]
@@ -3742,7 +3742,7 @@ class FrameWorker(threading.Thread):
                     input_face_disc, latent, swapper_output
                 )
 
-                if self.models_processor.device == "cuda":
+                if self.models_processor.device_type == "cuda":
                     torch.cuda.current_stream().synchronize()
 
                 swapper_output = torch.squeeze(swapper_output)
@@ -3834,7 +3834,7 @@ class FrameWorker(threading.Thread):
             # We use the new dfm_inference_lock to ensure thread-safety
             with self.models_processor.dfm_inference_lock:
                 # PRE-SYNC: Ensure GPU input is ready
-                if self.models_processor.device == "cuda":
+                if self.models_processor.device_type == "cuda":
                     torch.cuda.current_stream().synchronize()
 
                 out_celeb, _, _ = dfm_model.convert(

--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -797,8 +797,9 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         if self.build_progress_dialog:
             self.build_progress_dialog.close()
 
-    def __init__(self):
+    def __init__(self, gpu_id=0):
         super(MainWindow, self).__init__()
+        self.gpu_id = gpu_id
         self.setupUi(self)
         self._base_window_title = self.windowTitle()
         self.initialize_variables()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import sys
+import argparse
 import traceback
 from datetime import datetime
 from pathlib import Path
@@ -39,7 +40,16 @@ def _run_app() -> None:
     import qdarktheme
     from app.ui.core.proxy_style import ProxyStyle
 
-    app = QtWidgets.QApplication(sys.argv)
+    parser = argparse.ArgumentParser(description="VisoMaster")
+    parser.add_argument(
+        "--gpu-id",
+        type=int,
+        default=0,
+        help="CUDA GPU device ID to use (default: 0)",
+    )
+    args, remaining = parser.parse_known_args()
+
+    app = QtWidgets.QApplication(remaining)
     app.setStyle(ProxyStyle())
     with open("app/ui/styles/true_dark_styles.qss", "r") as f:
         _style = f.read()
@@ -51,7 +61,7 @@ def _run_app() -> None:
             + _style
         )
         app.setStyleSheet(_style)
-    window = main_ui.MainWindow()
+    window = main_ui.MainWindow(gpu_id=args.gpu_id)
     window.show()
     app.exec()
 


### PR DESCRIPTION
# Purpose
For users that have more than one GPU (e.g. Laptop with RTX 4060 8GB - gpu-id 0 and eGPU-RTX 5060 Ti 16GB - gpu-id 1) and would like to select the more performant GPU (e.g. gpu-id 1)

# Changes
1. Add optional command line parameter `--gpu-id <GPU_ID>` to select the GPU.  Defaults to 0 for backwards compatibility
2. Changes hardcoding of `device_id=0` to `device_type=device_type` and `device id=gpu_id` where appropriate
3. Tested on 4060 and 5060 using TensorRT