### PR TITLE
Fix/issue 198 202 203

### DIFF
--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -4235,10 +4235,24 @@ class VideoProcessor(QObject):
         finally:
             shutil.rmtree(temp_audio_dir, ignore_errors=True)
 
+    def _auto_save_workspace_for_output(self, final_file_path: str) -> None:
+        if not self.main_window.control.get("AutoSaveWorkspaceToggle"):
+            return
+        if not final_file_path:
+            return
+
+        try:
+            save_load_actions.save_current_workspace(
+                self.main_window, f"{final_file_path}.json"
+            )
+        except Exception as e:
+            print(f"[WARN] Failed to auto-save workspace after recording: {e}")
+
     def _finalize_default_style_recording(self):
         """Finalizes a successful default-style recording (adds audio, cleans up)."""
         print("[INFO] Finalizing default-style recording...")
         temp_audio_dir: str | None = None
+        final_file_path = ""
 
         # Check if processing stopped due to error limit
         if self.stopped_by_error_limit:
@@ -4540,21 +4554,7 @@ class VideoProcessor(QObject):
                 num_frames_processed = 0
             self._log_processing_summary(processing_time_sec, num_frames_processed)
 
-            # AutoSave workspace if enabled
-            if self.main_window.control.get("AutoSaveWorkspaceToggle"):
-                output_folder = (
-                    str(getattr(self, "active_output_folder", "") or "").strip()
-                    or str(
-                        self.main_window.control.get("OutputMediaFolder", "")
-                    ).strip()
-                )
-                json_file_path = misc_helpers.get_output_file_path(
-                    self.media_path, output_folder
-                )
-                json_file_path += ".json"
-                save_load_actions.save_current_workspace(
-                    self.main_window, json_file_path
-                )
+            self._auto_save_workspace_for_output(final_file_path)
 
             # 8b. Reopen media capture AFTER FFmpeg audio merge.
             if self.file_type == "video" and self.media_path:
@@ -5221,6 +5221,9 @@ class VideoProcessor(QObject):
         finally:
             # 6. Cleanup
             self._cleanup_temp_dir()
+
+            if concatenation_successful:
+                self._auto_save_workspace_for_output(final_file_path)
 
             # 7. Reset state
             self.segments_to_process = []

--- a/app/ui/launcher/launcher_window.py
+++ b/app/ui/launcher/launcher_window.py
@@ -82,6 +82,7 @@ ACTIONS_MAINT = [
     ("Revert to Previous Version", "_go_rollback", "Select and revert to older commit"),
     ("Back", "_go_home", "Return to home screen"),
 ]
+ROLLBACK_COMMIT_LIMIT = 50
 
 
 # ---------- Update Check ----------
@@ -138,7 +139,7 @@ class LauncherWindow(QtWidgets.QWidget):
         self.update_status = self._check_and_log_update_status()
 
         update_current_commit_in_cfg()
-        self.commits = fetch_commit_list(10)
+        self.commits = fetch_commit_list(ROLLBACK_COMMIT_LIMIT)
 
         # --- Checksum state ---
         self._load_checksum_status()
@@ -577,7 +578,7 @@ class LauncherWindow(QtWidgets.QWidget):
                 run_git(["reset", "--hard", f"origin/{branch}"])
                 update_current_commit_in_cfg()
                 update_last_updated_in_cfg()
-                self.commits = fetch_commit_list(10)
+                self.commits = fetch_commit_list(ROLLBACK_COMMIT_LIMIT)
                 self._rebuild_page("page_rollback", self._build_rollback_page)
                 self._refresh_update_indicators()
                 print("[Launcher] Update complete.")
@@ -785,7 +786,7 @@ class LauncherWindow(QtWidgets.QWidget):
                 update_current_commit_in_cfg()
                 update_last_updated_in_cfg()
                 print("[Launcher] Revert complete.")
-                self.commits = fetch_commit_list(10)
+                self.commits = fetch_commit_list(ROLLBACK_COMMIT_LIMIT)
                 self._rebuild_page("page_rollback", self._build_rollback_page)
                 self._refresh_update_indicators()
                 if is_launcher_update_available():

--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -100,6 +100,27 @@ class CardButton(QPushButton):
         self.main_window: "MainWindow" = kwargs.get("main_window", False)
         self.list_item = None
         self.list_widget: QtWidgets.QListWidget = None
+        self.popMenu: QtWidgets.QMenu | None = None
+
+    def _release_context_menu(self, *action_attrs: str) -> None:
+        for attr in action_attrs:
+            action = getattr(self, attr, None)
+            if action is not None:
+                try:
+                    action.deleteLater()
+                except RuntimeError:
+                    pass
+                setattr(self, attr, None)
+        if self.popMenu is not None:
+            try:
+                self.popMenu.deleteLater()
+            except RuntimeError:
+                pass
+            self.popMenu = None
+
+    def _exec_context_menu(self, point) -> None:
+        if self.popMenu is not None:
+            self.popMenu.exec_(self.mapToGlobal(point))
 
     def _restore_pre_click_checked_state(self):
         self.blockSignals(True)
@@ -225,7 +246,6 @@ class TargetMediaCardButton(CardButton):
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         # Connect the custom context menu request signal to the custom slot
         self.customContextMenuRequested.connect(self.on_context_menu)
-        self.create_context_menu()
 
     def set_thumbnail_pixmap(self, pixmap: QtGui.QPixmap) -> None:
         self._thumbnail_pixmap = pixmap
@@ -563,13 +583,22 @@ class TargetMediaCardButton(CardButton):
 
     def on_context_menu(self, point):
         # show context menu
-        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
-        self.remove_action.setEnabled(not scan_active)
-        self.delete_action.setEnabled(not scan_active)
-        self.clear_all_media_action.setEnabled(
-            bool(self.main_window.target_videos) and not scan_active
-        )
-        self.popMenu.exec_(self.mapToGlobal(point))
+        self.create_context_menu()
+        try:
+            scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+            self.remove_action.setEnabled(not scan_active)
+            self.delete_action.setEnabled(not scan_active)
+            self.clear_all_media_action.setEnabled(
+                bool(self.main_window.target_videos) and not scan_active
+            )
+            self._exec_context_menu(point)
+        finally:
+            self._release_context_menu(
+                "remove_action",
+                "delete_action",
+                "open_path_action",
+                "clear_all_media_action",
+            )
 
 
 class TargetFaceCardButton(CardButton):
@@ -637,7 +666,6 @@ class TargetFaceCardButton(CardButton):
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         # Connect the custom context menu request signal to the custom slot
         self.customContextMenuRequested.connect(self.on_context_menu)
-        self.create_context_menu()
 
         # Create parameter dict for the target
         if not self.main_window.parameters.get(self.face_id):
@@ -1054,18 +1082,33 @@ class TargetFaceCardButton(CardButton):
 
     def on_context_menu(self, point):
         # show context menu
-        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
-        current_face_size = getattr(
-            self.main_window, "face_thumbnail_button_size", None
-        )
-        self.face_header_action.setText(self.get_display_label())
-        self.parameters_paste_action.setEnabled(not scan_active)
-        self.load_parameters_action.setEnabled(not scan_active)
-        self.load_parameters_and_settings_action.setEnabled(not scan_active)
-        self.remove_action.setEnabled(not scan_active)
-        self.small_thumbnails_action.setChecked(current_face_size == (70, 70))
-        self.large_thumbnails_action.setChecked(current_face_size == (96, 96))
-        self.popMenu.exec_(self.mapToGlobal(point))
+        self.create_context_menu()
+        try:
+            scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+            current_face_size = getattr(
+                self.main_window, "face_thumbnail_button_size", None
+            )
+            self.face_header_action.setText(self.get_display_label())
+            self.parameters_paste_action.setEnabled(not scan_active)
+            self.load_parameters_action.setEnabled(not scan_active)
+            self.load_parameters_and_settings_action.setEnabled(not scan_active)
+            self.remove_action.setEnabled(not scan_active)
+            self.small_thumbnails_action.setChecked(current_face_size == (70, 70))
+            self.large_thumbnails_action.setChecked(current_face_size == (96, 96))
+            self._exec_context_menu(point)
+        finally:
+            self._release_context_menu(
+                "face_header_action",
+                "parameters_copy_action",
+                "parameters_paste_action",
+                "save_parameters_action",
+                "load_parameters_action",
+                "load_parameters_and_settings_action",
+                "thumbnail_size_action_group",
+                "small_thumbnails_action",
+                "large_thumbnails_action",
+                "remove_action",
+            )
 
     def remove_target_face_from_list(self):
         main_window = self.main_window
@@ -1130,7 +1173,9 @@ class TargetFaceCardButton(CardButton):
     def refresh_display_label(self):
         display_label = self.get_display_label()
         self.display_label.setText(display_label)
-        self.face_header_action.setText(display_label)
+        face_header_action = getattr(self, "face_header_action", None)
+        if face_header_action is not None:
+            face_header_action.setText(display_label)
 
     def remove_assigned_input_face(self, input_face_id):
         if self.assigned_input_faces.get(input_face_id):
@@ -1180,7 +1225,6 @@ class InputFaceCardButton(CardButton):
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         # Connect the custom context menu request signal to the custom slot
         self.customContextMenuRequested.connect(self.on_context_menu)
-        self.create_context_menu()
 
     def set_embedding(self, embedding_swap_model: str, embedding: np.ndarray):
         self.embedding_store[embedding_swap_model] = embedding
@@ -1458,19 +1502,32 @@ class InputFaceCardButton(CardButton):
 
     def on_context_menu(self, point):
         # show context menu
-        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
-        current_face_size = getattr(
-            self.main_window, "face_thumbnail_button_size", None
-        )
-        self.create_embed_action.setEnabled(not scan_active)
-        self.remove_action.setEnabled(not scan_active)
-        self.delete_action.setEnabled(not scan_active)
-        self.small_thumbnails_action.setChecked(current_face_size == (70, 70))
-        self.large_thumbnails_action.setChecked(current_face_size == (96, 96))
-        self.clear_all_faces_action.setEnabled(
-            bool(self.main_window.input_faces) and not scan_active
-        )
-        self.popMenu.exec_(self.mapToGlobal(point))
+        self.create_context_menu()
+        try:
+            scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+            current_face_size = getattr(
+                self.main_window, "face_thumbnail_button_size", None
+            )
+            self.create_embed_action.setEnabled(not scan_active)
+            self.remove_action.setEnabled(not scan_active)
+            self.delete_action.setEnabled(not scan_active)
+            self.small_thumbnails_action.setChecked(current_face_size == (70, 70))
+            self.large_thumbnails_action.setChecked(current_face_size == (96, 96))
+            self.clear_all_faces_action.setEnabled(
+                bool(self.main_window.input_faces) and not scan_active
+            )
+            self._exec_context_menu(point)
+        finally:
+            self._release_context_menu(
+                "create_embed_action",
+                "remove_action",
+                "delete_action",
+                "open_path_action",
+                "thumbnail_size_action_group",
+                "small_thumbnails_action",
+                "large_thumbnails_action",
+                "clear_all_faces_action",
+            )
 
     def create_embedding_from_selected_faces(self):
         if video_control_actions.block_if_issue_scan_active(
@@ -1529,7 +1586,6 @@ class EmbeddingCardButton(CardButton):
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         # Connect the custom context menu request signal to the custom slot
         self.customContextMenuRequested.connect(self.on_context_menu)
-        self.create_context_menu()
 
     # --- Property definitions to intercept when a K/V map is assigned ---
     @property
@@ -1626,12 +1682,19 @@ class EmbeddingCardButton(CardButton):
 
     def on_context_menu(self, point):
         # show context menu
-        scan_active = video_control_actions.is_issue_scan_active(self.main_window)
-        self.remove_action.setEnabled(not scan_active)
-        self.clear_all_embeddings_action.setEnabled(
-            bool(self.main_window.merged_embeddings) and not scan_active
-        )
-        self.popMenu.exec_(self.mapToGlobal(point))
+        self.create_context_menu()
+        try:
+            scan_active = video_control_actions.is_issue_scan_active(self.main_window)
+            self.remove_action.setEnabled(not scan_active)
+            self.clear_all_embeddings_action.setEnabled(
+                bool(self.main_window.merged_embeddings) and not scan_active
+            )
+            self._exec_context_menu(point)
+        finally:
+            self._release_context_menu(
+                "remove_action",
+                "clear_all_embeddings_action",
+            )
 
     def remove_embedding_from_list(self):
         if video_control_actions.block_if_issue_scan_active(

--- a/tests/unit/processors/test_video_processor_audio.py
+++ b/tests/unit/processors/test_video_processor_audio.py
@@ -315,6 +315,7 @@ def test_finalize_default_style_recording_uses_rebuilt_audio_when_frames_skipped
         ),
         _write_video_only_output=lambda *args: True,
         _log_processing_summary=lambda *args: None,
+        _auto_save_workspace_for_output=lambda *args: None,
         disable_virtualcam=lambda: None,
         processing_stopped_signal=SimpleNamespace(emit=lambda: None),
         file_type="image",
@@ -357,7 +358,7 @@ def _make_finalize_default_style_recording_dummy(
 ):
     temp_file = tmp_path / "temp_output.mp4"
     temp_file.write_bytes(b"temp-video")
-    return SimpleNamespace(
+    dummy = SimpleNamespace(
         feeder_thread=None,
         frames_to_display=[],
         frame_queue=queue.Queue(),
@@ -404,6 +405,12 @@ def _make_finalize_default_style_recording_dummy(
         file_type="image",
         start_time=0.0,
     )
+
+    def auto_save_workspace(final_file_path):
+        return VideoProcessor._auto_save_workspace_for_output(dummy, final_file_path)
+
+    dummy._auto_save_workspace_for_output = auto_save_workspace
+    return dummy
 
 
 def test_finalize_default_style_recording_uses_active_output_folder_for_output_and_autosave(
@@ -455,7 +462,6 @@ def test_finalize_default_style_recording_uses_active_output_folder_for_output_a
 
     assert [call["output_folder"] for call in output_path_calls] == [
         resolved_output_folder,
-        resolved_output_folder,
     ]
     assert ffmpeg_calls[-1][-1] == str(
         Path(resolved_output_folder) / "resolved_output.mp4"
@@ -499,3 +505,152 @@ def test_finalize_default_style_recording_falls_back_to_output_media_folder_when
     VideoProcessor._finalize_default_style_recording(dummy)
 
     assert output_path_calls == [str(tmp_path / "fallback-output")]
+
+
+def _make_finalize_segment_concatenation_dummy(
+    tmp_path,
+    *,
+    auto_save=False,
+    stopped_by_error_limit=False,
+):
+    segment_dir = tmp_path / "segments"
+    segment_dir.mkdir()
+    segment_file = segment_dir / "segment_000.mp4"
+    segment_file.write_bytes(b"segment-video")
+    q = queue.Queue()
+
+    dummy = SimpleNamespace(
+        recording_sp=None,
+        current_segment_index=1,
+        triggered_by_job_manager=False,
+        processing=True,
+        is_processing_segments=True,
+        recording=False,
+        temp_segment_files=[str(segment_file)],
+        segment_temp_dir=str(segment_dir),
+        segments_to_process=[(10, 20)],
+        current_segment_end_frame=20,
+        active_output_folder=str(tmp_path / "output"),
+        media_path=str(tmp_path / "input.mkv"),
+        stopped_by_error_limit=stopped_by_error_limit,
+        consecutive_read_errors=0,
+        total_skipped_frames=0,
+        frame_queue=q,
+        start_time=0.0,
+        end_time=0.0,
+        file_type="image",
+        main_window=SimpleNamespace(
+            control={
+                "AutoSaveWorkspaceToggle": auto_save,
+                "OpenOutputToggle": False,
+            },
+            display_messagebox_signal=SimpleNamespace(emit=lambda *args: None),
+        ),
+        _apply_job_timestamp_to_output_name=lambda *args: (None, None),
+        _attempt_segment_video_only_fallback=lambda *args, **kwargs: False,
+        _cleanup_temp_dir=lambda: setattr(dummy, "segment_temp_dir", None),
+        _format_duration=lambda seconds: f"{seconds:.2f}s",
+        processing_stopped_signal=SimpleNamespace(emit=lambda: None),
+    )
+    dummy._auto_save_workspace_for_output = lambda final_file_path: (
+        VideoProcessor._auto_save_workspace_for_output(dummy, final_file_path)
+    )
+    return dummy
+
+
+def _patch_segment_finalize_dependencies(monkeypatch, saved_workspaces):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        "app.processors.video_processor.layout_actions.enable_all_parameters_and_control_widget",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.video_control_actions.reset_media_buttons",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.processors.video_processor.save_load_actions.save_current_workspace",
+        lambda _main_window, json_path: saved_workspaces.append(json_path),
+    )
+
+
+def test_finalize_segment_concatenation_autosaves_after_successful_concat(
+    tmp_path, monkeypatch
+):
+    dummy = _make_finalize_segment_concatenation_dummy(tmp_path, auto_save=True)
+    final_output = tmp_path / "output" / "final_output.mp4"
+    saved_workspaces: list[str] = []
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: _RunResult())
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.get_output_file_path",
+        lambda *args, **kwargs: str(final_output),
+    )
+    _patch_segment_finalize_dependencies(monkeypatch, saved_workspaces)
+
+    VideoProcessor.finalize_segment_concatenation(dummy)
+
+    assert saved_workspaces == [f"{final_output}.json"]
+
+
+def test_finalize_segment_concatenation_skips_autosave_when_disabled(
+    tmp_path, monkeypatch
+):
+    dummy = _make_finalize_segment_concatenation_dummy(tmp_path, auto_save=False)
+    saved_workspaces: list[str] = []
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: _RunResult())
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.get_output_file_path",
+        lambda *args, **kwargs: str(tmp_path / "output" / "final_output.mp4"),
+    )
+    _patch_segment_finalize_dependencies(monkeypatch, saved_workspaces)
+
+    VideoProcessor.finalize_segment_concatenation(dummy)
+
+    assert saved_workspaces == []
+
+
+def test_finalize_segment_concatenation_skips_autosave_when_concat_fails(
+    tmp_path, monkeypatch
+):
+    dummy = _make_finalize_segment_concatenation_dummy(tmp_path, auto_save=True)
+    saved_workspaces: list[str] = []
+
+    def fake_run(*args, **kwargs):
+        raise RuntimeError("concat failed")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.get_output_file_path",
+        lambda *args, **kwargs: str(tmp_path / "output" / "final_output.mp4"),
+    )
+    _patch_segment_finalize_dependencies(monkeypatch, saved_workspaces)
+
+    VideoProcessor.finalize_segment_concatenation(dummy)
+
+    assert saved_workspaces == []
+
+
+def test_finalize_segment_concatenation_autosave_uses_incomplete_output_suffix(
+    tmp_path, monkeypatch
+):
+    dummy = _make_finalize_segment_concatenation_dummy(
+        tmp_path,
+        auto_save=True,
+        stopped_by_error_limit=True,
+    )
+    saved_workspaces: list[str] = []
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: _RunResult())
+    monkeypatch.setattr(
+        "app.processors.video_processor.misc_helpers.get_output_file_path",
+        lambda *args, **kwargs: str(tmp_path / "output" / "final_output.mp4"),
+    )
+    _patch_segment_finalize_dependencies(monkeypatch, saved_workspaces)
+
+    VideoProcessor.finalize_segment_concatenation(dummy)
+
+    assert saved_workspaces == [
+        str(tmp_path / "output" / "final_output_incomplete.mp4.json")
+    ]

--- a/tests/unit/ui/test_issue_scan_progress.py
+++ b/tests/unit/ui/test_issue_scan_progress.py
@@ -1907,42 +1907,106 @@ def test_target_face_parameter_mutations_are_blocked_while_scan_is_active(
 
 def test_target_face_context_menu_disables_mutating_actions_while_scan_is_active():
     menu_exec_calls = []
+    menu_state_snapshots = []
     target_face_button = SimpleNamespace(
         main_window=_make_scan_main_window(keep_controls=True),
-        face_header_action=_DummyButton("Face 1"),
-        parameters_copy_action=_DummyButton("Copy Parameters"),
-        parameters_paste_action=_DummyButton("Apply Copied Parameters"),
-        save_parameters_action=_DummyButton("Save Current Parameters and Settings"),
-        load_parameters_action=_DummyButton("Load Parameters"),
-        load_parameters_and_settings_action=_DummyButton(
-            "Load Parameters and Settings"
-        ),
-        small_thumbnails_action=_DummyButton("Small Thumbnails"),
-        large_thumbnails_action=_DummyButton("Large Thumbnails"),
-        remove_action=_DummyButton("Remove from List"),
         get_display_label=lambda: "Face 1",
         mapToGlobal=lambda point: point,
-        popMenu=SimpleNamespace(exec_=lambda point: menu_exec_calls.append(point)),
+        popMenu=None,
     )
+
+    def create_context_menu():
+        target_face_button.face_header_action = _DummyButton("Face 1")
+        target_face_button.parameters_copy_action = _DummyButton("Copy Parameters")
+        target_face_button.parameters_paste_action = _DummyButton(
+            "Apply Copied Parameters"
+        )
+        target_face_button.save_parameters_action = _DummyButton(
+            "Save Current Parameters and Settings"
+        )
+        target_face_button.load_parameters_action = _DummyButton("Load Parameters")
+        target_face_button.load_parameters_and_settings_action = _DummyButton(
+            "Load Parameters and Settings"
+        )
+        target_face_button.small_thumbnails_action = _DummyButton("Small Thumbnails")
+        target_face_button.large_thumbnails_action = _DummyButton("Large Thumbnails")
+        target_face_button.remove_action = _DummyButton("Remove from List")
+
+    def exec_context_menu(point):
+        menu_exec_calls.append(point)
+        menu_state_snapshots.append(
+            {
+                "parameters_copy": target_face_button.parameters_copy_action.enabled,
+                "parameters_paste": target_face_button.parameters_paste_action.enabled,
+                "save_parameters": target_face_button.save_parameters_action.enabled,
+                "load_parameters": target_face_button.load_parameters_action.enabled,
+                "load_parameters_and_settings": target_face_button.load_parameters_and_settings_action.enabled,
+                "remove": target_face_button.remove_action.enabled,
+            }
+        )
+
+    def release_context_menu(*action_attrs):
+        for attr in action_attrs:
+            setattr(target_face_button, attr, None)
+        target_face_button.popMenu = None
+
+    target_face_button.create_context_menu = create_context_menu
+    target_face_button._exec_context_menu = exec_context_menu
+    target_face_button._release_context_menu = release_context_menu
     target_face_button.main_window.scan_issue_worker = object()
 
     widget_components.TargetFaceCardButton.on_context_menu(target_face_button, 12)
 
-    assert target_face_button.parameters_copy_action.enabled is True
-    assert target_face_button.save_parameters_action.enabled is True
-    assert target_face_button.parameters_paste_action.enabled is False
-    assert target_face_button.load_parameters_action.enabled is False
-    assert target_face_button.load_parameters_and_settings_action.enabled is False
-    assert target_face_button.remove_action.enabled is False
+    assert menu_state_snapshots[-1] == {
+        "parameters_copy": True,
+        "parameters_paste": False,
+        "save_parameters": True,
+        "load_parameters": False,
+        "load_parameters_and_settings": False,
+        "remove": False,
+    }
     assert menu_exec_calls == [12]
+    assert target_face_button.remove_action is None
 
     target_face_button.main_window.scan_issue_worker = None
     target_face_button.main_window.scan_issue_ui_state = {}
 
     widget_components.TargetFaceCardButton.on_context_menu(target_face_button, 34)
 
-    assert target_face_button.parameters_paste_action.enabled is True
-    assert target_face_button.load_parameters_action.enabled is True
-    assert target_face_button.load_parameters_and_settings_action.enabled is True
-    assert target_face_button.remove_action.enabled is True
+    assert menu_state_snapshots[-1] == {
+        "parameters_copy": True,
+        "parameters_paste": True,
+        "save_parameters": True,
+        "load_parameters": True,
+        "load_parameters_and_settings": True,
+        "remove": True,
+    }
     assert menu_exec_calls == [12, 34]
+    assert target_face_button.remove_action is None
+
+
+def test_target_face_refresh_display_label_does_not_require_context_menu():
+    display_label = _DummyButton("Face")
+    target_face_button = SimpleNamespace(
+        display_label=display_label,
+        get_display_label=lambda: "Face 2",
+    )
+
+    widget_components.TargetFaceCardButton.refresh_display_label(target_face_button)
+
+    assert display_label.text == "Face 2"
+
+
+def test_target_face_refresh_display_label_updates_live_context_menu_header():
+    display_label = _DummyButton("Face")
+    face_header_action = _DummyButton("Face")
+    target_face_button = SimpleNamespace(
+        display_label=display_label,
+        face_header_action=face_header_action,
+        get_display_label=lambda: "Face 2",
+    )
+
+    widget_components.TargetFaceCardButton.refresh_display_label(target_face_button)
+
+    assert display_label.text == "Face 2"
+    assert face_header_action.text == "Face 2"


### PR DESCRIPTION
## Summary

Fixes three dev issues:

- Fixes #198 by reducing Qt/Win32 handle pressure from media/face/embedding card context menus.
- Fixes #202 by adding workspace autosave support after marker/start-end recording finalization.
- Fixes #203 by increasing the launcher rollback commit list from 10 to 50.

## Changes

- Make high-volume card context menus lazy:
  - target media cards
  - target face cards
  - input face cards
  - embedding cards
- Release temporary `QMenu` / `QAction` resources after context menus close.
- Preserve target-face label refresh behavior when no context menu has been created yet.
- Add autosave helper for completed recording outputs and reuse it for default + marker recording paths.
- Autosave marker recording workspaces beside the actual final output file, including fallback / `_incomplete` outputs.
- Add `ROLLBACK_COMMIT_LIMIT = 50` for launcher rollback history.

## Testing

- Manual tested marker/start-end recording workspace autosave.
- Manual tested launcher rollback page lists more commits and remains scrollable.
- Manual tested app startup/workspace load after lazy context-menu change.
- Ran focused pytest coverage for touched areas.
- Ran pre-commit successfully.