### PR TITLE
avoid stealing focus when hovering over embedding card button names

### DIFF
--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -93,14 +93,16 @@ class TwoLineElidedLabel(QtWidgets.QLabel):
         )
         super().setText(f"{first_line}\n{second_line}")
 
-
 class CardButton(QPushButton):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args)
-        self.main_window: "MainWindow" = kwargs.get("main_window", False)
+        self.main_window = kwargs.pop("main_window", None)
+        super().__init__(*args, **kwargs)
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setAutoDefault(False)
+        self.setDefault(False)
         self.list_item = None
-        self.list_widget: QtWidgets.QListWidget = None
-        self.popMenu: QtWidgets.QMenu | None = None
+        self.list_widget = None
+        self.popMenu = None
 
     def _release_context_menu(self, *action_attrs: str) -> None:
         for attr in action_attrs:


### PR DESCRIPTION
Small patch to avoid stealing focus when hovering over embedding card button names. This was annoying when the user was typing in the search box and moved the cursor by accident to a card name, it would steal focus discarding the text being typed in the embedding search box.