### PR TITLE
DFL_Xseg color fix

### DIFF
--- a/app/processors/face_masks.py
+++ b/app/processors/face_masks.py
@@ -1313,12 +1313,6 @@ class FaceMasks:
         outpred = 1.0 - outpred
         outpred = torch.unsqueeze(outpred, 0).type(torch.float32)
 
-        outpred_calc = torch.where(outpred_calc < 0.1, 0.0, 1.0).float()
-        outpred_calc = 1.0 - outpred_calc
-        outpred_calc = torch.unsqueeze(outpred_calc, 0).type(torch.float32)
-
-        outpred_calc_dill = outpred_calc.clone()
-
         if amount2 != amount:
             outpred2 = outpred.clone()
 
@@ -1403,6 +1397,10 @@ class FaceMasks:
                 outpred = 1.0 - outpred
                 outpred = outpred.clamp(0.0, 1.0)
 
+        # Derive calculation masks AFTER size processing, but BEFORE blur.
+        # This ensures color stats never sample excluded background pixels.
+        outpred_calc = torch.where(outpred < 0.5, 0.0, 1.0).float()
+        outpred_calc_dill = outpred_calc.clone()
         blur_amount = parameters.get("OccluderXSegBlurSlider", 0)
         if blur_amount > 0:
             k_size = blur_amount * 2 + 1

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -4859,6 +4859,20 @@ class FrameWorker(threading.Thread):
                     antialias=True,
                 )(swap_mask_noFP)
 
+            # --- START FIX: BORDER BLUR ALIGNMENT ---
+            # The standard Occluder blurs the global swap_mask, softening the harsh
+            # border_mask edges. DFLXSeg blurs its mask internally, leaving the base
+            # swap_mask edges razor-sharp. We apply the blur here to soften the boundaries
+            # BEFORE multiplying XSeg, avoiding double-blurring the XSeg internal edges.
+            if not parameters.get("OccluderEnableToggle", False):
+                blur_amount = parameters.get("OccluderXSegBlurSlider", 0)
+                if blur_amount > 0:
+                    kernel_size = blur_amount * 2 + 1
+                    sigma = (blur_amount + 1) * 0.2
+                    gauss_op = v2.GaussianBlur(kernel_size, sigma)
+                    swap_mask = gauss_op(swap_mask)
+                    swap_mask_noFP = gauss_op(swap_mask_noFP)
+            # --- END FIX ---
             # apply_dfl_xseg returns inverted masks (0=Face, 1=BG).
             # We multiply by (1 - mask) to carve out the background.
             swap_mask_noFP.mul_(1.0 - outpred_noFP_res)


### PR DESCRIPTION
## 🎯 Summary

This PR contains critical bug fixes for the DFLXSeg masking pipeline, addressing issues with **calculation mask derivation timing** and **border blur alignment**. These fixes ensure proper background exclusion in color statistics and prevent visual artifacts at mask boundaries.

## ✨ Key Improvements

### 1. **Fixed Calculation Mask Timing** (`app/processors/face_masks.py`)
- **Issue**: Calculation masks were derived at the wrong stage, using unprocessed predictions
- **Fix**: Moved mask derivation to occur **after size processing but before blur**, ensuring color statistics never sample excluded background pixels
- **Impact**: Eliminates artifacts caused by including background pixels in color calculations

### 2. **Border Blur Alignment Fix** (`app/processors/workers/frame_worker.py`)
- **Issue**: When DFLXSeg is enabled, the base swap mask edges remain razor-sharp while XSeg internally blurs its mask, creating misalignment
- **Fix**: Apply Gaussian blur to the swap mask before XSeg multiplication when using DFLXSeg
- **Impact**: Produces softer, more blended boundaries without double-blurring XSeg internal edges
