### PR TITLE
Feature: PeformRecast - Face Expression Restorer

### DIFF
--- a/app/processors/frame_edits.py
+++ b/app/processors/frame_edits.py
@@ -893,6 +893,140 @@ class FrameEdits:
 
         return out.type(torch.float32)
 
+    def apply_perform_recast(
+        self,
+        driving: torch.Tensor,
+        target: torch.Tensor,
+        parameters: dict,
+        control: dict,
+        driving_kps: np.ndarray = None,
+    ) -> torch.Tensor:
+        """Transfer expression onto the swapped face using PerformRecast.
+
+        This is the "Recast" mode of the Face Expression Restorer. Unlike the
+        LivePortrait path it uses the PerformRecast 49-keypoint sub-networks
+        (appearance F, motion M, warping W, SPADE generator G) and composes the
+        expression with either the Enhancement (additive delta) or Replacement
+        (absolute driving expression with source-side identity blending) mode.
+
+        Args:
+            driving: The original pre-swap face tensor (source of expression).
+            target: The swapped face tensor (identity/pose to preserve).
+            parameters: Dictionary containing UI parameters.
+            control: UI control dictionary.
+            driving_kps: Optional pre-computed 203-point driving landmarks.
+
+        Returns:
+            torch.Tensor: The expression-recast face image (float32, [0,255]).
+        """
+        import contextlib
+
+        recast = self.models_processor.perform_recast
+
+        # Use the current stream (see apply_face_expression_restorer for why a
+        # per-frame cuda.Stream() fragments the allocator).
+        local_stream = (
+            torch.cuda.current_stream() if torch.cuda.is_available() else None
+        )
+        stream_context = (
+            torch.cuda.stream(local_stream)
+            if local_stream
+            else contextlib.nullcontext()
+        )
+
+        with stream_context, torch.inference_mode():
+            use_mean_eyes = parameters.get("LandmarkMeanEyesToggle", False)
+
+            mode = parameters.get("RecastModeSelection", "Enhancement")
+            if isinstance(mode, str):
+                mode = mode.strip()
+            factor = float(parameters.get("RecastExpressionFactorDecimalSlider", 1.0))
+            region = parameters.get("RecastAnimationRegionSelection", "all")
+
+            crop_scale = parameters.get("FaceExpressionCropScaleBothDecimalSlider", 2.3)
+            vy_ratio = parameters.get("FaceExpressionVYRatioBothDecimalSlider", -0.125)
+            interp_mode = (
+                self.interpolation_expression_faceeditor_back
+                if self.interpolation_expression_faceeditor_back is not None
+                else v2.InterpolationMode.BILINEAR
+            )
+
+            # --- DRIVING FACE (source of expression) ---
+            if driving_kps is not None and not np.all(driving_kps == 0):
+                driving_lmk_crop = driving_kps
+            else:
+                _, driving_lmk_crop, _ = self.models_processor.run_detect_landmark(
+                    driving,
+                    bbox=np.array([0, 0, 512, 512]),
+                    det_kpss=[],
+                    detect_mode="203",
+                    score=0.5,
+                    from_points=False,
+                    use_mean_eyes=use_mean_eyes,
+                )
+
+            if driving_lmk_crop is None or (
+                hasattr(driving_lmk_crop, "__len__") and len(driving_lmk_crop) == 0
+            ):
+                return target
+
+            driving_face_512, _, _ = faceutil.warp_face_by_face_landmark_x(
+                driving,
+                driving_lmk_crop,
+                dsize=512,
+                scale=crop_scale,
+                vy_ratio=vy_ratio,
+                interpolation=interp_mode,
+            )
+            driving_face_256 = self.t256_face(driving_face_512)
+            x_d_info = recast.motion(driving_face_256)
+            exp_d = x_d_info["exp"]
+
+            # --- TARGET FACE (identity / pose to preserve) ---
+            target = target.clamp(0, 255).type(torch.uint8)
+            _, source_lmk, _ = self.models_processor.run_detect_landmark(
+                target,
+                bbox=np.array([0, 0, 512, 512], dtype=np.float32),
+                det_kpss=None,
+                detect_mode="203",
+                score=0.5,
+                from_points=False,
+                use_mean_eyes=use_mean_eyes,
+            )
+            if source_lmk is None or (
+                hasattr(source_lmk, "__len__") and len(source_lmk) == 0
+            ):
+                return target.type(torch.float32)
+
+            target_face_512, M_o2c, M_c2o = faceutil.warp_face_by_face_landmark_x(
+                target,
+                source_lmk,
+                dsize=512,
+                scale=crop_scale,
+                vy_ratio=vy_ratio,
+                interpolation=interp_mode,
+            )
+            target_face_256 = self.t256_face(target_face_512)
+
+            # Source motion + appearance. Appearance (F) takes the 512 crop.
+            x_s_info = recast.motion(target_face_256)
+            source_info = recast.build_source_info(x_s_info)
+            f_s = recast.extract_appearance(target_face_512)
+
+            # --- COMPOSE + GENERATE ---
+            x_d_i = recast.compose_driven_keypoints(
+                source_info, exp_d, mode=mode, factor=factor, region=region
+            )
+            out = recast.warp_decode(f_s, source_info["x_s"], x_d_i)
+            out = torch.squeeze(out).clamp_(0, 1)
+
+            # --- PASTE BACK ---
+            dsize = (target.shape[1], target.shape[2])
+            out = self._apply_kornia_warp(out, M_c2o, dsize)
+            out = out.mul_(255.0).clamp_(0, 255)
+
+        return out.type(torch.float32)
+
     def swap_edit_face_core(
         self,
         img: torch.Tensor,

--- a/app/processors/models_data.py
+++ b/app/processors/models_data.py
@@ -45,6 +45,9 @@ fp16_safe_models_list = [
     "LivePortraitStitchingLip",
     "LivePortraitStitching",
     "LivePortraitWarpingSpade",
+    # --- PerformRecast ---
+    "PerformRecastAppearanceFeatureExtractor",
+    "PerformRecastMotionExtractor",
     # --- Detectors ---
     "RetinaFace",
     "SCRFD2.5g",
@@ -100,6 +103,16 @@ fp16_safe_models_list = [
     "GhostFacev1",
     "GhostFacev2",
     "GhostFacev3",
+]
+
+# Models whose ONNX graph must be shape-inferred (with a static batch=1) before
+# the TensorRT EP can build an engine. The PerformRecast warping module contains
+# 5-D GridSample nodes whose outputs have no static shape, which makes the TRT EP
+# abort with "has no shape specified. Please run shape inference on the onnx
+# model first." The loader transparently builds a cached, shape-inferred sidecar
+# (``*.trtshape.onnx``) for these models. See ModelsProcessor._ensure_trt_ready_onnx.
+tensorrt_shape_infer_models = [
+    "PerformRecastWarpingModule",
 ]
 
 models_list = [
@@ -450,6 +463,31 @@ models_list = [
         "local_path": f"{models_dir}/liveportrait_onnx/warping_spade.onnx",
         "hash": "d6ee9af4352b47e88e0521eba6b774c48204afddc8d91c671a5f7b8a0dfb4971",
         "url": f"{assets_repo}/v0.1.0_lp/warping_spade.onnx",
+    },
+    # --- PerformRecast (expression-only "Recast" mode of the Face Expression Restorer) ---
+    {
+        "model_name": "PerformRecastAppearanceFeatureExtractor",
+        "local_path": f"{models_dir}/performrecast_onnx/appearance_feature_extractor.onnx",
+        "hash": "208e4f848b430cbfa71a36dab7ec25a5b345882f846dbb27288abcfb2ae89a96",
+        "url": "https://github.com/Glat0s/PerformRecast-onnx/releases/download/onnx-v1/appearance_feature_extractor.onnx",
+    },
+    {
+        "model_name": "PerformRecastMotionExtractor",
+        "local_path": f"{models_dir}/performrecast_onnx/motion_extractor.onnx",
+        "hash": "b1b26c1b6d7520eb8020175050f0381c4f402ccaa6afbaebee259da4ff9dcb6c",
+        "url": "https://github.com/Glat0s/PerformRecast-onnx/releases/download/onnx-v1/motion_extractor.onnx",
+    },
+    {
+        "model_name": "PerformRecastWarpingModule",
+        "local_path": f"{models_dir}/performrecast_onnx/warping_module.onnx",
+        "hash": "92d8a1414a31a4117237bbfb667be02e71831a085af6697c9c3465200228a0ce",
+        "url": "https://github.com/Glat0s/PerformRecast-onnx/releases/download/onnx-v1/warping_module.onnx",
+    },
+    {
+        "model_name": "PerformRecastSpadeGenerator",
+        "local_path": f"{models_dir}/performrecast_onnx/spade_generator.onnx",
+        "hash": "4d8127313b1c2f6b53320b65208dafc22db260550f690cfa114dec646c7a8f5f",
+        "url": "https://github.com/Glat0s/PerformRecast-onnx/releases/download/onnx-v1/spade_generator.onnx",
     },
     {
         "model_name": "RefLDMVAEEncoder",

--- a/app/processors/models_processor.py
+++ b/app/processors/models_processor.py
@@ -68,11 +68,13 @@ from app.processors.face_swappers import FaceSwappers
 from app.processors.frame_enhancers import FrameEnhancers
 from app.processors.face_editors import FaceEditors
 from app.processors.face_reaging import FaceReaging
+from app.processors.perform_recast import PerformRecast
 from app.processors.utils.dfm_model import DFMModel
 from app.processors.models_data import (
     models_list,
     arcface_mapping_model_dict,
     fp16_safe_models_list,
+    tensorrt_shape_infer_models,
 )
 from app.helpers.miscellaneous import is_file_exists
 from app.helpers.downloader import download_file
@@ -301,6 +303,7 @@ class ModelsProcessor(QtCore.QObject):
         self.frame_enhancers = FrameEnhancers(self)
         self.face_editors = FaceEditors(self)
         self.face_reaging = FaceReaging(self)
+        self.perform_recast = PerformRecast(self)
 
         # Initialize Mask Latent
         self.lp_mask_crop_latent = faceutil.create_faded_inner_mask(
@@ -527,6 +530,61 @@ class ModelsProcessor(QtCore.QObject):
     def binding_device_id(self) -> int:
         return self.gpu_id if self.device_type != "cpu" else 0
 
+    def _ensure_trt_ready_onnx(self, model_name: str, onnx_path: str) -> str:
+        """Return an ONNX path that the TensorRT EP can build an engine from.
+
+        Some models (see ``tensorrt_shape_infer_models``) contain ops — notably
+        5-D ``GridSample`` in the PerformRecast warping module — whose output
+        tensors carry no static shape. The TensorRT EP refuses such graphs with
+        "has no shape specified. Please run shape inference on the onnx model
+        first." We fix this once by pinning the batch dimension to 1 (the app
+        always feeds a single face) and running ONNX Runtime's symbolic shape
+        inference, then caching the result next to the original as
+        ``*.trtshape.onnx``. The cached file is reused unless the source ONNX is
+        newer. For models not in the list, the original path is returned as-is.
+        """
+        if model_name not in tensorrt_shape_infer_models:
+            return onnx_path
+        if not onnx_path.lower().endswith(".onnx"):
+            return onnx_path
+
+        sidecar_path = onnx_path[: -len(".onnx")] + ".trtshape.onnx"
+        try:
+            if os.path.exists(sidecar_path) and (
+                os.path.getmtime(sidecar_path) >= os.path.getmtime(onnx_path)
+            ):
+                return sidecar_path
+
+            print(
+                f"[INFO] Preparing TensorRT-ready (shape-inferred) ONNX for {model_name}..."
+            )
+            from onnxruntime.tools.onnx_model_utils import make_dim_param_fixed
+            from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
+
+            model = onnx.load(onnx_path)
+            # Pin the dynamic 'batch' axis to 1 so symbolic dims (e.g. "50*batch")
+            # resolve to concrete values the TensorRT builder accepts.
+            try:
+                make_dim_param_fixed(model.graph, "batch", 1)
+            except Exception as dim_err:
+                # Not fatal — symbolic shape inference may still add the shapes.
+                print(f"[WARN] Could not pin batch dim for {model_name}: {dim_err}")
+            model = SymbolicShapeInference.infer_shapes(
+                model, auto_merge=True, guess_output_rank=True
+            )
+            onnx.save(model, sidecar_path)
+            del model
+            gc.collect()
+            print(f"[INFO] Wrote shape-inferred ONNX: {os.path.basename(sidecar_path)}")
+            return sidecar_path
+        except Exception as e:
+            print(
+                f"[WARN] Shape-inference preprocessing failed for {model_name} ({e}). "
+                f"Falling back to the original ONNX."
+            )
+            traceback.print_exc()
+            return onnx_path
+
     def _check_tensorrt_cache(self, model_name: str, onnx_path: str) -> bool:
         """
         Checks if a valid TensorRT cache (ctx and engine file) exists for the given model.
@@ -692,6 +750,11 @@ class ModelsProcessor(QtCore.QObject):
                 )
                 return None
 
+            # Some models need a shape-inferred graph before the TensorRT EP can
+            # build an engine. This transparently swaps in a cached sidecar; the
+            # original path stays untouched for download/integrity checks.
+            onnx_path = self._ensure_trt_ready_onnx(model_name, onnx_path)
+
             build_was_triggered = (
                 False  # MP-05: flag to track if build dialog was shown
             )
@@ -771,7 +834,7 @@ class ModelsProcessor(QtCore.QObject):
                                 probe_process = ctx.Process(
                                     target=_probe_onnx_model_worker,
                                     args=(
-                                        self.models_path[model_name],
+                                        onnx_path,
                                         current_providers_list,
                                         model_trt_options,  # On passe les options dynamiques
                                         sess_options_dict,
@@ -870,7 +933,7 @@ class ModelsProcessor(QtCore.QObject):
                 session_options.log_severity_level = 3
 
                 model_instance = onnxruntime.InferenceSession(
-                    self.models_path[model_name],
+                    onnx_path,
                     sess_options=session_options,
                     providers=model_providers,
                 )
@@ -1601,6 +1664,11 @@ class ModelsProcessor(QtCore.QObject):
         """Unloads all loaded face editor models under the model lock."""
         with self.model_lock:
             self.face_editors.unload_models()
+
+    def unload_perform_recast_models(self):
+        """Unloads all loaded PerformRecast (Recast mode) models under the lock."""
+        with self.model_lock:
+            self.perform_recast.unload_models()
 
     def unload_face_mask_models(self):
         """Unloads all loaded face mask models under the model lock."""

--- a/app/processors/perform_recast.py
+++ b/app/processors/perform_recast.py
@@ -1,0 +1,302 @@
+"""PerformRecast — expression-only "Recast" backend for the Face Expression Restorer.
+
+PerformRecast (CVPR 2026) transfers the *expression* of a driving face onto a
+source face while preserving the source's identity and head pose. Inside
+VisoMaster the driving face is the original pre-swap face and the source is the
+swapped face, mirroring the role of the LivePortrait-based expression restorer.
+
+It uses four exported ONNX sub-networks (see ``models_data.py``):
+
+    F  PerformRecastAppearanceFeatureExtractor  (B,3,512,512)[0,1] -> feature_3d (B,32,16,64,64)
+    M  PerformRecastMotionExtractor             (B,3,256,256)[0,1] -> pitch,yaw,roll,t,exp,scale,kp
+    W  PerformRecastWarpingModule               feature_3d,kp_driving,kp_source -> occlusion_map,deformation,out (B,256,64,64)
+    G  PerformRecastSpadeGenerator              feature (B,256,64,64) -> out (B,3,512,512)[0,1]
+
+The model uses 49 implicit keypoints (NUM_KP = 49) — not LivePortrait's 21 — and
+a head-pose binning convention of ``softmax * 3 - 99`` (HopeNet), which differs
+from LivePortrait's ``- 97.5``. The keypoint transform and the two composition
+modes are ported verbatim from the reference ``src/pipeline.py`` /
+``scripts/onnx_inference.py`` so behaviour matches the upstream model.
+
+W and G have no fp16 kernel (5-D grid_sample / SPADE), so they always run fp32;
+all graph I/O is float32 regardless of internal precision.
+"""
+
+from typing import TYPE_CHECKING, Dict
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+if TYPE_CHECKING:
+    from app.processors.models_processor import ModelsProcessor
+
+# Implicit keypoint count of the PerformRecast motion model
+# (performrecast_models.yaml -> common_params.num_kp).
+NUM_KP = 49
+
+# ONNX model registry keys for the four sub-networks.
+APPEARANCE_MODEL = "PerformRecastAppearanceFeatureExtractor"
+MOTION_MODEL = "PerformRecastMotionExtractor"
+WARPING_MODEL = "PerformRecastWarpingModule"
+SPADE_MODEL = "PerformRecastSpadeGenerator"
+
+# Mapping of the user-facing mode label -> upstream inference_mode integer.
+MODE_REPLACEMENT = "Replacement"  # inference_mode 1
+MODE_ENHANCEMENT = "Enhancement"  # inference_mode 2
+
+
+class PerformRecast:
+    """onnxruntime-backed runner for the four PerformRecast sub-networks.
+
+    Mirrors the structure of :class:`app.processors.face_editors.FaceEditors`:
+    models are lazily loaded through ``models_processor.load_model`` on first
+    use and can be released together via :meth:`unload_models`.
+    """
+
+    # All four ONNX models, grouped so the UI can load/unload them together.
+    model_group = [APPEARANCE_MODEL, MOTION_MODEL, WARPING_MODEL, SPADE_MODEL]
+
+    def __init__(self, models_processor: "ModelsProcessor"):
+        self.models_processor = models_processor
+
+    # ------------------------------------------------------------------ #
+    # Low-level ONNX runner
+    # ------------------------------------------------------------------ #
+    def _session(self, model_name: str):
+        """Return a loaded InferenceSession for ``model_name`` (lazy load)."""
+        session = self.models_processor.models.get(model_name)
+        if session is None:
+            session = self.models_processor.load_model(model_name)
+            self.models_processor.models[model_name] = session
+        if session is None:
+            raise RuntimeError(f"Model {model_name} could not be loaded")
+        return session
+
+    def _run(self, model_name: str, feeds: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        """Run a model and return {output_name: np.ndarray}.
+
+        The exported graphs always take/return float32 (``keep_io_types=True``
+        for the fp16 variants), so every feed is coerced to contiguous float32.
+
+        TensorRT "lazy build" models compile their engine on the first real
+        inference (not during the isolated probe). We surface the build dialog
+        around that first run so the UI does not appear frozen — mirroring
+        FaceEditors._run_onnx_io_binding.
+        """
+        session = self._session(model_name)
+        feeds = {k: np.ascontiguousarray(v, dtype=np.float32) for k, v in feeds.items()}
+        names = [o.name for o in session.get_outputs()]
+
+        mp = self.models_processor
+        is_lazy_build = False
+        check_pending = getattr(mp, "check_and_clear_pending_build", None)
+        if callable(check_pending):
+            is_lazy_build = check_pending(model_name)
+        if is_lazy_build:
+            mp.show_build_dialog.emit(
+                "Finalizing TensorRT Build",
+                f"Performing first-run inference for:\n{model_name}\n\n"
+                f"This may take several minutes.",
+            )
+        try:
+            outs = session.run(None, feeds)
+        finally:
+            if is_lazy_build:
+                mp.hide_build_dialog.emit()
+
+        return dict(zip(names, outs))
+
+    def unload_models(self):
+        """Release all four PerformRecast models from VRAM."""
+        for model_name in self.model_group:
+            self.models_processor.unload_model(model_name)
+
+    # ------------------------------------------------------------------ #
+    # Model-level API (mirrors scripts/onnx_inference.py)
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _to_input(img: torch.Tensor) -> np.ndarray:
+        """(C,H,W) uint8/float [0,255] -> (1,3,H,W) float32 [0,1] numpy."""
+        x = img.detach().to(torch.float32) / 255.0
+        x = torch.clamp(x, 0.0, 1.0)
+        if x.dim() == 3:
+            x = x.unsqueeze(0)
+        return x.contiguous().cpu().numpy()
+
+    def extract_appearance(self, img512: torch.Tensor) -> np.ndarray:
+        """F: source crop (C,512,512)[0,255] -> feature_3d (1,32,16,64,64)."""
+        feeds = {"source_image": self._to_input(img512)}
+        return self._run(APPEARANCE_MODEL, feeds)["feature_3d"]
+
+    def motion(self, img256: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """M: crop (C,256,256)[0,255] -> raw motion dict as torch tensors.
+
+        Keys: pitch, yaw, roll (1,66); t (1,3); scale (1,1);
+        exp, kp reshaped to (1, NUM_KP, 3).
+        """
+        out = self._run(MOTION_MODEL, {"image": self._to_input(img256)})
+        device = self.models_processor.device
+        kp_info = {
+            k: torch.from_numpy(out[k]).to(device)
+            for k in ("pitch", "yaw", "roll", "t", "exp", "scale", "kp")
+        }
+        kp_info["exp"] = kp_info["exp"].reshape(1, -1, 3)
+        kp_info["kp"] = kp_info["kp"].reshape(1, -1, 3)
+        return kp_info
+
+    def warp_decode(
+        self, feature_3d: np.ndarray, kp_source: torch.Tensor, kp_driving: torch.Tensor
+    ) -> torch.Tensor:
+        """W + G: D(W(f_s; x_s, x_d)) -> RGB image (1,3,512,512) torch [0,1].
+
+        Note the upstream input ordering: the warping module receives
+        ``kp_driving`` first and ``kp_source`` second.
+        """
+        warped = self._run(
+            WARPING_MODEL,
+            {
+                "feature_3d": feature_3d,
+                "kp_driving": kp_driving.detach().cpu().numpy(),
+                "kp_source": kp_source.detach().cpu().numpy(),
+            },
+        )["out"]
+        out = self._run(SPADE_MODEL, {"feature": warped})["out"]
+        return torch.from_numpy(out).to(self.models_processor.device)
+
+    # ------------------------------------------------------------------ #
+    # Geometry — ported verbatim from src/pipeline.py (HopeNet -99 binning)
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _headpose_to_degree(pred: torch.Tensor) -> torch.Tensor:
+        """(bs,66) pose logits -> (bs,) degrees. PerformRecast uses *3 - 99."""
+        idx = torch.arange(66, dtype=torch.float32, device=pred.device)
+        pred = F.softmax(pred, dim=1)
+        return torch.sum(pred * idx, dim=1) * 3 - 99
+
+    @staticmethod
+    def _rotation_matrix(
+        yaw: torch.Tensor, pitch: torch.Tensor, roll: torch.Tensor
+    ) -> torch.Tensor:
+        """(bs,) degree angles -> (bs,3,3) rotation matrix (pitch·yaw·roll)."""
+        deg2rad = 3.14 / 180  # match upstream's literal 3.14 constant exactly
+        yaw = (yaw * deg2rad).unsqueeze(1)
+        pitch = (pitch * deg2rad).unsqueeze(1)
+        roll = (roll * deg2rad).unsqueeze(1)
+
+        zeros = torch.zeros_like(pitch)
+        ones = torch.ones_like(pitch)
+
+        pitch_mat = torch.cat(
+            [ones, zeros, zeros,
+             zeros, torch.cos(pitch), -torch.sin(pitch),
+             zeros, torch.sin(pitch), torch.cos(pitch)], dim=1
+        ).view(-1, 3, 3)
+        yaw_mat = torch.cat(
+            [torch.cos(yaw), zeros, torch.sin(yaw),
+             zeros, ones, zeros,
+             -torch.sin(yaw), zeros, torch.cos(yaw)], dim=1
+        ).view(-1, 3, 3)
+        roll_mat = torch.cat(
+            [torch.cos(roll), -torch.sin(roll), zeros,
+             torch.sin(roll), torch.cos(roll), zeros,
+             zeros, zeros, ones], dim=1
+        ).view(-1, 3, 3)
+
+        return torch.einsum("bij,bjk,bkm->bim", pitch_mat, yaw_mat, roll_mat)
+
+    def build_source_info(self, kp_info: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """Compute the per-frame source descriptor used during animation.
+
+        Returns a dict with the canonical keypoints ``kp`` (1,N,3), expression
+        ``exp`` (1,N,3), rotation ``R`` (1,3,3), ``scale`` (1,1), translation
+        ``t`` (1,3, tz zeroed) and the transformed source keypoints ``x_s``.
+        """
+        kp = kp_info["kp"]
+        exp = kp_info["exp"]
+        yaw = self._headpose_to_degree(kp_info["yaw"])
+        pitch = self._headpose_to_degree(kp_info["pitch"])
+        roll = self._headpose_to_degree(kp_info["roll"])
+        R = self._rotation_matrix(yaw, pitch, roll)
+        scale = kp_info["scale"]
+        t = kp_info["t"].clone()
+        t[..., 2] = 0  # zero tz
+
+        kp_e = kp + exp
+        kp_rotated = torch.einsum("bmp,bkp->bkm", R, kp_e)
+        kp_rotated = kp_rotated * scale.unsqueeze(1)
+        x_s = kp_rotated + t.unsqueeze(1)
+
+        return {"kp": kp, "exp": exp, "R": R, "scale": scale, "t": t, "x_s": x_s}
+
+    # ------------------------------------------------------------------ #
+    # Expression composition — ported from src/pipeline.py animate loop
+    # ------------------------------------------------------------------ #
+    # Implicit-keypoint channel groups referenced by the upstream
+    # "Replacement" modulation. Used here for optional region gating.
+    EYE_INDICES = list(range(31, 39))    # 31..38 (eye channels)
+    MOUTH_INDICES = list(range(44, 47))  # 44..46 (jaw / lip-contour channels)
+
+    def compose_driven_keypoints(
+        self,
+        source_info: Dict[str, torch.Tensor],
+        exp_d: torch.Tensor,
+        mode: str = MODE_ENHANCEMENT,
+        factor: float = 1.0,
+        region: str = "all",
+    ) -> torch.Tensor:
+        """Build the driven keypoints ``x_d_i`` fed to the warping module.
+
+        Args:
+            source_info: output of :meth:`build_source_info` (the swapped face).
+            exp_d: driving expression (1,N,3) from the original face's motion.
+            mode: ``"Replacement"`` (upstream mode 1) or ``"Enhancement"`` (mode 2).
+            factor: expression strength. 0 keeps the source expression, 1 applies
+                the full transfer; values >1 exaggerate it.
+            region: ``"all"`` | ``"eyes"`` | ``"lips"`` — restrict where the
+                driving expression is applied (source expression kept elsewhere).
+
+        Per-frame note: the upstream video pipeline uses the driving video's
+        first frame as the neutral reference for the relative delta. VisoMaster
+        processes frames independently, so the source (swapped) face's own
+        expression is used as that reference — making ``factor`` a clean
+        interpolation between "keep source" and "full driving expression".
+        """
+        x_s_c = source_info["kp"]
+        exp_s = source_info["exp"]
+        R = source_info["R"]
+        scale = source_info["scale"]
+        t = source_info["t"]
+
+        if mode == MODE_REPLACEMENT:
+            # Start from the absolute driving expression and blend back
+            # source-side eye / lip / jaw channels (identity micro-cues).
+            modulated = exp_d.clone()
+            modulated[:, 31:34, 2] = exp_s[:, 31:34, 2]
+            modulated[:, 36:39, 2] = exp_s[:, 36:39, 2]
+            modulated[:, 44:47, 2] = exp_s[:, 44:47, 2]
+            modulated[:, 44:47, 0] = exp_s[:, 44:47, 0]
+            modulated[:, 44:47, 1] = exp_s[:, 44:47, 1] * 0.2 + exp_d[:, 44:47, 1] * 0.8
+            modulated[:, 31:34, :2] = exp_s[:, 31:34, :2] * 0.3 + exp_d[:, 31:34, :2] * 0.7
+            modulated[:, 36:39, :2] = exp_s[:, 36:39, :2] * 0.3 + exp_d[:, 36:39, :2] * 0.7
+            # Interpolate from source toward the modulated target by `factor`.
+            new_exp = exp_s + factor * (modulated - exp_s)
+        elif mode == MODE_ENHANCEMENT:
+            # Add the driving expression delta (relative to source) on top of
+            # the source expression, scaled by `factor`.
+            new_exp = exp_s + factor * (exp_d - exp_s)
+        else:
+            raise ValueError(f"Unsupported recast mode: {mode!r}")
+
+        # Optional region gating: keep the source expression outside the region.
+        if region != "all":
+            indices = self.EYE_INDICES if region == "eyes" else self.MOUTH_INDICES
+            gated = exp_s.clone()
+            gated[:, indices, :] = new_exp[:, indices, :]
+            new_exp = gated
+
+        kp_e = x_s_c + new_exp
+        kp_rotated = torch.einsum("bmp,bkp->bkm", R, kp_e)
+        kp_rotated = kp_rotated * scale.unsqueeze(1)
+        x_d_i = kp_rotated + t.unsqueeze(1)
+        return x_d_i

--- a/app/processors/workers/frame_worker.py
+++ b/app/processors/workers/frame_worker.py
@@ -4572,16 +4572,26 @@ class FrameWorker(threading.Thread):
                 or parameters["FaceExpressionBrowsToggle"]
                 or parameters["FaceExpressionGeneralToggle"]
                 or parameters.get("FaceExpressionModeSelection", "Advanced") == "Simple"
+                or parameters.get("FaceExpressionModeSelection", "Advanced") == "Recast"
             )
             and parameters["FaceExpressionBeforeTypeSelection"] == "Beginning"
         ):
-            swap = self.frame_edits.apply_face_expression_restorer(
-                original_face_512,
-                swap,
-                cast(dict, parameters),
-                cast(dict, control),
-                driving_kps=kps_all_crop,
-            )
+            if parameters.get("FaceExpressionModeSelection", "Advanced") == "Recast":
+                swap = self.frame_edits.apply_perform_recast(
+                    original_face_512,
+                    swap,
+                    cast(dict, parameters),
+                    cast(dict, control),
+                    driving_kps=kps_all_crop,
+                )
+            else:
+                swap = self.frame_edits.apply_face_expression_restorer(
+                    original_face_512,
+                    swap,
+                    cast(dict, parameters),
+                    cast(dict, control),
+                    driving_kps=kps_all_crop,
+                )
 
         # Face editor beginning
         if (
@@ -4972,17 +4982,27 @@ class FrameWorker(threading.Thread):
                 or parameters["FaceExpressionBrowsToggle"]
                 or parameters["FaceExpressionGeneralToggle"]
                 or parameters.get("FaceExpressionModeSelection", "Advanced") == "Simple"
+                or parameters.get("FaceExpressionModeSelection", "Advanced") == "Recast"
             )
             and parameters["FaceExpressionBeforeTypeSelection"]
             == "After First Restorer"
         ):
-            swap = self.frame_edits.apply_face_expression_restorer(
-                original_face_512,
-                swap,
-                cast(dict, parameters),
-                cast(dict, control),
-                driving_kps=kps_all_crop,
-            )
+            if parameters.get("FaceExpressionModeSelection", "Advanced") == "Recast":
+                swap = self.frame_edits.apply_perform_recast(
+                    original_face_512,
+                    swap,
+                    cast(dict, parameters),
+                    cast(dict, control),
+                    driving_kps=kps_all_crop,
+                )
+            else:
+                swap = self.frame_edits.apply_face_expression_restorer(
+                    original_face_512,
+                    swap,
+                    cast(dict, parameters),
+                    cast(dict, control),
+                    driving_kps=kps_all_crop,
+                )
 
         # Face Editor (After First)
         if (
@@ -5057,17 +5077,27 @@ class FrameWorker(threading.Thread):
                 or parameters["FaceExpressionBrowsToggle"]
                 or parameters["FaceExpressionGeneralToggle"]
                 or parameters.get("FaceExpressionModeSelection", "Advanced") == "Simple"
+                or parameters.get("FaceExpressionModeSelection", "Advanced") == "Recast"
             )
             and parameters["FaceExpressionBeforeTypeSelection"]
             == "After Second Restorer"
         ):
-            swap = self.frame_edits.apply_face_expression_restorer(
-                original_face_512,
-                swap,
-                cast(dict, parameters),
-                cast(dict, control),
-                driving_kps=kps_all_crop,
-            )
+            if parameters.get("FaceExpressionModeSelection", "Advanced") == "Recast":
+                swap = self.frame_edits.apply_perform_recast(
+                    original_face_512,
+                    swap,
+                    cast(dict, parameters),
+                    cast(dict, control),
+                    driving_kps=kps_all_crop,
+                )
+            else:
+                swap = self.frame_edits.apply_face_expression_restorer(
+                    original_face_512,
+                    swap,
+                    cast(dict, parameters),
+                    cast(dict, control),
+                    driving_kps=kps_all_crop,
+                )
 
         # Editor (After Second)
         if (

--- a/app/ui/widgets/actions/control_actions.py
+++ b/app/ui/widgets/actions/control_actions.py
@@ -522,9 +522,16 @@ def _check_and_manage_face_editor_models(main_window: "MainWindow"):
     # Any LivePortrait feature is active if (Edit Face is fully on) OR (Expression Restore is on)
     any_editor_feature_active = true_edit_active or is_expr_restore_active
 
-    # Check the *actual* loaded state from the face_editors module
+    # Check the *actual* loaded state from the face_editors module. The
+    # PerformRecast ("Recast" mode) models are tracked separately because they
+    # are not part of the LivePortrait face-editor group.
+    recast_loaded = any(
+        models_processor.models.get(m) is not None
+        for m in models_processor.perform_recast.model_group
+    )
     models_are_currently_loaded = (
         models_processor.face_editors.current_face_editor_type is not None
+        or recast_loaded
     )
 
     if any_editor_feature_active and not models_are_currently_loaded:
@@ -541,6 +548,8 @@ def _check_and_manage_face_editor_models(main_window: "MainWindow"):
             "[INFO] Face Editor and Expression Restorer are inactive. Unloading LivePortrait models."
         )
         models_processor.unload_face_editor_models()
+        if recast_loaded:
+            models_processor.unload_perform_recast_models()
 
 
 def handle_face_editor_button_click(main_window: "MainWindow"):

--- a/app/ui/widgets/common_layout_data.py
+++ b/app/ui/widgets/common_layout_data.py
@@ -233,11 +233,12 @@ COMMON_LAYOUT_DATA: Any = {
         "FaceExpressionModeSelection": {
             "level": 2,
             "label": "Mode",
-            "options": ["Simple", "Advanced"],
+            "options": ["Simple", "Advanced", "Recast"],
             "default": "Simple",
             "parentToggle": "FaceExpressionEnableBothToggle",
             "requiredToggleValue": True,
-            "help": "Choose 'Advanced' for fine-tuning and retargeting options.",
+            "help": "Choose 'Advanced' for fine-tuning and retargeting options. "
+            "'Recast' uses the PerformRecast model for expression-only transfer.",
         },
         "FaceExpressionCropScaleBothDecimalSlider": {
             "level": 2,
@@ -262,6 +263,47 @@ COMMON_LAYOUT_DATA: Any = {
             "parentToggle": "FaceExpressionEnableBothToggle",
             "requiredToggleValue": True,
             "help": "Changes the vy ratio for crop scale. Increase the value to capture the face more distantly.",
+        },
+        # --- RECAST MODE WIDGETS (PerformRecast model) ---
+        "RecastModeSelection": {
+            "level": 3,
+            "label": "Recast Mode",
+            "options": ["Enhancement", "Replacement"],
+            "default": "Enhancement",
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Enhancement adds the driving expression on top of the swapped face's "
+            "expression. Replacement starts from the driving expression and blends back "
+            "the swapped face's eye/lip/jaw identity cues.",
+        },
+        "RecastExpressionFactorDecimalSlider": {
+            "level": 3,
+            "label": "Expression Factor",
+            "min_value": "0.0",
+            "max_value": "2.0",
+            "default": "1.0",
+            "step": 0.1,
+            "decimals": 1,
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Strength of the transferred expression. 0.0 keeps the swapped face's "
+            "expression, 1.0 applies the full driving expression, >1.0 exaggerates it.",
+        },
+        "RecastAnimationRegionSelection": {
+            "level": 3,
+            "label": "Animation Region",
+            "options": ["all", "eyes", "lips"],
+            "default": "all",
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Restrict the transferred expression to a facial region. The swapped "
+            "face's own expression is kept outside the selected region.",
         },
         # --- SIMPLE MODE WIDGETS (RESTORING OLD FUNCTIONALITY) ---
         "FaceExpressionNeutralDecimalSlider": {

--- a/tests/unit/processors/test_perform_recast.py
+++ b/tests/unit/processors/test_perform_recast.py
@@ -1,0 +1,322 @@
+"""Unit tests for app.processors.perform_recast (PerformRecast "Recast" mode).
+
+These exercise the pure logic — keypoint transform, the two composition modes,
+region gating and the W->G warp_decode chaining — with fully mocked ONNX
+sessions, so no GPU / real models are required.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+# perform_recast imports only numpy/torch (no onnxruntime at module level), so
+# no stubbing is required to import it here.
+from app.processors.perform_recast import (  # noqa: E402
+    NUM_KP,
+    MODE_ENHANCEMENT,
+    MODE_REPLACEMENT,
+    PerformRecast,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _fake_session(output_arrays: dict) -> MagicMock:
+    """Build a fake InferenceSession returning the given {name: ndarray}.
+
+    `get_outputs()` reports the names in insertion order; `run()` returns the
+    arrays in the same order (computed lazily so per-call shapes can depend on
+    feeds if a callable is supplied).
+    """
+    session = MagicMock()
+    out_objs = []
+    for name in output_arrays:
+        o = MagicMock()
+        o.name = name
+        out_objs.append(o)
+    session.get_outputs.return_value = out_objs
+
+    def _run(_names, feeds):
+        result = []
+        for name, val in output_arrays.items():
+            result.append(val(feeds) if callable(val) else val)
+        return result
+
+    session.run.side_effect = _run
+    return session
+
+
+class _FakeModelsProcessor:
+    def __init__(self):
+        self.device = torch.device("cpu")
+        self.models: dict = {}
+        self._sessions: dict = {}
+
+    def register(self, name, session):
+        self._sessions[name] = session
+
+    def load_model(self, name):
+        return self._sessions.get(name)
+
+    def unload_model(self, name, force_immediate=False):
+        self.models[name] = None
+
+
+def _motion_outputs(seed: int) -> dict:
+    """Deterministic motion-extractor outputs of the correct shapes."""
+    rng = np.random.RandomState(seed)
+    return {
+        "pitch": rng.rand(1, 66).astype(np.float32),
+        "yaw": rng.rand(1, 66).astype(np.float32),
+        "roll": rng.rand(1, 66).astype(np.float32),
+        "t": rng.rand(1, 3).astype(np.float32),
+        "exp": rng.rand(1, NUM_KP * 3).astype(np.float32),
+        "scale": (rng.rand(1, 3).astype(np.float32) + 0.5),
+        "kp": rng.rand(1, NUM_KP * 3).astype(np.float32),
+    }
+
+
+def _make_recast() -> PerformRecast:
+    mp = _FakeModelsProcessor()
+    mp.register("PerformRecastMotionExtractor", _fake_session(_motion_outputs(0)))
+    mp.register(
+        "PerformRecastAppearanceFeatureExtractor",
+        _fake_session({"feature_3d": np.zeros((1, 32, 16, 64, 64), dtype=np.float32)}),
+    )
+    mp.register(
+        "PerformRecastWarpingModule",
+        _fake_session(
+            {
+                "occlusion_map": np.zeros((1, 1, 64, 64), dtype=np.float32),
+                "deformation": np.zeros((1, 16, 64, 64, 3), dtype=np.float32),
+                "out": np.zeros((1, 256, 64, 64), dtype=np.float32),
+            }
+        ),
+    )
+    mp.register(
+        "PerformRecastSpadeGenerator",
+        _fake_session({"out": np.full((1, 3, 512, 512), 0.5, dtype=np.float32)}),
+    )
+    return PerformRecast(mp)  # type: ignore[arg-type]
+
+
+def _torch_motion(seed: int) -> dict:
+    out = _motion_outputs(seed)
+    info = {k: torch.from_numpy(v) for k, v in out.items()}
+    info["exp"] = info["exp"].reshape(1, -1, 3)
+    info["kp"] = info["kp"].reshape(1, -1, 3)
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Geometry
+# ---------------------------------------------------------------------------
+
+
+class TestGeometry:
+    def test_headpose_degree_formula(self):
+        # All probability mass on bin 33 -> 33*3 - 99 == 0 degrees.
+        logits = torch.full((1, 66), -1e4)
+        logits[0, 33] = 1e4
+        deg = PerformRecast._headpose_to_degree(logits)
+        assert deg.shape == (1,)
+        assert abs(deg.item() - 0.0) < 1e-3
+
+    def test_headpose_uses_minus_99_not_975(self):
+        # Mass on bin 0 -> 0*3 - 99 == -99 (PerformRecast convention).
+        logits = torch.full((1, 66), -1e4)
+        logits[0, 0] = 1e4
+        deg = PerformRecast._headpose_to_degree(logits)
+        assert abs(deg.item() - (-99.0)) < 1e-2
+
+    def test_rotation_matrix_identity_at_zero(self):
+        z = torch.zeros(1)
+        R = PerformRecast._rotation_matrix(z, z, z)
+        assert R.shape == (1, 3, 3)
+        assert torch.allclose(R[0], torch.eye(3), atol=1e-5)
+
+    def test_rotation_matrix_is_orthonormal(self):
+        R = PerformRecast._rotation_matrix(
+            torch.tensor([30.0]), torch.tensor([15.0]), torch.tensor([-20.0])
+        )
+        ident = R[0] @ R[0].T
+        assert torch.allclose(ident, torch.eye(3), atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Source descriptor
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSourceInfo:
+    def test_shapes(self):
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(2))
+        assert info["kp"].shape == (1, NUM_KP, 3)
+        assert info["exp"].shape == (1, NUM_KP, 3)
+        assert info["R"].shape == (1, 3, 3)
+        assert info["x_s"].shape == (1, NUM_KP, 3)
+
+    def test_tz_is_zeroed(self):
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(2))
+        assert torch.all(info["t"][..., 2] == 0)
+
+
+# ---------------------------------------------------------------------------
+# Composition modes
+# ---------------------------------------------------------------------------
+
+
+class TestComposeDrivenKeypoints:
+    def test_enhancement_factor_zero_equals_source(self):
+        """factor=0 keeps the source expression -> driven kp == source x_s."""
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(3))
+        exp_d = _torch_motion(99)["exp"]
+        x_d = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_ENHANCEMENT, factor=0.0
+        )
+        assert torch.allclose(x_d, info["x_s"], atol=1e-5)
+
+    def test_enhancement_factor_one_differs_from_source(self):
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(3))
+        exp_d = _torch_motion(99)["exp"]
+        x_d = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_ENHANCEMENT, factor=1.0
+        )
+        assert x_d.shape == (1, NUM_KP, 3)
+        assert not torch.allclose(x_d, info["x_s"], atol=1e-4)
+
+    def test_replacement_returns_correct_shape(self):
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(4))
+        exp_d = _torch_motion(7)["exp"]
+        x_d = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_REPLACEMENT, factor=1.0
+        )
+        assert x_d.shape == (1, NUM_KP, 3)
+
+    def test_unknown_mode_raises(self):
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(4))
+        exp_d = _torch_motion(7)["exp"]
+        with pytest.raises(ValueError):
+            recast.compose_driven_keypoints(info, exp_d, mode="Bogus")
+
+    def test_region_eyes_keeps_non_eye_keypoints_at_source(self):
+        """With region='eyes', keypoints outside the eye group are unchanged."""
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(5))
+        exp_d = _torch_motion(50)["exp"]
+        x_d = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_ENHANCEMENT, factor=1.0, region="eyes"
+        )
+        eye = recast.EYE_INDICES
+        non_eye = [i for i in range(NUM_KP) if i not in eye]
+        # Transform is applied per-keypoint independently, so untouched
+        # expression channels map to the unchanged source keypoints.
+        assert torch.allclose(x_d[:, non_eye, :], info["x_s"][:, non_eye, :], atol=1e-5)
+        assert not torch.allclose(x_d[:, eye, :], info["x_s"][:, eye, :], atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Model-level API
+# ---------------------------------------------------------------------------
+
+
+class TestModelAPI:
+    def test_motion_reshapes_exp_and_kp(self):
+        recast = _make_recast()
+        img = torch.randint(0, 256, (3, 256, 256), dtype=torch.uint8)
+        info = recast.motion(img)
+        assert info["exp"].shape == (1, NUM_KP, 3)
+        assert info["kp"].shape == (1, NUM_KP, 3)
+        assert info["scale"].shape == (1, 3)
+
+    def test_extract_appearance_shape(self):
+        recast = _make_recast()
+        img = torch.randint(0, 256, (3, 512, 512), dtype=torch.uint8)
+        feat = recast.extract_appearance(img)
+        assert feat.shape == (1, 32, 16, 64, 64)
+
+    def test_warp_decode_chains_w_then_g(self):
+        recast = _make_recast()
+        f_s = np.zeros((1, 32, 16, 64, 64), dtype=np.float32)
+        x_s = torch.zeros(1, NUM_KP, 3)
+        x_d = torch.zeros(1, NUM_KP, 3)
+        out = recast.warp_decode(f_s, x_s, x_d)
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (1, 3, 512, 512)
+
+    def test_to_input_normalises_to_0_1_with_batch(self):
+        arr = PerformRecast._to_input(torch.full((3, 8, 8), 255, dtype=torch.uint8))
+        assert arr.shape == (1, 3, 8, 8)
+        assert arr.dtype == np.float32
+        assert pytest.approx(arr.max(), abs=1e-6) == 1.0
+
+    def test_unload_models_calls_unload_for_each(self):
+        recast = _make_recast()
+        # Pretend all four are loaded.
+        for name in recast.model_group:
+            recast.models_processor.models[name] = object()
+        recast.unload_models()
+        for name in recast.model_group:
+            assert recast.models_processor.models[name] is None
+
+
+# ---------------------------------------------------------------------------
+# TensorRT readiness: the warping module needs shape inference (GridSample)
+# ---------------------------------------------------------------------------
+
+_WARPING_ONNX = os.path.join(
+    os.path.dirname(__file__),
+    "..", "..", "..", "model_assets", "performrecast_onnx", "warping_module.onnx",
+)
+
+
+class TestTensorRTShapeInference:
+    def test_warping_module_listed_for_shape_inference(self):
+        from app.processors.models_data import tensorrt_shape_infer_models
+
+        assert "PerformRecastWarpingModule" in tensorrt_shape_infer_models
+
+    @pytest.mark.skipif(
+        not os.path.exists(_WARPING_ONNX),
+        reason="warping_module.onnx not downloaded",
+    )
+    def test_static_shape_inference_makes_gridsample_shapes_concrete(self):
+        """The TRT 'has no shape specified' error is fixed once GridSample
+        outputs gain concrete shapes after batch pinning + shape inference."""
+        import onnx
+        from onnxruntime.tools.onnx_model_utils import make_dim_param_fixed
+        from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
+
+        model = onnx.load(_WARPING_ONNX)
+        make_dim_param_fixed(model.graph, "batch", 1)
+        model = SymbolicShapeInference.infer_shapes(
+            model, auto_merge=True, guess_output_rank=True
+        )
+        grid_vis = [
+            vi
+            for vi in list(model.graph.value_info) + list(model.graph.output)
+            if "GridSample" in vi.name
+        ]
+        assert grid_vis, "expected GridSample tensors in the warping module"
+        for vi in grid_vis:
+            dims = vi.type.tensor_type.shape.dim
+            assert len(dims) > 0, f"{vi.name} still has no shape"
+            # Every dim must be a concrete integer (no dim_param) for TRT.
+            for d in dims:
+                assert d.dim_value > 0 and not d.dim_param, (
+                    f"{vi.name} has a non-static dim: {d}"
+                )

--- a/tests/unit/ui/test_common_layout_recast.py
+++ b/tests/unit/ui/test_common_layout_recast.py
@@ -1,0 +1,85 @@
+"""Schema tests for the PerformRecast "Recast" widgets in COMMON_LAYOUT_DATA.
+
+Pure data-validation — no Qt/GPU. control_actions is stubbed so the module
+imports without PySide6.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+
+def _stub_module(name: str) -> MagicMock:
+    mod = MagicMock()
+    mod.__name__ = name
+    mod.__spec__ = None
+    return mod
+
+
+for _mod_name in [
+    "PySide6",
+    "PySide6.QtWidgets",
+    "PySide6.QtCore",
+    "PySide6.QtGui",
+    "app.ui.widgets.actions.control_actions",
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _stub_module(_mod_name)
+
+try:
+    import cv2  # noqa: F401
+except ImportError:
+    sys.modules["cv2"] = MagicMock()
+
+# common_layout_data uses `import app.ui.widgets.actions.control_actions as ...`.
+# With the leaf stubbed but the parent namespace package not yet imported, that
+# dotted form fails to resolve `actions`. Import the real (cheap, __init__-less)
+# namespace package first so the stubbed leaf binds correctly.
+import app.ui.widgets.actions  # noqa: E402,F401
+
+from app.ui.widgets.common_layout_data import COMMON_LAYOUT_DATA  # noqa: E402
+
+FACE_EXPR = COMMON_LAYOUT_DATA["Face expressions"]
+RECAST_WIDGETS = [
+    "RecastModeSelection",
+    "RecastExpressionFactorDecimalSlider",
+    "RecastAnimationRegionSelection",
+]
+
+
+def test_recast_is_a_mode_option():
+    assert "Recast" in FACE_EXPR["FaceExpressionModeSelection"]["options"]
+
+
+def test_recast_widgets_exist():
+    for name in RECAST_WIDGETS:
+        assert name in FACE_EXPR, f"{name} missing from Face expressions"
+
+
+def test_recast_widgets_gated_on_recast_selection():
+    for name in RECAST_WIDGETS:
+        entry = FACE_EXPR[name]
+        assert entry.get("parentSelection") == "FaceExpressionModeSelection"
+        assert entry.get("requiredSelectionValue") == "Recast"
+        assert entry.get("parentToggle") == "FaceExpressionEnableBothToggle"
+        assert entry.get("requiredToggleValue") is True
+
+
+def test_recast_mode_options_and_default():
+    entry = FACE_EXPR["RecastModeSelection"]
+    assert entry["options"] == ["Enhancement", "Replacement"]
+    assert entry["default"] in entry["options"]
+
+
+def test_recast_region_options_and_default():
+    entry = FACE_EXPR["RecastAnimationRegionSelection"]
+    assert entry["options"] == ["all", "eyes", "lips"]
+    assert entry["default"] == "all"
+
+
+def test_recast_expression_factor_range():
+    entry = FACE_EXPR["RecastExpressionFactorDecimalSlider"]
+    assert float(entry["min_value"]) == 0.0
+    assert float(entry["max_value"]) == 2.0
+    assert float(entry["default"]) == 1.0


### PR DESCRIPTION
integrated ONNX PerformRecast (https://github.com/youku-aigc/PerformRecast) models as a third Recast option in the existing Face Expression Restorer (alongside Simple/Advanced), wired end-to-end with UI, model registration, inference, and tests.

Changes:

Models (app/processors/models_data.py)
- Registered 4 new models: PerformRecastAppearanceFeatureExtractor (F), PerformRecastMotionExtractor (M), PerformRecastWarpingModule (W), PerformRecastSpadeGenerator (G).
- Added F and M to fp16_safe_models_list; W and G stay fp32 (5-D grid_sample / SPADE have no fp16 kernel - matching the upstream constraint).

New inference module (app/processors/perform_recast.py) — PerformRecast class with the 4 model calls, 49-keypoint transform, W to G warp_decode chain, and two composition modes

Pipeline:
- models_processor.py: instantiates self.perform_recast + a lock-guarded unloader.
- frame_edits.py: new apply_perform_recast() reusing the existing crop/landmark/paste-back scaffolding.
- frame_worker.py: all 3 pipeline positions (Beginning / After First / After Second) branch to Recast when the mode is selected.
- common_layout_data.py: Recast added to the mode dropdown + 3 gated widgets (RecastModeSelection, RecastExpressionFactorDecimalSlider, RecastAnimationRegionSelection).
- control_actions.py: unloads the Recast models when the feature is turned off.

Tests - test_perform_recast.py (17 tests: geometry, both modes, region gating, W to G chaining) and test_common_layout_recast.py (5 tests: UI schema).