### PR TITLE
PerformRecast: fix fidelity/perf/UX issues

### DIFF
--- a/app/helpers/downloader.py
+++ b/app/helpers/downloader.py
@@ -37,6 +37,14 @@ def download_file(
         bool: True if the file was successfully downloaded and verified, False otherwise.
     """
 
+    # Ensure the destination directory exists. Models grouped under subfolders
+    # (e.g. ``model_assets/performrecast_onnx/``) would otherwise fail with a
+    # FileNotFoundError on a fresh/portable install where the subfolder has not
+    # been created yet (the root cause of broken portable update downloads).
+    parent_dir = os.path.dirname(file_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
     # First, check if the file already exists and has the correct integrity.
     # This avoids re-downloading large files unnecessarily.
     if Path(file_path).is_file():

--- a/app/processors/frame_edits.py
+++ b/app/processors/frame_edits.py
@@ -39,6 +39,12 @@ class FrameEdits:
         )
         self.interpolation_expression_faceeditor_back = None
 
+        # Per-face EMA state for the optional Recast expression smoothing
+        # (``RecastExpressionSmoothToggle``). Keyed by a quantized face centroid
+        # so multiple faces in a frame are smoothed independently. Stateless
+        # frame processing otherwise has no driving-frame history.
+        self._recast_exp_state: dict = {}
+
     def set_transforms(self, t256_face, interpolation_expression_faceeditor_back):
         """
         Updates the scaling transforms and interpolation modes based on current control settings.
@@ -893,6 +899,63 @@ class FrameEdits:
 
         return out.type(torch.float32)
 
+    def _recast_smooth_exp(
+        self, exp_d: torch.Tensor, source_lmk, strength: float
+    ) -> torch.Tensor:
+        """Temporally smooth the driving expression with a per-face EMA.
+
+        VisoMaster processes frames independently (no driving-frame history),
+        so the upstream Kalman ``flag_smooth`` is approximated here with a
+        simple exponential moving average kept on the FrameEdits instance.
+        State is matched to the *nearest previous face centroid* within a
+        tolerance (not an exact grid bucket), so a moving face keeps tracking
+        its own EMA frame-to-frame instead of losing it whenever it drifts
+        across a grid boundary (which made smoothing a no-op before).
+        ``strength`` in [0,1] is the weight given to the previous estimate
+        (0 = no smoothing, higher = smoother/more lag).
+        """
+        strength = max(0.0, min(1.0, float(strength)))
+        if strength <= 0.0:
+            return exp_d
+
+        try:
+            centroid = np.asarray(source_lmk, dtype=np.float32).reshape(-1, 2).mean(0)
+            cx, cy = float(centroid[0]), float(centroid[1])
+        except Exception:
+            cx, cy = 0.0, 0.0
+
+        # Find the closest tracked face within tolerance (face size ~ hundreds
+        # of px, so 120px comfortably covers normal frame-to-frame motion).
+        tol = 120.0
+        best_key = None
+        best_dist = tol
+        for k, (pcx, pcy, _exp) in self._recast_exp_state.items():
+            dist = ((pcx - cx) ** 2 + (pcy - cy) ** 2) ** 0.5
+            if dist <= best_dist:
+                best_dist = dist
+                best_key = k
+
+        if best_key is not None:
+            _pcx, _pcy, prev = self._recast_exp_state[best_key]
+            if prev.shape == exp_d.shape:
+                smoothed = prev.to(exp_d.device) * strength + exp_d * (1.0 - strength)
+            else:
+                smoothed = exp_d
+            key = best_key
+        else:
+            smoothed = exp_d
+            # New face slot keyed by an incrementing id.
+            key = max(self._recast_exp_state.keys(), default=-1) + 1
+
+        self._recast_exp_state[key] = (cx, cy, smoothed.detach().clone())
+
+        # Bound the state dict so long multi-face sessions can't grow unbounded.
+        if len(self._recast_exp_state) > 16:
+            self._recast_exp_state.clear()
+            self._recast_exp_state[0] = (cx, cy, smoothed.detach().clone())
+
+        return smoothed
+
     def apply_perform_recast(
         self,
         driving: torch.Tensor,
@@ -934,6 +997,11 @@ class FrameEdits:
             else contextlib.nullcontext()
         )
 
+        # Eagerly load (and build TensorRT engines for) all four sub-networks so
+        # the build dialog is shown for every PerformRecast model, not just the
+        # ones that happen to need a lazy first-run build.
+        recast.prewarm()
+
         with stream_context, torch.inference_mode():
             use_mean_eyes = parameters.get("LandmarkMeanEyesToggle", False)
 
@@ -942,8 +1010,32 @@ class FrameEdits:
                 mode = mode.strip()
             factor = float(parameters.get("RecastExpressionFactorDecimalSlider", 1.0))
             region = parameters.get("RecastAnimationRegionSelection", "all")
+            eye_weight = float(
+                parameters.get("RecastEyeDrivingWeightDecimalSlider", 0.7)
+            )
+            lip_weight = float(
+                parameters.get("RecastLipDrivingWeightDecimalSlider", 0.8)
+            )
+            smooth_on = parameters.get("RecastExpressionSmoothToggle", False)
+            smooth_strength = float(
+                parameters.get("RecastSmoothStrengthDecimalSlider", 0.5)
+            )
+            feather_amount = float(
+                parameters.get("RecastPasteBackFeatherDecimalSlider", 0.0)
+            )
 
-            crop_scale = parameters.get("FaceExpressionCropScaleBothDecimalSlider", 2.3)
+            # Dedicated Recast crop scale, independent of the shared expression
+            # crop used by the Simple/Advanced (LivePortrait) modes. Tighter
+            # crops give better identity detail but, if too tight for a pose,
+            # drive the generator out of distribution into black frames (caught
+            # by the degenerate-output guard below; fp16 widens that range).
+            # Default matches the proven 2.3 framing; raise for VR180.
+            crop_scale = parameters.get("RecastCropScaleDecimalSlider", None)
+            if crop_scale is None:
+                crop_scale = parameters.get(
+                    "FaceExpressionCropScaleBothDecimalSlider", 2.3
+                )
+            crop_scale = float(crop_scale)
             vy_ratio = parameters.get("FaceExpressionVYRatioBothDecimalSlider", -0.125)
             interp_mode = (
                 self.interpolation_expression_faceeditor_back
@@ -951,13 +1043,19 @@ class FrameEdits:
                 else v2.InterpolationMode.BILINEAR
             )
 
+            # Detection bboxes are derived from the actual tensor size rather
+            # than hardcoded to 512. In VR180 mode the face tensor handed to
+            # Recast is not guaranteed to be exactly 512x512, and a mismatched
+            # bbox produced degenerate landmarks / crops.
+            d_h, d_w = int(driving.shape[-2]), int(driving.shape[-1])
+
             # --- DRIVING FACE (source of expression) ---
             if driving_kps is not None and not np.all(driving_kps == 0):
                 driving_lmk_crop = driving_kps
             else:
                 _, driving_lmk_crop, _ = self.models_processor.run_detect_landmark(
                     driving,
-                    bbox=np.array([0, 0, 512, 512]),
+                    bbox=np.array([0, 0, d_w, d_h], dtype=np.float32),
                     det_kpss=[],
                     detect_mode="203",
                     score=0.5,
@@ -977,6 +1075,10 @@ class FrameEdits:
                 scale=crop_scale,
                 vy_ratio=vy_ratio,
                 interpolation=interp_mode,
+                # Replicate edge pixels instead of filling out-of-bounds samples
+                # with black — prevents all-black face crops when the crop window
+                # extends past the image (the VR180 black-crop bug).
+                padding_mode="border",
             )
             driving_face_256 = self.t256_face(driving_face_512)
             x_d_info = recast.motion(driving_face_256)
@@ -984,9 +1086,10 @@ class FrameEdits:
 
             # --- TARGET FACE (identity / pose to preserve) ---
             target = target.clamp(0, 255).type(torch.uint8)
+            t_h, t_w = int(target.shape[-2]), int(target.shape[-1])
             _, source_lmk, _ = self.models_processor.run_detect_landmark(
                 target,
-                bbox=np.array([0, 0, 512, 512], dtype=np.float32),
+                bbox=np.array([0, 0, t_w, t_h], dtype=np.float32),
                 det_kpss=None,
                 detect_mode="203",
                 score=0.5,
@@ -1005,6 +1108,7 @@ class FrameEdits:
                 scale=crop_scale,
                 vy_ratio=vy_ratio,
                 interpolation=interp_mode,
+                padding_mode="border",
             )
             target_face_256 = self.t256_face(target_face_512)
 
@@ -1013,14 +1117,50 @@ class FrameEdits:
             source_info = recast.build_source_info(x_s_info)
             f_s = recast.extract_appearance(target_face_512)
 
+            # Optional temporal smoothing of the driving expression.
+            if smooth_on:
+                exp_d = self._recast_smooth_exp(exp_d, source_lmk, smooth_strength)
+
             # --- COMPOSE + GENERATE ---
             x_d_i = recast.compose_driven_keypoints(
-                source_info, exp_d, mode=mode, factor=factor, region=region
+                source_info,
+                exp_d,
+                mode=mode,
+                factor=factor,
+                region=region,
+                eye_driving_weight=eye_weight,
+                lip_driving_weight=lip_weight,
             )
             out = recast.warp_decode(f_s, source_info["x_s"], x_d_i)
-            out = torch.squeeze(out).clamp_(0, 1)
+            out = torch.squeeze(out)
+
+            # --- DEGENERATE-OUTPUT GUARD ---
+            # The PerformRecast generator can emit an all-black (or NaN/Inf)
+            # frame when it is fed an out-of-distribution crop (e.g. a too-tight
+            # crop scale, or an extreme keypoint pose that overflows the fp16
+            # warp). Rather than paste a black face into the result, fall back to
+            # the un-recast swap for this frame so the output stays clean.
+            if not torch.isfinite(out).all() or ((out < 0.02).float().mean() > 0.9):
+                return target.type(torch.float32)
+            out = out.clamp_(0, 1)
 
             # --- PASTE BACK ---
+            # Optionally feather the crop border so the recast face blends into
+            # the surrounding swap instead of showing a hard 512-crop seam. The
+            # border falls back to the underlying swapped-face crop (not black),
+            # so this only affects the edge transition, never identity.
+            if feather_amount > 0.0:
+                fade = max(1, int(round(feather_amount * 256)))
+                paste_mask = faceutil.create_faded_inner_mask(
+                    (out.shape[1], out.shape[2]),
+                    border_thickness=0,
+                    fade_thickness=fade,
+                    blur_radius=3,
+                    device=out.device,
+                ).unsqueeze(0)
+                tgt01 = (target_face_512.to(out.dtype) / 255.0).clamp_(0, 1)
+                out = out * paste_mask + tgt01 * (1.0 - paste_mask)
+
             dsize = (target.shape[1], target.shape[2])
             out = self._apply_kornia_warp(out, M_c2o, dsize)
             out = out.mul_(255.0).clamp_(0, 255)

--- a/app/processors/models_data.py
+++ b/app/processors/models_data.py
@@ -6,6 +6,16 @@ models_dir = Path(__file__).resolve().parent.parent.parent / "model_assets"
 refldm_ckpts_path = models_dir / "ref-ldm_embedding/ckpts"
 os.makedirs(refldm_ckpts_path, exist_ok=True)
 
+# Ensure the grouped ONNX model subfolders exist up front. On a fresh/portable
+# install (and during portable app updates) these subfolders are otherwise only
+# created on first download — but the PerformRecast models were missing the
+# folder, so the portable updater had nowhere to place the freshly downloaded
+# ONNX files. Creating them here makes the destinations exist regardless of how
+# the models arrive (download vs. copy-in). The downloader also makes parent
+# dirs on demand, so this is belt-and-suspenders.
+for _subfolder in ("liveportrait_onnx", "performrecast_onnx"):
+    os.makedirs(models_dir / _subfolder, exist_ok=True)
+
 assets_repo = "https://github.com/visomaster/visomaster-assets/releases/download"
 
 arcface_mapping_model_dict = {
@@ -46,6 +56,13 @@ fp16_safe_models_list = [
     "LivePortraitStitching",
     "LivePortraitWarpingSpade",
     # --- PerformRecast ---
+    # Only F/M are fp16-safe. We tried building W (warping_module) and G
+    # (spade_generator) as mixed-precision fp16 TensorRT engines from the fp32
+    # ONNX, but in practice fp16 makes the generator emit degenerate / black
+    # faces on many ordinary frames (the 5-D grid_sample / SPADE paths overflow
+    # in fp16) — so at the natural ~2.3 crop scale far too many frames had to be
+    # skipped. This is exactly the caveat documented upstream, so W/G are kept
+    # fp32 (intentionally absent from this list). Do NOT add them back.
     "PerformRecastAppearanceFeatureExtractor",
     "PerformRecastMotionExtractor",
     # --- Detectors ---

--- a/app/processors/models_processor.py
+++ b/app/processors/models_processor.py
@@ -558,23 +558,40 @@ class ModelsProcessor(QtCore.QObject):
             print(
                 f"[INFO] Preparing TensorRT-ready (shape-inferred) ONNX for {model_name}..."
             )
-            from onnxruntime.tools.onnx_model_utils import make_dim_param_fixed
-            from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
-
-            model = onnx.load(onnx_path)
-            # Pin the dynamic 'batch' axis to 1 so symbolic dims (e.g. "50*batch")
-            # resolve to concrete values the TensorRT builder accepts.
-            try:
-                make_dim_param_fixed(model.graph, "batch", 1)
-            except Exception as dim_err:
-                # Not fatal — symbolic shape inference may still add the shapes.
-                print(f"[WARN] Could not pin batch dim for {model_name}: {dim_err}")
-            model = SymbolicShapeInference.infer_shapes(
-                model, auto_merge=True, guess_output_rank=True
+            # This shape-inference pass can take a noticeable amount of time for
+            # large graphs (the PerformRecast warping module is ~200 MB) and runs
+            # *before* the engine-build probe, so without a dialog the UI looks
+            # frozen with no indication of what is happening. Surface a dialog for
+            # this preprocessing step too. It is only paid once (result cached).
+            self.show_build_dialog.emit(
+                "Preparing TensorRT Model",
+                f"Running shape inference for:\n{model_name}\n\n"
+                f"This one-time step prepares the model for the TensorRT engine "
+                f"build and may take a moment.",
             )
-            onnx.save(model, sidecar_path)
-            del model
-            gc.collect()
+            try:
+                from onnxruntime.tools.onnx_model_utils import make_dim_param_fixed
+                from onnxruntime.tools.symbolic_shape_infer import (
+                    SymbolicShapeInference,
+                )
+
+                model = onnx.load(onnx_path)
+                # Pin the dynamic 'batch' axis to 1 so symbolic dims (e.g.
+                # "50*batch") resolve to concrete values the TensorRT builder
+                # accepts.
+                try:
+                    make_dim_param_fixed(model.graph, "batch", 1)
+                except Exception as dim_err:
+                    # Not fatal — symbolic shape inference may still add shapes.
+                    print(f"[WARN] Could not pin batch dim for {model_name}: {dim_err}")
+                model = SymbolicShapeInference.infer_shapes(
+                    model, auto_merge=True, guess_output_rank=True
+                )
+                onnx.save(model, sidecar_path)
+                del model
+                gc.collect()
+            finally:
+                self.hide_build_dialog.emit()
             print(f"[INFO] Wrote shape-inferred ONNX: {os.path.basename(sidecar_path)}")
             return sidecar_path
         except Exception as e:

--- a/app/processors/perform_recast.py
+++ b/app/processors/perform_recast.py
@@ -73,22 +73,38 @@ class PerformRecast:
             raise RuntimeError(f"Model {model_name} could not be loaded")
         return session
 
-    def _run(self, model_name: str, feeds: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
-        """Run a model and return {output_name: np.ndarray}.
+    def _infer(
+        self,
+        model_name: str,
+        inputs: Dict[str, "torch.Tensor"],
+        output_specs: Dict[str, tuple],
+    ) -> Dict[str, "torch.Tensor"]:
+        """Run a model and return the requested outputs as torch tensors.
 
-        The exported graphs always take/return float32 (``keep_io_types=True``
-        for the fp16 variants), so every feed is coerced to contiguous float32.
+        On CUDA this uses zero-copy onnxruntime IO binding (matching
+        ``FaceEditors._run_onnx_io_binding``) so the per-frame inputs/outputs
+        stay on the GPU instead of round-tripping through host numpy buffers —
+        the original ``session.run(None, feeds)`` path forced a full CPU<->GPU
+        copy of every tensor each call (notably the 32x16x64x64 feature volume
+        and the 256x64x64 warp output), which is why Recast was slower than the
+        IO-bound LivePortrait expression restorer. On CPU (and under the mocked
+        sessions used by the unit tests) it falls back to ``session.run``.
+
+        Args:
+            model_name: registry key of the sub-network.
+            inputs: feed name -> torch tensor (any device/dtype; coerced to
+                contiguous float32 on the models_processor device).
+            output_specs: output name -> concrete shape for the outputs we
+                actually consume. Other graph outputs are still produced but
+                left for onnxruntime to allocate (we never read them).
 
         TensorRT "lazy build" models compile their engine on the first real
         inference (not during the isolated probe). We surface the build dialog
-        around that first run so the UI does not appear frozen — mirroring
-        FaceEditors._run_onnx_io_binding.
+        around that first run so the UI does not appear frozen.
         """
         session = self._session(model_name)
-        feeds = {k: np.ascontiguousarray(v, dtype=np.float32) for k, v in feeds.items()}
-        names = [o.name for o in session.get_outputs()]
-
         mp = self.models_processor
+
         is_lazy_build = False
         check_pending = getattr(mp, "check_and_clear_pending_build", None)
         if callable(check_pending):
@@ -100,12 +116,99 @@ class PerformRecast:
                 f"This may take several minutes.",
             )
         try:
-            outs = session.run(None, feeds)
+            if getattr(mp, "device_type", "cpu") == "cuda":
+                return self._infer_iobinding(session, inputs, output_specs)
+            return self._infer_numpy(session, inputs, output_specs)
         finally:
             if is_lazy_build:
                 mp.hide_build_dialog.emit()
 
-        return dict(zip(names, outs))
+    def _infer_iobinding(
+        self, session, inputs: Dict[str, "torch.Tensor"], output_specs: Dict[str, tuple]
+    ) -> Dict[str, "torch.Tensor"]:
+        """Zero-copy CUDA inference path (see :meth:`_infer`)."""
+        mp = self.models_processor
+        io_binding = session.io_binding()
+
+        # Keep references to the coerced input tensors alive until run() — the
+        # binding only stores raw data pointers.
+        kept = []
+        for name, tensor in inputs.items():
+            t = tensor.detach().to(mp.device, torch.float32).contiguous()
+            kept.append(t)
+            io_binding.bind_input(
+                name=name,
+                device_type=mp.device_type,
+                device_id=mp.binding_device_id,
+                element_type=np.float32,
+                shape=tuple(t.shape),
+                buffer_ptr=t.data_ptr(),
+            )
+
+        out_buffers: Dict[str, "torch.Tensor"] = {}
+        for o in session.get_outputs():
+            name = o.name
+            if name in output_specs:
+                buf = torch.empty(
+                    output_specs[name], dtype=torch.float32, device=mp.device
+                ).contiguous()
+                out_buffers[name] = buf
+                io_binding.bind_output(
+                    name=name,
+                    device_type=mp.device_type,
+                    device_id=mp.binding_device_id,
+                    element_type=np.float32,
+                    shape=tuple(buf.shape),
+                    buffer_ptr=buf.data_ptr(),
+                )
+            else:
+                # Output we never read — let ORT allocate it on the device.
+                io_binding.bind_output(
+                    name=name,
+                    device_type=mp.device_type,
+                    device_id=mp.binding_device_id,
+                )
+
+        # Ensure PyTorch has finished writing the input buffers before ORT reads
+        # from the bound pointers.
+        if mp.device_type == "cuda":
+            torch.cuda.current_stream().synchronize()
+        session.run_with_iobinding(io_binding)
+        return out_buffers
+
+    def _infer_numpy(
+        self, session, inputs: Dict[str, "torch.Tensor"], output_specs: Dict[str, tuple]
+    ) -> Dict[str, "torch.Tensor"]:
+        """Host (CPU / mocked-session) fallback path (see :meth:`_infer`)."""
+        device = self.models_processor.device
+        feeds = {}
+        for name, tensor in inputs.items():
+            if isinstance(tensor, torch.Tensor):
+                arr = tensor.detach().cpu().numpy()
+            else:
+                arr = tensor
+            feeds[name] = np.ascontiguousarray(arr, dtype=np.float32)
+
+        names = [o.name for o in session.get_outputs()]
+        outs = dict(zip(names, session.run(None, feeds)))
+        return {
+            name: torch.from_numpy(np.asarray(outs[name])).to(device)
+            for name in output_specs
+        }
+
+    def prewarm(self):
+        """Load all four sub-networks up front (no inference).
+
+        Loading each model triggers its TensorRT engine build / cache probe (and
+        the associated "Building TensorRT Cache" dialog) inside
+        ``models_processor.load_model``. Doing this once, eagerly and in a fixed
+        order at the start of a Recast frame — instead of lazily interleaved with
+        inference — guarantees the build dialog is shown for *every* PerformRecast
+        model so the user knows what the app is doing during the (multi-minute)
+        engine builds. It is a cheap dict lookup once the models are loaded.
+        """
+        for model_name in self.model_group:
+            self._session(model_name)
 
     def unload_models(self):
         """Release all four PerformRecast models from VRAM."""
@@ -124,45 +227,70 @@ class PerformRecast:
             x = x.unsqueeze(0)
         return x.contiguous().cpu().numpy()
 
-    def extract_appearance(self, img512: torch.Tensor) -> np.ndarray:
+    def _to_input_t(self, img: torch.Tensor) -> torch.Tensor:
+        """(C,H,W) uint8/float [0,255] -> (1,3,H,W) float32 [0,1] on device."""
+        x = img.detach().to(self.models_processor.device, torch.float32) / 255.0
+        x = torch.clamp(x, 0.0, 1.0)
+        if x.dim() == 3:
+            x = x.unsqueeze(0)
+        return x.contiguous()
+
+    def extract_appearance(self, img512: torch.Tensor) -> torch.Tensor:
         """F: source crop (C,512,512)[0,255] -> feature_3d (1,32,16,64,64)."""
-        feeds = {"source_image": self._to_input(img512)}
-        return self._run(APPEARANCE_MODEL, feeds)["feature_3d"]
+        out = self._infer(
+            APPEARANCE_MODEL,
+            {"source_image": self._to_input_t(img512)},
+            {"feature_3d": (1, 32, 16, 64, 64)},
+        )
+        return out["feature_3d"]
 
     def motion(self, img256: torch.Tensor) -> Dict[str, torch.Tensor]:
         """M: crop (C,256,256)[0,255] -> raw motion dict as torch tensors.
 
-        Keys: pitch, yaw, roll (1,66); t (1,3); scale (1,1);
+        Keys: pitch, yaw, roll (1,66); t (1,3); scale (1,3);
         exp, kp reshaped to (1, NUM_KP, 3).
         """
-        out = self._run(MOTION_MODEL, {"image": self._to_input(img256)})
-        device = self.models_processor.device
-        kp_info = {
-            k: torch.from_numpy(out[k]).to(device)
-            for k in ("pitch", "yaw", "roll", "t", "exp", "scale", "kp")
-        }
+        kp_info = self._infer(
+            MOTION_MODEL,
+            {"image": self._to_input_t(img256)},
+            {
+                "pitch": (1, 66),
+                "yaw": (1, 66),
+                "roll": (1, 66),
+                "t": (1, 3),
+                "exp": (1, NUM_KP * 3),
+                "scale": (1, 3),
+                "kp": (1, NUM_KP * 3),
+            },
+        )
         kp_info["exp"] = kp_info["exp"].reshape(1, -1, 3)
         kp_info["kp"] = kp_info["kp"].reshape(1, -1, 3)
         return kp_info
 
     def warp_decode(
-        self, feature_3d: np.ndarray, kp_source: torch.Tensor, kp_driving: torch.Tensor
+        self, feature_3d, kp_source: torch.Tensor, kp_driving: torch.Tensor
     ) -> torch.Tensor:
         """W + G: D(W(f_s; x_s, x_d)) -> RGB image (1,3,512,512) torch [0,1].
 
-        Note the upstream input ordering: the warping module receives
-        ``kp_driving`` first and ``kp_source`` second.
+        ``feature_3d`` may be a torch tensor (IO-binding path) or a numpy array
+        (legacy/fallback). Note the upstream input ordering: the warping module
+        receives ``kp_driving`` first and ``kp_source`` second. The intermediate
+        warp feature stays on the GPU between W and G on the CUDA path.
         """
-        warped = self._run(
+        device = self.models_processor.device
+        if not isinstance(feature_3d, torch.Tensor):
+            feature_3d = torch.from_numpy(np.asarray(feature_3d)).to(device)
+        warped = self._infer(
             WARPING_MODEL,
             {
                 "feature_3d": feature_3d,
-                "kp_driving": kp_driving.detach().cpu().numpy(),
-                "kp_source": kp_source.detach().cpu().numpy(),
+                "kp_driving": kp_driving,
+                "kp_source": kp_source,
             },
+            {"out": (1, 256, 64, 64)},
         )["out"]
-        out = self._run(SPADE_MODEL, {"feature": warped})["out"]
-        return torch.from_numpy(out).to(self.models_processor.device)
+        out = self._infer(SPADE_MODEL, {"feature": warped}, {"out": (1, 3, 512, 512)})
+        return out["out"]
 
     # ------------------------------------------------------------------ #
     # Geometry — ported verbatim from src/pipeline.py (HopeNet -99 binning)
@@ -188,24 +316,53 @@ class PerformRecast:
         ones = torch.ones_like(pitch)
 
         pitch_mat = torch.cat(
-            [ones, zeros, zeros,
-             zeros, torch.cos(pitch), -torch.sin(pitch),
-             zeros, torch.sin(pitch), torch.cos(pitch)], dim=1
+            [
+                ones,
+                zeros,
+                zeros,
+                zeros,
+                torch.cos(pitch),
+                -torch.sin(pitch),
+                zeros,
+                torch.sin(pitch),
+                torch.cos(pitch),
+            ],
+            dim=1,
         ).view(-1, 3, 3)
         yaw_mat = torch.cat(
-            [torch.cos(yaw), zeros, torch.sin(yaw),
-             zeros, ones, zeros,
-             -torch.sin(yaw), zeros, torch.cos(yaw)], dim=1
+            [
+                torch.cos(yaw),
+                zeros,
+                torch.sin(yaw),
+                zeros,
+                ones,
+                zeros,
+                -torch.sin(yaw),
+                zeros,
+                torch.cos(yaw),
+            ],
+            dim=1,
         ).view(-1, 3, 3)
         roll_mat = torch.cat(
-            [torch.cos(roll), -torch.sin(roll), zeros,
-             torch.sin(roll), torch.cos(roll), zeros,
-             zeros, zeros, ones], dim=1
+            [
+                torch.cos(roll),
+                -torch.sin(roll),
+                zeros,
+                torch.sin(roll),
+                torch.cos(roll),
+                zeros,
+                zeros,
+                zeros,
+                ones,
+            ],
+            dim=1,
         ).view(-1, 3, 3)
 
         return torch.einsum("bij,bjk,bkm->bim", pitch_mat, yaw_mat, roll_mat)
 
-    def build_source_info(self, kp_info: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def build_source_info(
+        self, kp_info: Dict[str, torch.Tensor]
+    ) -> Dict[str, torch.Tensor]:
         """Compute the per-frame source descriptor used during animation.
 
         Returns a dict with the canonical keypoints ``kp`` (1,N,3), expression
@@ -234,7 +391,7 @@ class PerformRecast:
     # ------------------------------------------------------------------ #
     # Implicit-keypoint channel groups referenced by the upstream
     # "Replacement" modulation. Used here for optional region gating.
-    EYE_INDICES = list(range(31, 39))    # 31..38 (eye channels)
+    EYE_INDICES = list(range(31, 39))  # 31..38 (eye channels)
     MOUTH_INDICES = list(range(44, 47))  # 44..46 (jaw / lip-contour channels)
 
     def compose_driven_keypoints(
@@ -244,6 +401,8 @@ class PerformRecast:
         mode: str = MODE_ENHANCEMENT,
         factor: float = 1.0,
         region: str = "all",
+        eye_driving_weight: float = 0.7,
+        lip_driving_weight: float = 0.8,
     ) -> torch.Tensor:
         """Build the driven keypoints ``x_d_i`` fed to the warping module.
 
@@ -255,12 +414,24 @@ class PerformRecast:
                 the full transfer; values >1 exaggerate it.
             region: ``"all"`` | ``"eyes"`` | ``"lips"`` — restrict where the
                 driving expression is applied (source expression kept elsewhere).
+            eye_driving_weight: in Replacement mode, how strongly the driver
+                overrides the source eye-channel identity (0 keeps source eyes,
+                1 fully follows the driver). Upstream default 0.7.
+            lip_driving_weight: same, for the lip/jaw channels. Upstream
+                default 0.8.
 
-        Per-frame note: the upstream video pipeline uses the driving video's
-        first frame as the neutral reference for the relative delta. VisoMaster
-        processes frames independently, so the source (swapped) face's own
-        expression is used as that reference — making ``factor`` a clean
-        interpolation between "keep source" and "full driving expression".
+        Mode semantics:
+          * Replacement — ``factor=1`` yields the driver's expression with the
+            swapped face's eye/lip identity blended back (``eye/lip_driving_weight``).
+            ``factor`` interpolates source -> that target.
+          * Enhancement — adds the driver's expression on top of the swapped
+            face's own expression (``exp_s + factor*exp_d``); ``factor=0`` keeps
+            the source, higher values stack/boost the driver's expression.
+
+        The upstream video pipeline uses the driving video's first frame as a
+        neutral reference; VisoMaster is stateless per frame, so Enhancement
+        treats the implicit keypoint ``exp_d`` (already a delta from the
+        canonical keypoints) as the additive delta directly.
         """
         x_s_c = source_info["kp"]
         exp_s = source_info["exp"]
@@ -270,21 +441,43 @@ class PerformRecast:
 
         if mode == MODE_REPLACEMENT:
             # Start from the absolute driving expression and blend back
-            # source-side eye / lip / jaw channels (identity micro-cues).
+            # source-side eye / lip / jaw channels (identity micro-cues). The
+            # blend weights default to the upstream 0.7 (eyes) / 0.8 (lips), but
+            # are exposed so users can dial how strongly the driver overrides
+            # the swapped face's own eye/lip identity (similarity preservation).
+            ew = float(eye_driving_weight)
+            lw = float(lip_driving_weight)
             modulated = exp_d.clone()
             modulated[:, 31:34, 2] = exp_s[:, 31:34, 2]
             modulated[:, 36:39, 2] = exp_s[:, 36:39, 2]
             modulated[:, 44:47, 2] = exp_s[:, 44:47, 2]
             modulated[:, 44:47, 0] = exp_s[:, 44:47, 0]
-            modulated[:, 44:47, 1] = exp_s[:, 44:47, 1] * 0.2 + exp_d[:, 44:47, 1] * 0.8
-            modulated[:, 31:34, :2] = exp_s[:, 31:34, :2] * 0.3 + exp_d[:, 31:34, :2] * 0.7
-            modulated[:, 36:39, :2] = exp_s[:, 36:39, :2] * 0.3 + exp_d[:, 36:39, :2] * 0.7
+            modulated[:, 44:47, 1] = (
+                exp_s[:, 44:47, 1] * (1.0 - lw) + exp_d[:, 44:47, 1] * lw
+            )
+            modulated[:, 31:34, :2] = (
+                exp_s[:, 31:34, :2] * (1.0 - ew) + exp_d[:, 31:34, :2] * ew
+            )
+            modulated[:, 36:39, :2] = (
+                exp_s[:, 36:39, :2] * (1.0 - ew) + exp_d[:, 36:39, :2] * ew
+            )
             # Interpolate from source toward the modulated target by `factor`.
             new_exp = exp_s + factor * (modulated - exp_s)
         elif mode == MODE_ENHANCEMENT:
-            # Add the driving expression delta (relative to source) on top of
-            # the source expression, scaled by `factor`.
-            new_exp = exp_s + factor * (exp_d - exp_s)
+            # ENHANCEMENT = keep the swapped face's own expression and ADD the
+            # driving expression on top of it (scaled by `factor`). This is
+            # genuinely additive, so it stays distinct from Replacement (which
+            # *replaces* the expression with the driver's). The implicit keypoint
+            # `exp` is already a delta from the canonical keypoints, so the
+            # driver's `exp_d` acts as the additive expression delta directly —
+            # no explicit neutral-reference frame is needed.
+            #
+            # (Previously this used `exp_s + factor*(exp_d - exp_s)`, i.e. the
+            # source's own expression as the neutral reference. At factor=1 that
+            # cancels `exp_s` and collapses to `exp_d` — making Enhancement
+            # nearly identical to Replacement, which is why switching modes
+            # appeared to do nothing.)
+            new_exp = exp_s + factor * exp_d
         else:
             raise ValueError(f"Unsupported recast mode: {mode!r}")
 

--- a/app/processors/utils/faceutil.py
+++ b/app/processors/utils/faceutil.py
@@ -1698,6 +1698,12 @@ def warp_face_by_face_landmark_x(img, pts, **kwargs):
     dsize = kwargs.get("dsize", 224)  # Default LivePortrait size
     scale = kwargs.get("scale", 1.5)
     vy_ratio = kwargs.get("vy_ratio", -0.1)
+    # Out-of-bounds sampling fill. Defaults to "zeros" (unchanged behaviour).
+    # Callers that crop with a wide scale and/or a face near the image edge
+    # (e.g. the VR180 perspective crops fed to PerformRecast) can pass
+    # "border" to replicate edge pixels instead of producing black borders,
+    # which otherwise yield all/mostly-black face crops.
+    padding_mode = kwargs.get("padding_mode", "zeros")
 
     # Pad image if necessary
     img = pad_image_by_size(img, dsize)
@@ -1713,7 +1719,9 @@ def warp_face_by_face_landmark_x(img, pts, **kwargs):
 
     # 100% GPU Warping using Kornia
     # Bypasses the slow t = trans.SimilarityTransform() completely
-    warped_img = transform_img_kgm(img.float(), M_o2c, dsize=dsize)
+    warped_img = transform_img_kgm(
+        img.float(), M_o2c, dsize=dsize, padding_mode=padding_mode
+    )
 
     # Ensure we return the original dtype (usually uint8 or float32 depending on pipeline)
     warped_img = warped_img.to(img.dtype)

--- a/app/ui/widgets/common_layout_data.py
+++ b/app/ui/widgets/common_layout_data.py
@@ -280,9 +280,9 @@ COMMON_LAYOUT_DATA: Any = {
         },
         "RecastExpressionFactorDecimalSlider": {
             "level": 3,
-            "label": "Expression Factor",
+            "label": "Expression Strength",
             "min_value": "0.0",
-            "max_value": "2.0",
+            "max_value": "3.0",
             "default": "1.0",
             "step": 0.1,
             "decimals": 1,
@@ -290,8 +290,30 @@ COMMON_LAYOUT_DATA: Any = {
             "requiredToggleValue": True,
             "parentSelection": "FaceExpressionModeSelection",
             "requiredSelectionValue": "Recast",
-            "help": "Strength of the transferred expression. 0.0 keeps the swapped face's "
-            "expression, 1.0 applies the full driving expression, >1.0 exaggerates it.",
+            "help": "Strength / exaggeration of the transferred expression. 0.0 keeps "
+            "the swapped face's expression, 1.0 applies the full driving expression, "
+            ">1.0 exaggerates it (up to 3.0 for stylization).",
+        },
+        "RecastCropScaleDecimalSlider": {
+            "level": 3,
+            "label": "Recast Crop Scale",
+            "min_value": "1.5",
+            "max_value": "3.0",
+            "default": "2.3",
+            "step": 0.1,
+            "decimals": 1,
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Face crop framing fed to the PerformRecast models, independent of "
+            "the shared 'Crop Scale' used by the Simple/Advanced (LivePortrait) modes. "
+            "LOWER = tighter face = more identity detail / better similarity, but too "
+            "tight for a given pose makes the generator emit a black frame (which is "
+            "skipped, keeping the plain swap). RAISE it if you see black/missing faces — "
+            "VR180 framing usually needs ~2.8-3.0. fp16 widens the black-prone range, so "
+            "if you want to go tighter for similarity and see flicker, either raise this "
+            "slightly or tune similarity via Mode / Expression Strength / Eye-Lip weights.",
         },
         "RecastAnimationRegionSelection": {
             "level": 3,
@@ -303,7 +325,81 @@ COMMON_LAYOUT_DATA: Any = {
             "parentSelection": "FaceExpressionModeSelection",
             "requiredSelectionValue": "Recast",
             "help": "Restrict the transferred expression to a facial region. The swapped "
-            "face's own expression is kept outside the selected region.",
+            "face's own expression is kept outside the selected region. Index groups: "
+            "eyes = keypoints 31-38, lips/jaw = keypoints 44-46.",
+        },
+        "RecastEyeDrivingWeightDecimalSlider": {
+            "level": 4,
+            "label": "Eye Driving Weight",
+            "min_value": "0.0",
+            "max_value": "1.0",
+            "default": "0.7",
+            "step": 0.05,
+            "decimals": 2,
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Replacement mode only: how strongly the driver overrides the swapped "
+            "face's eye-channel identity. 0.0 keeps the swapped face's eyes, 1.0 fully "
+            "follows the driver. Default 0.7 matches the upstream PerformRecast blend.",
+        },
+        "RecastLipDrivingWeightDecimalSlider": {
+            "level": 4,
+            "label": "Lip Driving Weight",
+            "min_value": "0.0",
+            "max_value": "1.0",
+            "default": "0.8",
+            "step": 0.05,
+            "decimals": 2,
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Replacement mode only: how strongly the driver overrides the swapped "
+            "face's lip/jaw identity. 0.0 keeps the swapped face's lips, 1.0 fully follows "
+            "the driver. Default 0.8 matches the upstream PerformRecast blend.",
+        },
+        "RecastExpressionSmoothToggle": {
+            "level": 3,
+            "label": "Smooth Expression",
+            "default": False,
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Temporally smooth the driving expression with a per-face exponential "
+            "moving average to reduce micro-jitter / flicker between frames.",
+        },
+        "RecastSmoothStrengthDecimalSlider": {
+            "level": 4,
+            "label": "Smooth Strength",
+            "min_value": "0.0",
+            "max_value": "0.95",
+            "default": "0.5",
+            "step": 0.05,
+            "decimals": 2,
+            "parentToggle": "FaceExpressionEnableBothToggle & RecastExpressionSmoothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Weight given to the previous frame's expression. 0.0 = no smoothing, "
+            "higher = smoother but more lag.",
+        },
+        "RecastPasteBackFeatherDecimalSlider": {
+            "level": 3,
+            "label": "Paste-back Feather",
+            "min_value": "0.0",
+            "max_value": "0.3",
+            "default": "0.0",
+            "step": 0.02,
+            "decimals": 2,
+            "parentToggle": "FaceExpressionEnableBothToggle",
+            "requiredToggleValue": True,
+            "parentSelection": "FaceExpressionModeSelection",
+            "requiredSelectionValue": "Recast",
+            "help": "Feather the recast crop border so it blends into the surrounding "
+            "swapped face instead of showing a hard crop seam. 0.0 disables it.",
         },
         # --- SIMPLE MODE WIDGETS (RESTORING OLD FUNCTIONALITY) ---
         "FaceExpressionNeutralDecimalSlider": {

--- a/tests/unit/processors/test_perform_recast.py
+++ b/tests/unit/processors/test_perform_recast.py
@@ -197,6 +197,35 @@ class TestComposeDrivenKeypoints:
         assert x_d.shape == (1, NUM_KP, 3)
         assert not torch.allclose(x_d, info["x_s"], atol=1e-4)
 
+    def test_modes_produce_different_results(self):
+        """Enhancement (additive) must differ from Replacement at factor=1 —
+        the regression that made switching modes a no-op."""
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(13))
+        exp_d = _torch_motion(77)["exp"]
+        x_enh = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_ENHANCEMENT, factor=1.0
+        )
+        x_rep = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_REPLACEMENT, factor=1.0
+        )
+        assert not torch.allclose(x_enh, x_rep, atol=1e-4)
+
+    def test_enhancement_is_additive(self):
+        """Enhancement adds the driver's expression on top of the source."""
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(14))
+        exp_d = _torch_motion(88)["exp"]
+        x_d = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_ENHANCEMENT, factor=1.0
+        )
+        # Reconstruct expected: kp + (exp_s + exp_d) through the same geometry.
+        kp_e = info["kp"] + (info["exp"] + exp_d)
+        R, scale, t = info["R"], info["scale"], info["t"]
+        kp_rot = torch.einsum("bmp,bkp->bkm", R, kp_e) * scale.unsqueeze(1)
+        x_expected = kp_rot + t.unsqueeze(1)
+        assert torch.allclose(x_d, x_expected, atol=1e-5)
+
     def test_replacement_returns_correct_shape(self):
         recast = _make_recast()
         info = recast.build_source_info(_torch_motion(4))
@@ -212,6 +241,65 @@ class TestComposeDrivenKeypoints:
         exp_d = _torch_motion(7)["exp"]
         with pytest.raises(ValueError):
             recast.compose_driven_keypoints(info, exp_d, mode="Bogus")
+
+    def test_replacement_eye_lip_weight_zero_keeps_source(self):
+        """eye/lip driving weight 0 -> the eye/lip planar channels stay at the
+        source expression; weight 1 -> they follow the driver."""
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(8))
+        exp_d = _torch_motion(123)["exp"]
+
+        x_keep = recast.compose_driven_keypoints(
+            info,
+            exp_d,
+            mode=MODE_REPLACEMENT,
+            factor=1.0,
+            eye_driving_weight=0.0,
+            lip_driving_weight=0.0,
+        )
+        x_follow = recast.compose_driven_keypoints(
+            info,
+            exp_d,
+            mode=MODE_REPLACEMENT,
+            factor=1.0,
+            eye_driving_weight=1.0,
+            lip_driving_weight=1.0,
+        )
+        # With weight 0 the eye planar channels equal the source; with weight 1
+        # they differ (driver), so the two compositions must differ on the eyes.
+        assert not torch.allclose(x_keep[:, 31:34, :], x_follow[:, 31:34, :], atol=1e-4)
+
+    def test_replacement_default_weights_match_legacy_constants(self):
+        """Default weights (0.7 eyes / 0.8 lips) reproduce the original
+        hardcoded 0.3/0.7 and 0.2/0.8 blend exactly."""
+        recast = _make_recast()
+        info = recast.build_source_info(_torch_motion(11))
+        exp_s = info["exp"]
+        exp_d = _torch_motion(222)["exp"]
+
+        # Recompute the legacy modulated expression directly.
+        modulated = exp_d.clone()
+        modulated[:, 31:34, 2] = exp_s[:, 31:34, 2]
+        modulated[:, 36:39, 2] = exp_s[:, 36:39, 2]
+        modulated[:, 44:47, 2] = exp_s[:, 44:47, 2]
+        modulated[:, 44:47, 0] = exp_s[:, 44:47, 0]
+        modulated[:, 44:47, 1] = exp_s[:, 44:47, 1] * 0.2 + exp_d[:, 44:47, 1] * 0.8
+        modulated[:, 31:34, :2] = exp_s[:, 31:34, :2] * 0.3 + exp_d[:, 31:34, :2] * 0.7
+        modulated[:, 36:39, :2] = exp_s[:, 36:39, :2] * 0.3 + exp_d[:, 36:39, :2] * 0.7
+        legacy_new_exp = exp_s + 1.0 * (modulated - exp_s)
+
+        # The composed driven keypoints use the same transform, so compare the
+        # internal new_exp by reconstructing it through a region='all' compose
+        # against a hand-built reference transform.
+        x_default = recast.compose_driven_keypoints(
+            info, exp_d, mode=MODE_REPLACEMENT, factor=1.0
+        )
+        # Build expected x_d from legacy_new_exp using the same geometry.
+        kp_e = info["kp"] + legacy_new_exp
+        R, scale, t = info["R"], info["scale"], info["t"]
+        kp_rot = torch.einsum("bmp,bkp->bkm", R, kp_e) * scale.unsqueeze(1)
+        x_expected = kp_rot + t.unsqueeze(1)
+        assert torch.allclose(x_default, x_expected, atol=1e-5)
 
     def test_region_eyes_keeps_non_eye_keypoints_at_source(self):
         """With region='eyes', keypoints outside the eye group are unchanged."""
@@ -264,6 +352,15 @@ class TestModelAPI:
         assert arr.dtype == np.float32
         assert pytest.approx(arr.max(), abs=1e-6) == 1.0
 
+    def test_prewarm_loads_all_models(self):
+        recast = _make_recast()
+        assert all(
+            recast.models_processor.models.get(n) is None for n in recast.model_group
+        )
+        recast.prewarm()
+        for name in recast.model_group:
+            assert recast.models_processor.models.get(name) is not None
+
     def test_unload_models_calls_unload_for_each(self):
         recast = _make_recast()
         # Pretend all four are loaded.
@@ -280,7 +377,12 @@ class TestModelAPI:
 
 _WARPING_ONNX = os.path.join(
     os.path.dirname(__file__),
-    "..", "..", "..", "model_assets", "performrecast_onnx", "warping_module.onnx",
+    "..",
+    "..",
+    "..",
+    "model_assets",
+    "performrecast_onnx",
+    "warping_module.onnx",
 )
 
 

--- a/tests/unit/ui/test_common_layout_recast.py
+++ b/tests/unit/ui/test_common_layout_recast.py
@@ -81,5 +81,42 @@ def test_recast_region_options_and_default():
 def test_recast_expression_factor_range():
     entry = FACE_EXPR["RecastExpressionFactorDecimalSlider"]
     assert float(entry["min_value"]) == 0.0
-    assert float(entry["max_value"]) == 2.0
+    # Range was raised to 3.0 to allow stylization/exaggeration.
+    assert float(entry["max_value"]) == 3.0
     assert float(entry["default"]) == 1.0
+
+
+def test_recast_crop_scale_defaults_to_safe_framing():
+    entry = FACE_EXPR["RecastCropScaleDecimalSlider"]
+    # Default matches the proven 2.3 framing (best viable similarity). Too-tight
+    # crops drive the generator into black frames (handled by the guard); wider
+    # is safer. Default must stay within range.
+    assert float(entry["default"]) == 2.3
+    assert (
+        float(entry["min_value"])
+        <= float(entry["default"])
+        <= float(entry["max_value"])
+    )
+
+
+def test_recast_blend_weight_defaults_match_upstream():
+    eye = FACE_EXPR["RecastEyeDrivingWeightDecimalSlider"]
+    lip = FACE_EXPR["RecastLipDrivingWeightDecimalSlider"]
+    assert float(eye["default"]) == 0.7
+    assert float(lip["default"]) == 0.8
+    for entry in (eye, lip):
+        assert float(entry["min_value"]) == 0.0
+        assert float(entry["max_value"]) == 1.0
+
+
+def test_recast_smoothing_widgets_exist_and_default_off():
+    toggle = FACE_EXPR["RecastExpressionSmoothToggle"]
+    assert toggle["default"] is False
+    strength = FACE_EXPR["RecastSmoothStrengthDecimalSlider"]
+    # Strength is additionally gated on the smoothing toggle.
+    assert "RecastExpressionSmoothToggle" in strength["parentToggle"]
+
+
+def test_recast_paste_back_feather_defaults_off():
+    entry = FACE_EXPR["RecastPasteBackFeatherDecimalSlider"]
+    assert float(entry["default"]) == 0.0


### PR DESCRIPTION
Performance
- Convert the four PerformRecast sub-networks (F/M/W/G) to zero-copy onnxruntime IO binding on CUDA (PerformRecast._infer / _infer_iobinding), matching FaceEditors._run_onnx_io_binding. The old session.run(None, numpy_feeds) path forced a full CPU<->GPU copy of every tensor each call (the 32x16x64x64 feature volume and the 256x64x64 warp output in particular) and kept the W->G intermediate on the host — this was why Recast was slower than the IO-bound LivePortrait expression restorer. A numpy fallback is kept for CPU / mocked-session use.

Black / degenerate face frames
- Root cause: too-tight a crop drives the generator out of distribution and it emits an all-black (or NaN) frame; fp16 widens that range. Fixes:
  * Degenerate-output guard in apply_perform_recast: if the generated crop is non-finite or essentially all-black, skip the recast for that frame and keep the plain swap (never paste a black face).
  * warp_face_by_face_landmark_x gains a padding_mode kwarg (default zeros, unchanged for all other callers); the Recast crops pass border so out-of-bounds samples replicate edge pixels instead of going black.
  * Detection bboxes / paste-back dsize derived from the actual tensor shape instead of a hardcoded 512.

Fixed Recast Mode options (Replacement vs Enhancement)
- Bug: Enhancement used the swapped face own expression as the neutral reference (exp_s + factor*(exp_d - exp_s)); at factor=1 that cancels exp_s and collapses to exp_d — nearly identical to Replacement, so switching modes did nothing. Enhancement is now genuinely additive (exp_s + factor*exp_d): it keeps the swapped face expression and stacks the driver on top, matching its UI description and staying distinct from Replacement.

Identity / similarity controls
- Dedicated RecastCropScaleDecimalSlider (independent of the shared expression crop). Default 2.3 = the proven framing (best viable similarity; the model cannot use a tight ~1.5 crop — it goes black there). Tooltip explains the similarity/black trade-off and that VR180 usually needs ~2.8-3.0.
- Replacement-mode eye/lip identity blend weights exposed (RecastEyeDrivingWeightDecimalSlider 0.7, RecastLipDrivingWeightDecimalSlider 0.8 — the previously hardcoded 0.7/0.8 blends) so users can dial how strongly the driver overrides the swapped face eye/lip identity.

Temporal smoothing now engages
- RecastExpressionSmoothToggle + RecastSmoothStrengthDecimalSlider apply a per-face EMA on the driving expression. The state is matched to the nearest previous face centroid within a tolerance (not an exact grid bucket), so a moving face keeps tracking its own EMA frame-to-frame instead of losing it on every small drift (which made smoothing a no-op). Off by default.

Other plan UI improvements
- Expression-strength range raised to 3.0 and relabelled Expression Strength.
- Optional paste-back feather (RecastPasteBackFeatherDecimalSlider) blends the recast crop border back toward the underlying swapped face (off by default).
- Animation-region tooltip documents the eye/lip channel index groups.

Portable-install folder fix
- downloader.download_file creates the destination parent directory before writing; models_data also explicitly creates model_assets/performrecast_onnx (and liveportrait_onnx) at import so the portable updater always has a destination.

TensorRT build-dialog coverage
- PerformRecast.prewarm() loads all four models eagerly (in a fixed order) at the start of apply_perform_recast so the engine-build dialog is shown for every model, not just lazy first-run ones.
- A Preparing TensorRT Model dialog now covers the one-time _ensure_trt_ready_onnx shape-inference step (previously a silent gap).

Tests
- Extend tests/unit/processors/test_perform_recast.py (mode distinctness, additive Enhancement, eye/lip blend weights, legacy-constant parity, prewarm) and tests/unit/ui/test_common_layout_recast.py (factor range 3.0, crop-scale default, blend-weight defaults, smoothing + feather widgets).