### PR TITLE
feat: configurable VR coverage and projection (e.g. 90°, 180°, 200°)

### DIFF
--- a/app/helpers/vr_geometry.py
+++ b/app/helpers/vr_geometry.py
@@ -1,0 +1,520 @@
+"""Frame geometry description for the VR face-swap path.
+
+The VR pipeline works in four steps: turn a bounding box in the flat video frame
+into a *direction* on the viewing sphere, render an undistorted perspective crop
+around that direction, swap the face inside the crop, then project the crop back
+into the frame.  Three of those four steps need to agree on exactly how a pixel
+in the frame maps to a direction.
+
+That mapping used to be hardcoded for VR180 side-by-side equirectangular
+content, where each eye covers 180° horizontally and 180° vertically.  That is a
+convenient special case: it makes the *whole* stereo frame a valid 360°×180°
+equirect, with the left eye occupying longitudes -180…0° and the right eye
+0…180°, which is why the projection code could treat a stereo pair as a single
+sphere.  Nothing else worked.
+
+``VRGeometry`` makes the mapping explicit so that
+
+* per-eye coverage is configurable (:data:`COVERAGE_MIN_DEG` …
+  :data:`COVERAGE_MAX_DEG`, with 180° reproducing the old behaviour), and
+* fisheye-encoded content (200° lenses and friends) works alongside
+  equirectangular.
+
+Both projections share one angle convention, so the rest of the pipeline is
+unaffected by which one is in use:
+
+``theta``
+    Frame-level longitude in degrees, spanning ``±lon_span_deg / 2``.  In
+    Both-Eyes mode the left eye occupies the negative half and the right eye the
+    positive half, so a ``theta`` names one eye's view unambiguously.
+``phi``
+    Elevation in degrees, positive up.
+
+Note that ``theta`` is *bookkeeping* only.  The eye is tracked separately, as an
+explicit ``is_left_eye``, all the way down into the projection maths — it cannot
+be recovered from a direction, because both eyes look the same way and therefore
+produce identical rays.  (An earlier design gave each eye its own slice of a
+widened longitude range; that silently breaks above 180° coverage, where the
+slices run past ±180° and ``atan2`` folds them back on top of each other.)  All
+ray maths is consequently done in the eye's own camera frame: ``x`` = optical
+axis, ``y`` = right, ``z`` = up, matching the existing converters.
+
+Pixel positions use the endpoint-inclusive ``size - 1`` convention that the
+original converters used, so the default geometry reproduces their output.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+PROJECTION_EQUIRECTANGULAR = "Equirectangular"
+PROJECTION_FISHEYE = "Fisheye (equidistant)"
+PROJECTIONS = (PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE)
+
+EYE_MODE_BOTH = "Both Eyes"
+EYE_MODE_SINGLE = "Single Eye"
+
+COVERAGE_MIN_DEG = 90.0
+COVERAGE_MAX_DEG = 360.0
+COVERAGE_DEFAULT_DEG = 180.0
+
+# A latitude/longitude parameterisation of the sphere stops being injective past
+# ±90° elevation, so the vertical span an *equirectangular* frame can describe is
+# capped at 180°.  Content whose vertical coverage genuinely exceeds that has to
+# be stored as fisheye, which has no poles.
+LAT_SPAN_MAX_DEG = 180.0
+
+# Control keys this module reads.  Kept here so the worker and the UI layout
+# cannot drift apart.
+COVERAGE_CONTROL_KEY = "VRCoverageSlider"
+PROJECTION_CONTROL_KEY = "VRProjectionSelection"
+EYE_MODE_CONTROL_KEY = "VR180EyeModeSelection"
+
+
+@dataclass(frozen=True)
+class VRGeometry:
+    """How pixels in a VR video frame map to directions on the viewing sphere.
+
+    Frozen (and therefore hashable) so it can be used directly as an
+    ``lru_cache`` key by the projection converters.
+    """
+
+    frame_height: int
+    frame_width: int
+    both_eyes: bool = True
+    projection: str = PROJECTION_EQUIRECTANGULAR
+    coverage_deg: float = COVERAGE_DEFAULT_DEG
+
+    @classmethod
+    def from_control(
+        cls, control: dict, frame_height: int, frame_width: int
+    ) -> VRGeometry:
+        """Build the geometry described by the UI control dict."""
+        try:
+            coverage = float(control.get(COVERAGE_CONTROL_KEY, COVERAGE_DEFAULT_DEG))
+        except (TypeError, ValueError):
+            # A slider mid-edit can briefly hold a non-numeric value.
+            coverage = COVERAGE_DEFAULT_DEG
+        coverage = min(max(coverage, COVERAGE_MIN_DEG), COVERAGE_MAX_DEG)
+
+        projection = str(
+            control.get(PROJECTION_CONTROL_KEY, PROJECTION_EQUIRECTANGULAR)
+        )
+        if projection not in PROJECTIONS:
+            projection = PROJECTION_EQUIRECTANGULAR
+
+        return cls(
+            frame_height=int(frame_height),
+            frame_width=int(frame_width),
+            both_eyes=(
+                control.get(EYE_MODE_CONTROL_KEY, EYE_MODE_BOTH) != EYE_MODE_SINGLE
+            ),
+            projection=projection,
+            coverage_deg=coverage,
+        )
+
+    # ------------------------------------------------------------------
+    # Derived sizes and spans
+    # ------------------------------------------------------------------
+
+    @property
+    def is_fisheye(self) -> bool:
+        return self.projection == PROJECTION_FISHEYE
+
+    @property
+    def eye_width(self) -> int:
+        """Pixel width of a single eye's view."""
+        return self.frame_width // 2 if self.both_eyes else self.frame_width
+
+    @property
+    def lon_span_deg(self) -> float:
+        """Longitude range spanned by the *whole frame*."""
+        return self.coverage_deg * (2.0 if self.both_eyes else 1.0)
+
+    @property
+    def lat_span_deg(self) -> float:
+        """Latitude range spanned by the frame.
+
+        Derived from the horizontal coverage on the assumption of square angular
+        pixels, which is what both an equirectangular remap and an equidistant
+        fisheye produce.  A standard 2:1 VR180 frame has square eyes, so this
+        gives back 180°.
+        """
+        span = self.coverage_deg * self.frame_height / max(self.eye_width, 1)
+        return min(span, LAT_SPAN_MAX_DEG)
+
+    @property
+    def angular_pixel_span(self) -> float:
+        """Pixel width one eye's angular coverage maps onto.
+
+        Uses the endpoint-inclusive ``frame_width - 1`` convention of the original
+        converters, so a standard 360-wide stereo frame gives each eye 179.5 px
+        for its 180° — exactly reproducing the previous sampling.
+        """
+        return (self.frame_width - 1) / (2.0 if self.both_eyes else 1.0)
+
+    @property
+    def deg_per_pixel(self) -> float:
+        """Angular size of one pixel.
+
+        Exact everywhere for an equidistant fisheye; for equirectangular it is
+        the horizontal scale at the equator only (longitude compresses towards
+        the poles — see :meth:`bbox_angular_size_deg`).
+        """
+        return self.coverage_deg / max(self.angular_pixel_span, 1e-9)
+
+    @property
+    def reproduces_legacy_vr180(self) -> bool:
+        """True when this geometry is the old hardcoded VR180 special case.
+
+        Used to keep the longitude seam wrapping (and therefore bit-identical
+        output) on the default settings path.
+        """
+        return (
+            not self.is_fisheye
+            and self.both_eyes
+            and abs(self.coverage_deg - COVERAGE_DEFAULT_DEG) < 1e-6
+        )
+
+    @property
+    def wraps_longitude(self) -> bool:
+        """Whether a single view closes into a full circle.
+
+        Only then may a sample that runs off one horizontal edge be wrapped to
+        the other; otherwise it has to be clamped, because the pixels there
+        belong to a different eye (or to nothing at all).
+        """
+        return not self.is_fisheye and abs(self.coverage_deg - 360.0) < 1e-6
+
+    # ------------------------------------------------------------------
+    # Eyes
+    # ------------------------------------------------------------------
+
+    def eye_of_pixel(self, x: float) -> bool | None:
+        """Which eye a frame x-coordinate belongs to.
+
+        Returns True for the left eye, False for the right, and None when the
+        frame holds a single view.
+        """
+        if not self.both_eyes:
+            return None
+        return x < self.eye_width
+
+    def eye_of_theta(self, theta: float) -> bool | None:
+        """Which eye a frame-level longitude belongs to.
+
+        The left eye owns the negative half of the frame's longitude range, which
+        is also the left half of its pixels, so this agrees with
+        :meth:`eye_of_pixel`.
+        """
+        if not self.both_eyes:
+            return None
+        return theta < 0.0
+
+    def eye_x_offset(self, is_left_eye: bool | None) -> int:
+        """First frame column belonging to an eye."""
+        if not self.both_eyes or is_left_eye is None:
+            return 0
+        return 0 if is_left_eye else self.eye_width
+
+    def eye_x_bounds(self, is_left_eye: bool | None) -> tuple[float, float]:
+        """Inclusive first/last frame column belonging to an eye."""
+        if not self.both_eyes or is_left_eye is None:
+            return 0.0, float(self.frame_width - 1)
+        x0 = self.eye_x_offset(is_left_eye)
+        return float(x0), float(x0 + self.eye_width - 1)
+
+    # ``is_left_eye=None`` means "treat the frame as a single view", which is how
+    # the stitcher has always signalled single-eye mode.  It therefore overrides
+    # the eye layout rather than being merely unknown.
+
+    def eye_coverage_deg(self, is_left_eye: bool | None) -> float:
+        """Horizontal degrees the addressed view spans.
+
+        ``None`` collapses the frame to a single view, so it spans the frame's
+        whole longitude range rather than one eye's coverage.  On a stereo frame
+        at default settings that is 360°, which is how the original code treated
+        single-eye stitching.
+        """
+        return self.lon_span_deg if is_left_eye is None else self.coverage_deg
+
+    def eye_pixel_span(self, is_left_eye: bool | None) -> float:
+        """Pixel width the addressed view's angular coverage maps onto."""
+        if is_left_eye is None:
+            return float(self.frame_width - 1)
+        return self.angular_pixel_span
+
+    def eye_pixel_center(self, is_left_eye: bool | None) -> float:
+        """Frame column of an eye's optical axis."""
+        span = self.eye_pixel_span(is_left_eye)
+        if not self.both_eyes or is_left_eye is None:
+            return span / 2.0
+        return span / 2.0 if is_left_eye else span * 1.5
+
+    def eye_center_theta(self, is_left_eye: bool | None) -> float:
+        """Frame-level longitude of an eye's optical axis."""
+        if not self.both_eyes or is_left_eye is None:
+            return 0.0
+        return -self.coverage_deg / 2.0 if is_left_eye else self.coverage_deg / 2.0
+
+    def fisheye_pixels_per_radian(self, is_left_eye: bool | None) -> float:
+        """Equidistant fisheye scale factor.
+
+        Radius from the optical axis is proportional to the angle away from it,
+        with the full coverage circle's diameter spanning the eye's pixel width.
+        """
+        half_angle_rad = math.radians(self.eye_coverage_deg(is_left_eye) / 2.0)
+        return (self.eye_pixel_span(is_left_eye) / 2.0) / max(half_angle_rad, 1e-9)
+
+    def partner_theta(self, theta: float, is_left_eye: bool | None) -> float:
+        """The same direction as seen by the other eye.
+
+        Both eyes look the same way, so the partner sits at the identical
+        eye-relative angle — one ``coverage_deg`` away in frame-level longitude.
+        """
+        if not self.both_eyes or is_left_eye is None:
+            return theta
+        return theta + self.coverage_deg if is_left_eye else theta - self.coverage_deg
+
+    def rotation_theta(self, theta: float, is_left_eye: bool | None) -> float:
+        """Longitude to build a crop's rotation matrix from.
+
+        All projections are handled in the eye's own camera frame, so the eye's
+        optical axis is subtracted from the frame-level longitude.  For a
+        single-view frame the axis is 0° and this is the identity.
+        """
+        return theta - self.eye_center_theta(is_left_eye)
+
+    # ------------------------------------------------------------------
+    # Bounding boxes
+    # ------------------------------------------------------------------
+
+    def pixel_to_theta_phi(self, x: float, y: float) -> tuple[float, float]:
+        """Direction of a single frame pixel, as (theta, phi) in degrees."""
+        is_left_eye = self.eye_of_pixel(x)
+        cx = self.eye_pixel_center(is_left_eye)
+        cy = (self.frame_height - 1) / 2.0
+        du = x - cx
+        dv = y - cy
+
+        if not self.is_fisheye:
+            # Latitude/longitude grid, measured from this eye's optical axis.
+            theta_local = (
+                du
+                / max(self.eye_pixel_span(is_left_eye) / 2.0, 1e-9)
+                * (self.eye_coverage_deg(is_left_eye) / 2.0)
+            )
+            phi = (
+                -dv
+                / max((self.frame_height - 1) / 2.0, 1e-9)
+                * (self.lat_span_deg / 2.0)
+            )
+            return theta_local + self.eye_center_theta(is_left_eye), phi
+
+        radius = math.hypot(du, dv)
+        if radius < 1e-9:
+            theta_local, phi = 0.0, 0.0
+        else:
+            alpha = radius / self.fisheye_pixels_per_radian(is_left_eye)
+            sin_a = math.sin(alpha)
+            ray_x = math.cos(alpha)
+            ray_y = sin_a * (du / radius)
+            ray_z = sin_a * (-dv / radius)
+            theta_local = math.degrees(math.atan2(ray_y, ray_x))
+            phi = math.degrees(math.asin(max(-1.0, min(1.0, ray_z))))
+        return theta_local + self.eye_center_theta(is_left_eye), phi
+
+    def bbox_to_theta_phi(self, bbox) -> tuple[float, float]:
+        """Direction of a bounding box's centre, as (theta, phi) in degrees."""
+        x_center = (float(bbox[0]) + float(bbox[2])) / 2.0
+        y_center = (float(bbox[1]) + float(bbox[3])) / 2.0
+        return self.pixel_to_theta_phi(x_center, y_center)
+
+    def bbox_angular_size_deg(self, bbox, phi_deg: float) -> tuple[float, float]:
+        """Angular width and height a bounding box subtends, in degrees.
+
+        Used to pick a per-face crop FOV, so it wants the *true* angular size
+        rather than a naive pixel-to-degree scaling.
+        """
+        width_px = float(bbox[2]) - float(bbox[0])
+        height_px = float(bbox[3]) - float(bbox[1])
+
+        if self.is_fisheye:
+            # An equidistant fisheye has a uniform angular scale in every
+            # direction, so no latitude correction applies.
+            deg_per_px = self.deg_per_pixel
+            return width_px * deg_per_px, height_px * deg_per_px
+
+        width_deg = width_px * self.deg_per_pixel
+        height_deg = height_px / max(self.frame_height - 1, 1) * self.lat_span_deg
+
+        # Equirectangular projection compresses longitude towards the poles, so
+        # a face at high elevation spans more degrees than its pixel width
+        # suggests: true angular width ≈ pixel width / cos(latitude).
+        #
+        # cos_phi is clamped to 0.35 (≈70° latitude) to cap the correction at
+        # ~2.9×.  An earlier clamp of 0.1 allowed up to 10× amplification near
+        # the poles, which produced extreme FOVs and garbage landmarks ("eye
+        # sideways, mouth near ear") for faces at the top or bottom of frame.
+        # The secondary cap of 2× the raw width keeps the corrected value
+        # continuous with the uncorrected one for near-pole detections.
+        cos_phi = math.cos(math.radians(phi_deg))
+        width_deg_corrected = width_deg / max(cos_phi, 0.35)
+        width_deg = min(width_deg_corrected, width_deg * 2.0)
+        return width_deg, height_deg
+
+    # ------------------------------------------------------------------
+    # Tiled detection
+    # ------------------------------------------------------------------
+
+    def tile_grid(self, tile_fov_deg: float = 90.0) -> list[tuple[float, float]]:
+        """(theta, phi) centres for the tiled-detection sweep.
+
+        Tiles are spaced at two thirds of their FOV so neighbours overlap by a
+        third, which is enough that a face never falls only on a seam.  Bands
+        are placed at the equator, mid-latitude, and near the vertical extremes;
+        the outermost bands get fewer tiles because a band of given angular
+        radius needs proportionally fewer views to cover it.
+
+        On the default VR180 geometry this yields the same 24 tiles the previous
+        hardcoded grid used (the near-pole tiles are spaced slightly differently,
+        which the generous 90° tile FOV absorbs).
+        """
+        lon_span = self.lon_span_deg
+        spacing = max(tile_fov_deg * 2.0 / 3.0, 1.0)
+
+        def _band_thetas(count: int) -> list[float]:
+            step = lon_span / count
+            return [-lon_span / 2.0 + step * (i + 0.5) for i in range(count)]
+
+        main_count = max(1, math.ceil(lon_span / spacing))
+        main_thetas = _band_thetas(main_count)
+        outer_thetas = _band_thetas(max(1, main_count // 2))
+
+        lat_half = self.lat_span_deg / 2.0
+        grid: list[tuple[float, float]] = []
+        for phi_fraction in (0.0, 40.0 / 90.0, -40.0 / 90.0):
+            phi = lat_half * phi_fraction
+            grid.extend((theta, phi) for theta in main_thetas)
+        for phi_fraction in (70.0 / 90.0, -70.0 / 90.0):
+            phi = lat_half * phi_fraction
+            grid.extend((theta, phi) for theta in outer_thetas)
+        return grid
+
+
+# ----------------------------------------------------------------------
+# Torch mappings shared by the forward (equirect→perspective) and inverse
+# (perspective→equirect) converters, so the two can never disagree.
+# ----------------------------------------------------------------------
+
+
+def rays_to_frame_pixels(
+    rays: torch.Tensor, geometry: VRGeometry, is_left_eye: bool | None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map unit direction vectors to frame pixel coordinates.
+
+    ``rays`` is ``(..., 3)``, expressed in the eye's own camera frame — i.e. the
+    frame :meth:`VRGeometry.rotation_theta` rotates into.
+
+    Returns ``(x_px, y_px)`` in frame pixel space.  Coordinates outside the eye's
+    columns are possible and left for the caller to wrap or clamp.
+    """
+    eye_center_x = geometry.eye_pixel_center(is_left_eye)
+    half_eye_px = geometry.eye_pixel_span(is_left_eye) / 2.0
+    center_y = (geometry.frame_height - 1) / 2.0
+
+    if not geometry.is_fisheye:
+        longitude = torch.atan2(rays[..., 1], rays[..., 0])
+        # Clamp before asin: float rounding at the poles can push the component
+        # a hair outside [-1, 1] and produce NaN.
+        latitude = torch.asin(torch.clamp(rays[..., 2], -1.0, 1.0))
+        half_lon_rad = math.radians(geometry.eye_coverage_deg(is_left_eye) / 2.0)
+        half_lat_rad = math.radians(geometry.lat_span_deg / 2.0)
+        x_px = (longitude / half_lon_rad) * half_eye_px + eye_center_x
+        y_px = (-latitude / half_lat_rad) * center_y + center_y
+        return x_px, y_px
+
+    # Equidistant fisheye: distance from the optical axis in the image is
+    # proportional to the ray's angle away from that axis.
+    alpha = torch.acos(torch.clamp(rays[..., 0], -1.0, 1.0))
+    radius = alpha * geometry.fisheye_pixels_per_radian(is_left_eye)
+    # Length of the ray's projection onto the image plane, used to get its
+    # direction there.  Floored so a ray exactly along the axis (where the
+    # direction is undefined but the radius is 0) does not divide by zero.
+    in_plane = torch.sqrt(rays[..., 1] ** 2 + rays[..., 2] ** 2).clamp(min=1e-12)
+    x_px = eye_center_x + radius * (rays[..., 1] / in_plane)
+    y_px = center_y - radius * (rays[..., 2] / in_plane)
+    return x_px, y_px
+
+
+def frame_pixel_rays(
+    geometry: VRGeometry,
+    is_left_eye: bool | None,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Unit direction for every pixel of the frame — the inverse mapping.
+
+    Returns ``(rays, valid)`` where ``rays`` is ``(H, W, 3)`` and ``valid`` is
+    ``(H, W)`` bool, or None when every pixel of the frame carries a usable
+    direction for this eye.  Directions are expressed in the eye's own camera
+    frame, i.e. the frame :meth:`VRGeometry.rotation_theta` rotates out of.
+    """
+    height, width = geometry.frame_height, geometry.frame_width
+
+    columns = torch.arange(width, dtype=torch.float32).unsqueeze(0)
+    rows = torch.arange(height, dtype=torch.float32).unsqueeze(1)
+    du = columns - geometry.eye_pixel_center(is_left_eye)
+    dv = rows - (height - 1) / 2.0
+    half_eye_px = geometry.eye_pixel_span(is_left_eye) / 2.0
+    half_frame_px = max((height - 1) / 2.0, 1e-9)
+
+    eye_coverage = geometry.eye_coverage_deg(is_left_eye)
+
+    if not geometry.is_fisheye:
+        lon_rad = torch.deg2rad(du / half_eye_px * (eye_coverage / 2.0))
+        lat_rad = torch.deg2rad(-dv / half_frame_px * (geometry.lat_span_deg / 2.0))
+        cos_lat = torch.cos(lat_rad)
+        rays = torch.stack(
+            torch.broadcast_tensors(
+                cos_lat * torch.cos(lon_rad),
+                cos_lat * torch.sin(lon_rad),
+                torch.broadcast_to(torch.sin(lat_rad), (height, width)),
+            ),
+            dim=2,
+        )
+        if is_left_eye is None or not geometry.both_eyes:
+            # One view spanning the whole frame — every pixel belongs to it.
+            return rays.to(device), None
+        # The other eye's columns look the same way but through a different
+        # optical centre, so they must never be written from this eye's crop.
+        # A hair of tolerance keeps the boundary column itself included.
+        valid = (du.abs() <= half_eye_px + 1e-4).expand(height, width)
+        return rays.to(device), valid.to(device)
+
+    radius = torch.sqrt(du**2 + dv**2)
+    alpha = radius / geometry.fisheye_pixels_per_radian(is_left_eye)
+
+    safe_radius = radius.clamp(min=1e-12)
+    sin_a = torch.sin(alpha)
+    rays = torch.stack(
+        torch.broadcast_tensors(
+            torch.cos(alpha),
+            sin_a * (du / safe_radius),
+            sin_a * (-dv / safe_radius),
+        ),
+        dim=2,
+    )
+
+    # Outside the lens circle there is no image data, and in Both-Eyes mode the
+    # other eye's half belongs to a different optical axis entirely.  Both are
+    # marked invalid so the caller can reject them rather than sampling garbage.
+    valid = alpha <= math.radians(eye_coverage / 2.0)
+    if geometry.both_eyes and is_left_eye is not None:
+        x_min, x_max = geometry.eye_x_bounds(is_left_eye)
+        valid = valid & (columns >= x_min) & (columns <= x_max)
+    valid = valid.expand(height, width)
+
+    return rays.to(device), valid.to(device)

--- a/app/helpers/vr_utils.py
+++ b/app/helpers/vr_utils.py
@@ -1,11 +1,12 @@
 import threading
+from collections import OrderedDict
+
 import numpy as np
 import torch
 import torch.nn.functional as F
 from torchvision import transforms
-from collections import OrderedDict
-from typing import Optional
 
+from app.helpers.vr_geometry import VRGeometry
 
 # Assuming Equirec2Perspec_vr and Perspec2Equirec_vr are in app.processors.external
 from app.processors.external.Equirec2Perspec_vr import (
@@ -53,11 +54,19 @@ def _get_sobel_kernels(device):
 
 
 class EquirectangularConverter:
-    def __init__(self, equirect_image_data_rgb_uint8: np.ndarray, device: torch.device):
+    def __init__(
+        self,
+        equirect_image_data_rgb_uint8: np.ndarray,
+        device: torch.device,
+        geometry: VRGeometry | None = None,
+    ):
         """
         Initializes with equirectangular image data.
         :param equirect_image_data_rgb_uint8: NumPy array (H, W, C) in RGB, uint8 format.
         :param device: PyTorch device to use.
+        :param geometry: how the frame's pixels map to directions.  Defaults to the
+            historical VR180 side-by-side assumption (each eye 180°, whole frame a
+            360°×180° equirect).
         """
 
         self.device = device
@@ -71,41 +80,61 @@ class EquirectangularConverter:
         self.channels, self.height, self.width = (
             self.equirect_tensor_cxhxw_rgb_uint8.shape
         )
+        self.geometry = geometry or VRGeometry(
+            frame_height=self.height, frame_width=self.width
+        )
         self.e2p_instance = E2P_Equirectangular(self.equirect_tensor_cxhxw_rgb_uint8)
 
     def calculate_theta_phi_from_bbox(self, bbox_np: np.ndarray):
+        # Truncating to int matches the detector's pixel-grid resolution and keeps
+        # the angles stable frame to frame for a stationary face.
         x1, y1, x2, y2 = map(int, bbox_np)
-        x_center = (x1 + x2) / 2
-        y_center = (y1 + y2) / 2
-
-        theta = (x_center / self.width - 0.5) * 360.0
-        phi = (
-            -(y_center / self.height - 0.5) * 180.0
-        )  # Negative because image y is top-to-bottom
-
-        return theta, phi
+        return self.geometry.bbox_to_theta_phi((x1, y1, x2, y2))
 
     def get_perspective_crop(
-        self, FOV: float, THETA: float, PHI: float, height: int, width: int
+        self,
+        FOV: float,
+        THETA: float,
+        PHI: float,
+        height: int,
+        width: int,
+        is_left_eye: bool | None = None,
     ) -> torch.Tensor:
         """
         Returns a perspective crop as a Torch tensor (C, H, W) in RGB, uint8 format, on GPU.
+
+        :param is_left_eye: which eye THETA falls in, or None to derive it from THETA.
+            Only consulted for projections that are defined per-eye (fisheye) or when
+            coverage is partial, where the crop must not sample the neighbouring eye.
         """
+        if is_left_eye is None:
+            is_left_eye = self.geometry.eye_of_theta(THETA)
         # E2P_Equirectangular.GetPerspective now returns a Torch tensor (CHW, RGB, uint8)
         persp_torch_cxhxw_rgb_uint8 = self.e2p_instance.GetPerspective(
-            FOV, THETA, PHI, height, width
+            FOV,
+            THETA,
+            PHI,
+            height,
+            width,
+            geometry=self.geometry,
+            is_left_eye=is_left_eye,
         )
         return persp_torch_cxhxw_rgb_uint8
 
 
 class PerspectiveConverter:
     def __init__(
-        self, base_equirect_image_data_rgb_uint8: np.ndarray, device: torch.device
+        self,
+        base_equirect_image_data_rgb_uint8: np.ndarray,
+        device: torch.device,
+        geometry: VRGeometry | None = None,
     ):
         """
         Initializes with the base equirectangular image data (used for dimensions and as background).
         :param base_equirect_image_data_rgb_uint8: NumPy array (H, W, C) in RGB, uint8 format.
         :param device: PyTorch device to use.
+        :param geometry: how the frame's pixels map to directions.  Defaults to the
+            historical VR180 side-by-side assumption.
         """
 
         self.device = device
@@ -116,6 +145,7 @@ class PerspectiveConverter:
         self.orig_height: int = h
         self.orig_width: int = w
         self.orig_channels: int = c
+        self.geometry = geometry or VRGeometry(frame_height=h, frame_width=w)
         self.sobel_x_kernel, self.sobel_y_kernel = _get_sobel_kernels(self.device)
         # Bounded LRU cache for GaussianBlur instances (keyed by kernel_size, sigma).
         # A plain dict would grow unbounded across frames with varying face sizes.
@@ -192,7 +222,7 @@ class PerspectiveConverter:
         theta: float,
         phi: float,
         fov: float,
-        is_left_eye: Optional[bool],  # None = single-eye (full-frame) mode
+        is_left_eye: bool | None,  # None = single-eye (full-frame) mode
     ):
         """
         Stitches a single processed perspective crop back into the target equirectangular image.
@@ -208,7 +238,12 @@ class PerspectiveConverter:
             return
 
         p2e_instance = P2E_Perspective(
-            processed_crop_torch_cxhxw_rgb_uint8, FOV=fov, THETA=theta, PHI=phi
+            processed_crop_torch_cxhxw_rgb_uint8,
+            FOV=fov,
+            THETA=theta,
+            PHI=phi,
+            geometry=self.geometry,
+            is_left_eye=is_left_eye,
         )
         equirect_component_torch, mask_torch_original_shape = p2e_instance.GetEquirec(
             self.orig_height, self.orig_width
@@ -226,6 +261,9 @@ class PerspectiveConverter:
         # mask 4× per frame × 8 workers — a third of a gigabyte of PCIe traffic
         # per frame, with each upload's sync spin-waiting on CUDA 13/Windows
         # and saturating CPU cores instead of waking them.
+        # The mask is derived from the projected component, so it also depends on the
+        # projection and coverage — those are part of the key so that changing the
+        # coverage slider mid-session cannot reuse the previous geometry's mask.
         _fmask_key = (
             round(theta, 3),
             round(phi, 3),
@@ -233,6 +271,7 @@ class PerspectiveConverter:
             is_left_eye,
             self.orig_height,
             self.orig_width,
+            self.geometry,
             str(_mask_device),
         )
         # Thread-safe cache lookup: hold the lock only for the dict read so concurrent

--- a/app/processors/external/Equirec2Perspec_vr.py
+++ b/app/processors/external/Equirec2Perspec_vr.py
@@ -1,11 +1,13 @@
-import cv2
 import threading
 from collections import OrderedDict
 from functools import lru_cache
-from typing import Dict, Any
+
+import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F
+
+from app.helpers.vr_geometry import VRGeometry, rays_to_frame_pixels
 
 # E2P-CACHE-01: perspective plane grid cache — (FOV, height, width) → (persp_xx, persp_yy, w_len, h_len).
 # Stores CPU tensors; callers move to device.  Thread-safe: _PERSP_GRID_CACHE_LOCK guards
@@ -81,18 +83,26 @@ class Equirectangular:
         # for that frame, then freed by setting to None at the next copy_() invalidation.
         # This avoids 24+ redundant uint8→float32 conversions per frame (one per tile/crop)
         # that were the dominant VR processing bottleneck after the VR-MEM-01 change.
-        self._img_float: "torch.Tensor | None" = None
+        self._img_float: torch.Tensor | None = None
 
-    def GetPerspective(self, FOV: float, THETA: float, PHI: float, height: int, width: int) -> torch.Tensor:
+    def GetPerspective(self, FOV: float, THETA: float, PHI: float, height: int, width: int,
+                       geometry: "VRGeometry | None" = None,
+                       is_left_eye: "bool | None" = None) -> torch.Tensor:
         #
         # THETA is left/right angle, PHI is up/down angle, both in degree
+        #
+        # geometry describes how the source frame's pixels map to directions, and
+        # is_left_eye says which eye THETA addresses (None = the frame is one view).
+        # Passing no geometry keeps the historical assumption that the whole frame is
+        # a 360°x180° equirect, i.e. VR180 side-by-side.
         #
         # Returns: Perspective crop as Torch tensor (C, H, W) in RGB, uint8 format, on GPU.
 
         equ_h = self._height
         equ_w = self._width
-        equ_cx = (equ_w - 1) / 2.0
-        equ_cy = (equ_h - 1) / 2.0
+
+        if geometry is None:
+            geometry = VRGeometry(frame_height=equ_h, frame_width=equ_w)
 
         # E2P-CACHE-01: perspective plane grid — depends only on FOV and output size,
         # NOT on THETA/PHI. Cached AS GPU TENSORS keyed by (FOV, h, w, device): a
@@ -136,8 +146,14 @@ class Equirectangular:
 
         # E2P-CACHE-02: rotation matrices cached by (THETA, PHI, device).
         # Avoids 2× cv2.Rodrigues + numpy→GPU on every call (was 48+ calls per tile-detect frame).
+        # Rotation happens in the addressed eye's own camera frame, so THETA has the
+        # eye's optical axis subtracted from it.  Doing this in a frame-level sphere
+        # instead would break above 180° coverage, where the two eyes' longitude
+        # ranges pass ±180° and atan2 folds them onto each other.
         R1_torch, R2_torch = _get_e2p_rotation_matrices_cached(
-            float(THETA), float(PHI), str(self.device)
+            float(geometry.rotation_theta(float(THETA), is_left_eye)),
+            float(PHI),
+            str(self.device),
         )
 
         # Rotate the 3D points
@@ -151,20 +167,22 @@ class Equirectangular:
         rotated_xyz_flat = R2_torch @ R1_torch @ xyz_flat
         rotated_xyz = rotated_xyz_flat.T.reshape(height, width, 3) # H, W, 3
 
-        # Convert Cartesian to spherical coordinates (longitude, latitude)
-        # x_eq = rotated_xyz[..., 0], y_eq = rotated_xyz[..., 1], z_eq = rotated_xyz[..., 2]
-        lon_rad = torch.atan2(rotated_xyz[..., 1], rotated_xyz[..., 0]) # Longitude
-        # Bug 1 fix: clamp to [-1, 1] before asin to avoid NaN from float rounding at poles
-        lat_rad = torch.asin(torch.clamp(rotated_xyz[..., 2], -1.0, 1.0))  # Latitude
-
-        # Convert spherical to equirectangular pixel coordinates
-        lon_px = (lon_rad / torch.pi) * equ_cx + equ_cx # Map [-pi, pi] to [0, equ_w-1]
-        lat_px = (-lat_rad / (torch.pi / 2.0)) * equ_cy + equ_cy # Map [-pi/2, pi/2] to [0, equ_h-1] (lat is inverted)
+        # Project each ray onto the source frame.  Which formula applies depends on
+        # the projection, so it lives in vr_geometry alongside its exact inverse
+        # (used by Perspec2Equirec) to keep the two from drifting apart.
+        lon_px, lat_px = rays_to_frame_pixels(rotated_xyz, geometry, is_left_eye)
 
         # Pre-sanitise pixel coords before normalising for grid_sample.
-        # Longitude: wrap circularly so the 0°/360° seam maps cleanly.
-        # fmod handles the case where atan2 returns exactly ±π, producing lon_px == equ_w.
-        lon_px = torch.fmod(lon_px, equ_w)
+        if geometry.wraps_longitude:
+            # This view closes into a full circle, so wrap circularly and the
+            # 0°/360° seam maps cleanly.  fmod also handles atan2 returning
+            # exactly ±π, which would give lon_px == equ_w.
+            lon_px = torch.fmod(lon_px, equ_w)
+        else:
+            # Partial coverage: pixels past the edge belong to the other eye (or to
+            # nothing), so clamp within this eye's columns instead of wrapping.
+            eye_x_min, eye_x_max = geometry.eye_x_bounds(is_left_eye)
+            lon_px = torch.clamp(lon_px, eye_x_min, eye_x_max)
         # Latitude: clamp at the poles so float rounding near ±90° never exceeds image bounds.
         lat_px = torch.clamp(lat_px, 0.0, equ_h - 1.0)
 

--- a/app/processors/external/Perspec2Equirec_vr.py
+++ b/app/processors/external/Perspec2Equirec_vr.py
@@ -1,11 +1,13 @@
 import threading
+from collections import OrderedDict
+from functools import lru_cache
+
 import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F
-from functools import lru_cache
-from collections import OrderedDict
 
+from app.helpers.vr_geometry import VRGeometry, frame_pixel_rays
 
 # P2E-CACHE-01: module-level (grid, mask_out) cache — purely geometric, so the same
 # (theta, phi, fov, crop_h, crop_w, eq_h, eq_w) always produces the same tensors.
@@ -23,35 +25,40 @@ _P2E_GRID_MASK_CACHE_MAX = 4
 _P2E_GRID_MASK_CACHE_LOCK = threading.Lock()
 
 
-# calculates the 3D coordinate grid for an equirectangular output.
+# calculates the 3D coordinate grid for the output frame.
 # It is decorated with @lru_cache to ensure it only runs once for a given
-# height and width, caching the result for all subsequent calls.
+# geometry, caching the result for all subsequent calls.
 # Always stored on CPU — callers move to device as needed, keeping GPU memory free.
-# maxsize=4: caps the cache at 4 unique resolutions (~88 MB each at 4K) to prevent
+# maxsize=8: caps the cache at 8 unique geometries (~88 MB each at 4K) to prevent
 # unbounded CPU RAM growth when multiple video resolutions are processed in a session.
-@lru_cache(maxsize=4)
-def _get_equirect_xyz_grid_cached(height: int, width: int) -> torch.Tensor:
+# Raised from 4 because a Both-Eyes fisheye needs one entry per eye (each eye has
+# its own optical axis), where equirectangular needs only one for the whole frame.
+@lru_cache(maxsize=8)
+def _get_frame_xyz_grid_cached(
+    geometry: VRGeometry, is_left_eye: "bool | None"
+) -> tuple[torch.Tensor, "torch.Tensor | None"]:
     """
     Generates and caches a grid of 3D Cartesian unit vectors corresponding to
-    pixels in an equirectangular projection. Cached on CPU to avoid GPU fragmentation.
+    pixels in the source frame, plus a validity mask (None when every pixel
+    carries a usable direction). Cached on CPU to avoid GPU fragmentation.
     """
-    print(f"[VR Grid Cache] Generating new equirectangular XYZ grid for {width}x{height} on cpu...")
+    print(
+        f"[VR Grid Cache] Generating new {geometry.projection} XYZ grid for "
+        f"{geometry.frame_width}x{geometry.frame_height} "
+        f"at {geometry.coverage_deg:g}° coverage on cpu..."
+    )
+    return frame_pixel_rays(geometry, is_left_eye, torch.device("cpu"))
 
-    # Create equirectangular grid on CPU — caller moves to device
-    equ_lon_coords = torch.linspace(-180, 180, width, dtype=torch.float32)
-    equ_lat_coords = torch.linspace(90, -90, height, dtype=torch.float32)
-    equ_lon_grid, equ_lat_grid = torch.meshgrid(equ_lon_coords, equ_lat_coords, indexing='xy')
 
-    # Convert equirectangular (lon, lat) to 3D Cartesian unit vectors
-    lon_rad = torch.deg2rad(equ_lon_grid)
-    lat_rad = torch.deg2rad(equ_lat_grid)
+def clear_p2e_caches() -> None:
+    """Release the cached pixel→ray grids and (grid, mask) pairs.
 
-    x_3d = torch.cos(lat_rad) * torch.cos(lon_rad)
-    y_3d = torch.cos(lat_rad) * torch.sin(lon_rad)
-    z_3d = torch.sin(lat_rad)
-    xyz_equ_norm = torch.stack((x_3d, y_3d, z_3d), dim=2)  # Shape: H, W, 3
-
-    return xyz_equ_norm
+    Called between jobs so entries built for one video's resolution and VR
+    geometry do not sit on CPU and GPU memory while the next one runs.
+    """
+    _get_frame_xyz_grid_cached.cache_clear()
+    with _P2E_GRID_MASK_CACHE_LOCK:
+        _P2E_GRID_MASK_CACHE.clear()
 
 
 # This function should be at the module level
@@ -84,10 +91,15 @@ def _get_rotation_matrices_cached(THETA_deg: float, PHI_deg: float, device_str: 
     return R1_inv_torch, R2_inv_torch
 
 class Perspective:
-    def __init__(self, img_tensor_cxhxw_rgb_uint8: torch.Tensor, FOV: float, THETA: float, PHI: float):
+    def __init__(self, img_tensor_cxhxw_rgb_uint8: torch.Tensor, FOV: float, THETA: float, PHI: float,
+                 geometry: "VRGeometry | None" = None, is_left_eye: "bool | None" = None):
         """
         Initializes with a perspective image tensor.
         :param img_tensor_cxhxw_rgb_uint8: Torch tensor (C, H, W) in RGB, uint8 format, on GPU.
+        :param geometry: how the target frame's pixels map to directions.  None keeps
+            the historical assumption of a 360°x180° equirect frame (VR180 SBS); the
+            frame size is then filled in by GetEquirec, which is where it is known.
+        :param is_left_eye: which eye this crop belongs to, or None for a single-view frame.
         """
         if not isinstance(img_tensor_cxhxw_rgb_uint8, torch.Tensor):
             raise ValueError("Input must be a PyTorch tensor.")
@@ -97,6 +109,9 @@ class Perspective:
         self._img_tensor_cxhxw_rgb_float = img_tensor_cxhxw_rgb_uint8.float() / 255.0 # Normalize to [0,1]
         self.device = img_tensor_cxhxw_rgb_uint8.device
         self._channels, self._height, self._width = self._img_tensor_cxhxw_rgb_float.shape
+
+        self.geometry = geometry
+        self.is_left_eye = is_left_eye
 
         # Store original THETA, PHI degrees and device string for caching rotation matrices
         self.THETA_deg_for_cache = THETA
@@ -113,9 +128,17 @@ class Perspective:
         self.w_len = torch.tan(torch.deg2rad(torch.tensor(self.wFOV / 2.0, device=self.device)))
         self.h_len = torch.tan(torch.deg2rad(torch.tensor(self.hFOV / 2.0, device=self.device)))
 
+        # Rotation happens in whichever frame the pixel→ray grid is expressed in:
+        # the frame-level sphere for equirectangular, the eye's own camera frame for
+        # a fisheye.  rotation_theta() picks the matching longitude.
+        self.rotation_theta_deg = (
+            THETA if self.geometry is None
+            else self.geometry.rotation_theta(THETA, self.is_left_eye)
+        )
+
         # Call the new module-level cached function
         self.R1, self.R2 = _get_rotation_matrices_cached(
-            self.THETA_deg_for_cache,
+            self.rotation_theta_deg,
             self.PHI_deg_for_cache,
             self.device_str_for_cache
         )
@@ -134,8 +157,21 @@ class Perspective:
         # hit, every frame, on every pool worker — and each upload's sync was
         # spin-waiting on CUDA 13/Windows. The "GPU fragmentation" the original
         # comment worried about is bounded by _P2E_GRID_MASK_CACHE_MAX entries.
+        geometry = self.geometry
+        if geometry is None:
+            geometry = VRGeometry(frame_height=height, frame_width=width)
+        elif (geometry.frame_height, geometry.frame_width) != (height, width):
+            raise ValueError(
+                f"geometry describes a {geometry.frame_width}x{geometry.frame_height} "
+                f"frame but GetEquirec was asked for {width}x{height}"
+            )
+
+        # The grid also depends on the projection, coverage and eye, so the geometry
+        # is part of the key — otherwise switching coverage mid-session would keep
+        # reusing a grid built for the previous one.
         _cache_key = (self.THETA_deg_for_cache, self.PHI_deg_for_cache,
                       self.wFOV, self._height, self._width, height, width,
+                      geometry, self.is_left_eye,
                       str(self.device))
         # Thread-safe cache lookup — hold lock only for the dict read.
         with _P2E_GRID_MASK_CACHE_LOCK:
@@ -146,7 +182,12 @@ class Perspective:
         else:
             # Call the cached function to get the 3D coordinate grid (stored on CPU).
             # Move to device for the matrix multiply and projection.
-            xyz_equ_norm = _get_equirect_xyz_grid_cached(height, width).to(self.device)
+            xyz_equ_norm, pixel_valid = _get_frame_xyz_grid_cached(
+                geometry, self.is_left_eye
+            )
+            xyz_equ_norm = xyz_equ_norm.to(self.device)
+            if pixel_valid is not None:
+                pixel_valid = pixel_valid.to(self.device)
 
             # Rotate these 3D points (from equirect space to perspective camera's view space)
             xyz_flat = xyz_equ_norm.reshape(-1, 3).T  # (3, H*W)
@@ -171,6 +212,10 @@ class Perspective:
                              (v_norm >= -self.h_len) & (v_norm <= self.h_len)
 
             mask = is_in_front & fov_conditions  # H, W boolean tensor
+            if pixel_valid is not None:
+                # Fisheye: pixels outside the lens circle, or belonging to the other
+                # eye, hold no direction at all and must never be written to.
+                mask = mask & pixel_valid
 
             grid_x_persp = u_norm / self.w_len
             grid_y_persp = -(v_norm / self.h_len)  # Invert Y-axis for grid_sample convention
@@ -197,7 +242,7 @@ class Perspective:
             # intermediates are no longer referenced.
             del xyz_equ_norm, xyz_flat, rotated_xyz_flat, rotated_xyz_persp_view
             del depth_val, is_in_front, safe_depth_divisor, u_norm, v_norm
-            del fov_conditions, mask, grid_x_persp, grid_y_persp
+            del fov_conditions, mask, grid_x_persp, grid_y_persp, pixel_valid
 
         # Image-dependent sampling — always executed (image changes every frame)
         equirect_component_float = F.grid_sample(self._img_tensor_cxhxw_rgb_float.unsqueeze(0), grid,

--- a/app/processors/video_utils/worker_pool_manager.py
+++ b/app/processors/video_utils/worker_pool_manager.py
@@ -154,9 +154,11 @@ class WorkerPoolManager(QObject):
         if clear_module_caches:
             try:
                 from app.processors.external.Equirec2Perspec_vr import clear_persp_cache
+                from app.processors.external.Perspec2Equirec_vr import clear_p2e_caches
                 from app.helpers.vr_utils import clear_feathered_mask_cache
 
                 clear_persp_cache()
+                clear_p2e_caches()
                 clear_feathered_mask_cache()
             except Exception:
                 pass

--- a/app/processors/workers/frame_worker_vr.py
+++ b/app/processors/workers/frame_worker_vr.py
@@ -1,7 +1,7 @@
-import math
-import traceback
-import threading
 import gc
+import math
+import threading
+import traceback
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -9,13 +9,14 @@ import torch
 import torchvision
 from torchvision.transforms import v2
 
-from app.helpers.vr_utils import EquirectangularConverter, PerspectiveConverter
 from app.helpers.miscellaneous import (
     ParametersDict,
     draw_bounding_boxes_on_detected_faces,
-    keypoints_adjustments,
     get_grid_for_pasting,
+    keypoints_adjustments,
 )
+from app.helpers.vr_geometry import VRGeometry, rays_to_frame_pixels
+from app.helpers.vr_utils import EquirectangularConverter, PerspectiveConverter
 
 if TYPE_CHECKING:
     from app.ui.widgets import widget_components
@@ -26,9 +27,13 @@ if TYPE_CHECKING:
 
 class VRProcessor:
     """
-    Handles all VR180/360 specific operations.
+    Handles all VR specific operations.
     Delegates back to the main FrameWorker for standard pipeline operations
     (swap_core, recognition, UI state) to guarantee thread safety.
+
+    The mapping from frame pixels to directions on the viewing sphere is described
+    by a VRGeometry built from the UI controls, so per-eye coverage (90°–360°) and
+    the storage projection (equirectangular or fisheye) are both configurable.
     """
 
     def __init__(self, worker: "FrameWorker"):
@@ -38,12 +43,14 @@ class VRProcessor:
         self.VR_PERSPECTIVE_RENDER_SIZE: int = 512
         self.VR_FOV_SCALE_FACTOR: float = 1.5
 
-        # VR converter caches (VR-08 & Improvement K)
+        # VR converter caches (VR-08 & Improvement K).  Keyed on the geometry, which
+        # carries the frame size as well as the projection and coverage, so a change
+        # to any of them rebuilds the converter.
         self._vr_converter: EquirectangularConverter | None = None
-        self._vr_frame_size: tuple[int, int] | None = None
+        self._vr_geometry: VRGeometry | None = None
 
         self._vr_p2e_converter: PerspectiveConverter | None = None
-        self._vr_p2e_frame_size: tuple[int, int] | None = None
+        self._vr_p2e_geometry: VRGeometry | None = None
 
         # VR tracking state
         self.last_detected_faces_vr: list[dict[str, Any]] = []
@@ -70,33 +77,34 @@ class VRProcessor:
         return np.eye(3) + math.sin(angle) * K + (1.0 - math.cos(angle)) * (K @ K)
 
     @staticmethod
-    def _project_crop_bbox_to_equirect(
+    def _project_crop_bbox_to_frame(
         bbox_crop: np.ndarray,
         theta: float,
         phi: float,
         fov: float,
         crop_size: int,
-        eq_h: int,
-        eq_w: int,
+        geometry: VRGeometry,
+        is_left_eye: "bool | None",
     ) -> "np.ndarray | None":
-        """Project a crop-space bounding box back to equirectangular pixel coordinates.
+        """Project a crop-space bounding box back to frame pixel coordinates.
 
         Samples 9 points (4 corners + 4 edge midpoints + centre) through the same
         forward rotation used by E2P, then takes the axis-aligned bounding box of
         the projected points.
 
-        Returns (x1, y1, x2, y2) float32 in equirect pixel space, or None if the
+        Returns (x1, y1, x2, y2) float32 in frame pixel space, or None if the
         resulting box is degenerate (<2 px on either side).
         """
         y_axis = np.array([0.0, 1.0, 0.0], np.float64)
         z_axis = np.array([0.0, 0.0, 1.0], np.float64)
-        R1 = VRProcessor._rodrigues_np(z_axis * math.radians(theta))
+        # Same longitude convention as E2P: frame-level for equirectangular,
+        # eye-relative for a fisheye.
+        rot_theta = geometry.rotation_theta(theta, is_left_eye)
+        R1 = VRProcessor._rodrigues_np(z_axis * math.radians(rot_theta))
         R2 = VRProcessor._rodrigues_np(np.dot(R1, y_axis) * math.radians(-phi))
         R = R2 @ R1
 
         w_len = math.tan(math.radians(fov / 2.0))
-        equ_cx = (eq_w - 1) / 2.0
-        equ_cy = (eq_h - 1) / 2.0
 
         x1_c, y1_c, x2_c, y2_c = (
             float(bbox_crop[0]),
@@ -119,23 +127,26 @@ class VRProcessor:
             (x2_c, y2_c),
         ]
 
-        lon_pxs: list[float] = []
-        lat_pxs: list[float] = []
-        for u, v in sample_pts:
+        rays: np.ndarray = np.empty((len(sample_pts), 3), dtype=np.float32)
+        for i, (u, v) in enumerate(sample_pts):
             px_norm = 2.0 * u / (crop_size - 1) - 1.0
             py_norm = 2.0 * v / (crop_size - 1) - 1.0
             d = np.array([1.0, w_len * px_norm, -w_len * py_norm], np.float64)
-            d_norm = d / np.linalg.norm(d)
-            d_world = R @ d_norm
-            lon = math.atan2(d_world[1], d_world[0])
-            lat = math.asin(float(np.clip(d_world[2], -1.0, 1.0)))
-            lon_pxs.append((lon / math.pi) * equ_cx + equ_cx)
-            lat_pxs.append((-lat / (math.pi / 2.0)) * equ_cy + equ_cy)
+            rays[i] = R @ (d / np.linalg.norm(d))
 
-        x1_eq = float(np.clip(min(lon_pxs), 0.0, eq_w - 1))
-        y1_eq = float(np.clip(min(lat_pxs), 0.0, eq_h - 1))
-        x2_eq = float(np.clip(max(lon_pxs), 0.0, eq_w - 1))
-        y2_eq = float(np.clip(max(lat_pxs), 0.0, eq_h - 1))
+        # Reuse the shared projection so the tiled detector's bboxes land exactly
+        # where the crop was actually sampled from.
+        x_px_t, y_px_t = rays_to_frame_pixels(
+            torch.from_numpy(rays), geometry, is_left_eye
+        )
+        x_pxs = x_px_t.numpy()
+        y_pxs = y_px_t.numpy()
+
+        eq_w, eq_h = geometry.frame_width, geometry.frame_height
+        x1_eq = float(np.clip(x_pxs.min(), 0.0, eq_w - 1))
+        y1_eq = float(np.clip(y_pxs.min(), 0.0, eq_h - 1))
+        x2_eq = float(np.clip(x_pxs.max(), 0.0, eq_w - 1))
+        y2_eq = float(np.clip(y_pxs.max(), 0.0, eq_h - 1))
 
         if x2_eq - x1_eq < 2.0 or y2_eq - y1_eq < 2.0:
             return None
@@ -145,61 +156,32 @@ class VRProcessor:
         self,
         equirect_converter: EquirectangularConverter,
         control: dict,
-        eq_h: int,
-        eq_w: int,
+        geometry: VRGeometry,
         crop_size: int,
         stop_event: threading.Event | None = None,
     ) -> list:
         """Detect faces in a grid of undistorted perspective crops.
 
-        Catches faces that are invisible to the equirect-domain detector because
-        of projection distortion (high elevation, near the ±180° seam, or very
-        large near-camera faces).
+        Catches faces that are invisible to the frame-domain detector because of
+        projection distortion (high elevation, near an eye's edge, or very large
+        near-camera faces).
 
-        Returns a list of float32 numpy arrays, each (4,) or (5,) in equirect
-        pixel coordinates.
+        Returns a list of float32 numpy arrays, each (4,) or (5,) in frame pixel
+        coordinates.
         """
-        # Full-sphere tile grid: (theta_deg, phi_deg)
-        # 60° horizontal spacing at each latitude band gives ~30° overlap with a 90° FOV tile.
-        TILE_GRID = [
-            # equator band
-            (-150, 0),
-            (-90, 0),
-            (-30, 0),
-            (30, 0),
-            (90, 0),
-            (150, 0),
-            # upper band ~40°
-            (-150, 40),
-            (-90, 40),
-            (-30, 40),
-            (30, 40),
-            (90, 40),
-            (150, 40),
-            # lower band ~-40°
-            (-150, -40),
-            (-90, -40),
-            (-30, -40),
-            (30, -40),
-            (90, -40),
-            (150, -40),
-            # near-pole tiles — 3 per pole is sufficient given the 90° FOV
-            (-90, 70),
-            (0, 70),
-            (90, 70),
-            (-90, -70),
-            (0, -70),
-            (90, -70),
-        ]
         tile_fov = 90.0
+        # The grid is derived from the geometry so it sweeps exactly the sphere the
+        # frame actually covers, rather than a hardcoded full 360°×180°.
+        tile_grid = geometry.tile_grid(tile_fov_deg=tile_fov)
         det_score = control["DetectorScoreSlider"] / 100.0
         found: list = []
 
-        for theta, phi in TILE_GRID:
+        for theta, phi in tile_grid:
             if stop_event is not None and stop_event.is_set():
                 break
+            is_left_eye = geometry.eye_of_theta(theta)
             tile_crop = equirect_converter.get_perspective_crop(
-                tile_fov, theta, phi, crop_size, crop_size
+                tile_fov, theta, phi, crop_size, crop_size, is_left_eye=is_left_eye
             )
             if tile_crop is None or tile_crop.numel() == 0:
                 continue
@@ -226,8 +208,14 @@ class VRProcessor:
                 continue
 
             for bbox_tile in bboxes_tile:
-                eq_bbox = self._project_crop_bbox_to_equirect(
-                    bbox_tile[:4], theta, phi, tile_fov, crop_size, eq_h, eq_w
+                eq_bbox = self._project_crop_bbox_to_frame(
+                    bbox_tile[:4],
+                    theta,
+                    phi,
+                    tile_fov,
+                    crop_size,
+                    geometry,
+                    is_left_eye,
                 )
                 if eq_bbox is None:
                     continue
@@ -542,8 +530,8 @@ class VRProcessor:
         stop_event: threading.Event,
     ) -> torch.Tensor:
         """
-        Handles the specific logic for VR180/360 frames:
-        - Equirectangular detection
+        Handles the specific logic for VR frames:
+        - Whole-frame detection
         - Perspective cropping
         - Processing per crop
         - Stitching back
@@ -556,16 +544,26 @@ class VRProcessor:
             self.worker.main_window.editFacesButton.isChecked()
         )
 
+        # How this frame's pixels map to directions: eye layout, storage projection
+        # and per-eye coverage.  Everything downstream asks the geometry rather than
+        # assuming the VR180 360°×180° special case.
+        geometry = VRGeometry.from_control(
+            control,
+            frame_height=img_numpy_rgb_uint8.shape[0],
+            frame_width=img_numpy_rgb_uint8.shape[1],
+        )
+
         # VR-08: cache the EquirectangularConverter instance at worker level.
-        # When the frame size is unchanged (common for video), reuse the cached
+        # When the geometry is unchanged (common for video), reuse the cached
         # instance and update its image data in-place to avoid redundant Python-side
         # object allocation.
-        _cur_frame_size = (img_numpy_rgb_uint8.shape[0], img_numpy_rgb_uint8.shape[1])
-        if self._vr_converter is None or self._vr_frame_size != _cur_frame_size:
+        if self._vr_converter is None or self._vr_geometry != geometry:
             self._vr_converter = EquirectangularConverter(
-                img_numpy_rgb_uint8, device=self.worker.models_processor.device
+                img_numpy_rgb_uint8,
+                device=self.worker.models_processor.device,
+                geometry=geometry,
             )
-            self._vr_frame_size = _cur_frame_size
+            self._vr_geometry = geometry
         else:
             # VR-MEM-01: update in-place to avoid new GPU allocation per frame.
             self._vr_converter.equirect_tensor_cxhxw_rgb_uint8.copy_(
@@ -615,11 +613,9 @@ class VRProcessor:
         # A standard VR180 SBS equirect is 2:1 (W=2H), so each half is square (H×H).
         # Detecting on each 1:1 half gives the detector 4× more pixels per face vs
         # letterboxing the full 2:1 equirect to 512×256.
-        _eq_h = img_numpy_rgb_uint8.shape[0]
-        _eq_w = img_numpy_rgb_uint8.shape[1]
-        _is_both_eyes = (
-            control.get("VR180EyeModeSelection", "Both Eyes") != "Single Eye"
-        )
+        _eq_h = geometry.frame_height
+        _eq_w = geometry.frame_width
+        _is_both_eyes = geometry.both_eyes
         _aspect = _eq_w / max(_eq_h, 1)
         _do_per_eye_detect = _is_both_eyes and _aspect >= 1.8
 
@@ -695,8 +691,7 @@ class VRProcessor:
             _tile_bboxes = self._detect_faces_vr_tiled(
                 equirect_converter,
                 control,
-                _eq_h,
-                _eq_w,
+                geometry,
                 self.VR_PERSPECTIVE_RENDER_SIZE,
                 stop_event=stop_event,
             )
@@ -832,13 +827,9 @@ class VRProcessor:
         # relative position and size. This prevents one-eye-only swaps when the detector
         # fires on one half but not the other due to marginal confidence or rendering
         # differences between the two stereo views.
-        # Only applies to Both-Eyes VR180 (not Single Eye, not VR360 panoramic).
-        if (
-            control.get("VR180EyeModeSelection", "Both Eyes") != "Single Eye"
-            and bboxes_eq_np.ndim == 2
-            and bboxes_eq_np.shape[0] > 0
-        ):
-            _half_w = equirect_converter.width / 2.0
+        # Only applies to Both-Eyes mode (not to a single-view frame).
+        if geometry.both_eyes and bboxes_eq_np.ndim == 2 and bboxes_eq_np.shape[0] > 0:
+            _half_w = float(geometry.eye_width)
             _cx = (bboxes_eq_np[:, 0] + bboxes_eq_np[:, 2]) / 2.0
             _is_left = _cx < _half_w
             _mirrored_bboxes: list[np.ndarray] = []
@@ -889,44 +880,26 @@ class VRProcessor:
             theta, phi = equirect_converter.calculate_theta_phi_from_bbox(
                 bbox_eq_single
             )
+            _is_left_eye = geometry.eye_of_pixel(
+                (float(bbox_eq_single[0]) + float(bbox_eq_single[2])) / 2.0
+            )
+            # None = the frame holds a single view, so there is no side to name.
             original_eye_side = (
-                "L"
-                if (bbox_eq_single[0] + bbox_eq_single[2]) / 2
-                < equirect_converter.width / 2
-                else "R"
-            )
-            angular_width_deg = (
-                (bbox_eq_single[2] - bbox_eq_single[0])
-                / equirect_converter.width
-                * 360.0
-            )
-            angular_height_deg = (
-                (bbox_eq_single[3] - bbox_eq_single[1])
-                / equirect_converter.height
-                * 180.0
+                "single" if _is_left_eye is None else ("L" if _is_left_eye else "R")
             )
 
             # VR-13: use renamed VR_FOV_SCALE_FACTOR (was VR_DYNAMIC_FOV_PADDING_FACTOR)
-            # VR-02: correct angular_width_deg for latitude compression in equirectangular
-            # projection: true angular width ≈ equirect_width / cos(phi_radians)
-            phi_radians = math.radians(phi)
-            cos_phi = math.cos(phi_radians)
-            # Clamp cos_phi to 0.35 (≈70° latitude) to cap the correction at ~2.9×.
-            # The previous clamp of 0.1 allowed up to ×10 amplification near the poles,
-            # which produced extreme FOVs causing landmark coordinates to be garbage
-            # ("eye sideways, mouth near ear") for faces near the top/bottom of the frame.
-            # Secondary cap: never let the correction exceed 2× the raw angular width,
-            # ensuring continuity with non-corrected detection for near-pole detections.
-            angular_width_deg_corrected = angular_width_deg / max(cos_phi, 0.35)
-            angular_width_deg_corrected = min(
-                angular_width_deg_corrected, angular_width_deg * 2.0
+            # The angular size (including the equirectangular latitude-compression
+            # correction, which a fisheye does not need) is computed by the geometry.
+            angular_width_deg, angular_height_deg = geometry.bbox_angular_size_deg(
+                bbox_eq_single, phi
             )
             # Improvement C: use VR180MaxFOVSlider instead of the previous hard-cap of
             # 100°.  Near-camera faces can subtend >100° and were being clipped.
             _vr_max_fov = float(control.get("VR180MaxFOVSlider", 120))
             dynamic_fov_for_crop = float(
                 np.clip(
-                    max(angular_width_deg_corrected, angular_height_deg)
+                    max(angular_width_deg, angular_height_deg)
                     * self.VR_FOV_SCALE_FACTOR,
                     15.0,
                     _vr_max_fov,
@@ -939,6 +912,7 @@ class VRProcessor:
                 phi,
                 self.VR_PERSPECTIVE_RENDER_SIZE,
                 self.VR_PERSPECTIVE_RENDER_SIZE,
+                is_left_eye=_is_left_eye,
             )
             if face_crop_tensor is None or face_crop_tensor.numel() == 0:
                 continue
@@ -977,6 +951,7 @@ class VRProcessor:
                     "theta": theta,
                     "phi": phi,
                     "original_eye_side": original_eye_side,
+                    "is_left_eye": _is_left_eye,
                     "face_crop_tensor": face_crop_tensor,
                     "fov_used_for_crop": dynamic_fov_for_crop,
                     "kps_on_crop": kpss_5_crop[0] if landmark_ok else None,
@@ -1015,10 +990,11 @@ class VRProcessor:
                 _fd["kps_all_on_crop"] = _rall if len(_rall) > 0 else None
 
         # Step 2: VR-LANDMARK-MIRROR — if a face crop still has no landmarks but the
-        # partner eye view (same face, other VR180 half) succeeded, reuse those
-        # keypoints as a last resort. In the equirectangular projection the partner's
-        # theta is exactly ±180° away (mirrored x-offset = width/2).
-        if control.get("VR180EyeModeSelection", "Both Eyes") != "Single Eye":
+        # partner eye view (same face, other stereo half) succeeded, reuse those
+        # keypoints as a last resort.  Both eyes look the same way, so the partner
+        # sits at the identical eye-relative angle — one coverage width away in
+        # frame-level theta (180° on standard VR180).
+        if geometry.both_eyes:
             _kps_cache: dict[tuple[float, float], tuple] = {}
             for _fd in _crop_landmark_results:
                 if _fd["kps_on_crop"] is not None:
@@ -1028,10 +1004,8 @@ class VRProcessor:
                     )
             for _fd in _crop_landmark_results:
                 if _fd["kps_on_crop"] is None:
-                    _mir_theta = (
-                        _fd["theta"] + 180.0
-                        if "L" in _fd["original_eye_side"]
-                        else _fd["theta"] - 180.0
+                    _mir_theta = geometry.partner_theta(
+                        _fd["theta"], _fd["is_left_eye"]
                     )
                     for (_ct, _cp), _ckps in _kps_cache.items():
                         if abs(_ct - _mir_theta) < 1.0 and abs(_cp - _fd["phi"]) < 0.5:
@@ -1060,7 +1034,7 @@ class VRProcessor:
             phi = _fd["phi"]
             original_eye_side = _fd["original_eye_side"]
             dynamic_fov_for_crop = _fd["fov_used_for_crop"]
-            similarity_type = str("Auto")
+            similarity_type = "Auto"
 
             face_emb_crop, _ = self.worker.function_worker.run_recognize_direct(
                 face_crop_tensor,
@@ -1095,6 +1069,7 @@ class VRProcessor:
                         "theta": theta,
                         "phi": phi,
                         "original_eye_side": original_eye_side,
+                        "is_left_eye": _fd["is_left_eye"],
                         "face_crop_tensor": face_crop_tensor,
                         "kps_on_crop": kps_on_crop,
                         "kps_all_on_crop": kps_all_on_crop,
@@ -1161,10 +1136,10 @@ class VRProcessor:
                     )
                 )
 
-            # VR-07: append (eye_side, tensor, theta, phi, fov) tuple instead of dict entry
+            # VR-07: append (is_left_eye, tensor, theta, phi, fov) tuple instead of dict entry
             processed_perspective_crops_details.append(
                 (
-                    item_data["original_eye_side"],
+                    item_data["is_left_eye"],
                     processed_crop_for_stitching,
                     item_data["theta"],
                     item_data["phi"],
@@ -1189,30 +1164,29 @@ class VRProcessor:
             return _result_no_stitch
 
         final_equirect_torch_cxhxw_rgb_uint8 = original_equirect_tensor_for_vr.clone()
-        vr_single_eye_mode = (
-            control.get("VR180EyeModeSelection", "Both Eyes") == "Single Eye"
-        )
 
         # Improvement K: cache PerspectiveConverter across frames (like E2P converter).
         # PerspectiveConverter only uses img_numpy_rgb_uint8 for its dimensions; the
         # per-frame image content is not stored in the converter itself (stitch_single_perspective
         # receives the target tensor directly).  We can therefore reuse the cached instance
-        # whenever the frame resolution is unchanged, avoiding repeated kernel allocation.
-        # NOTE: deliberately uses _vr_p2e_frame_size (NOT _vr_frame_size) for this check.
-        # _vr_frame_size is updated by the E2P branch above, so by the time we reach this
-        # point it always equals _cur_frame_size.  A separate tracking attribute ensures the
-        # P2E converter is properly recreated when the frame resolution changes.
-        if self._vr_p2e_converter is None or self._vr_p2e_frame_size != _cur_frame_size:
+        # whenever the geometry is unchanged, avoiding repeated kernel allocation.
+        # NOTE: deliberately uses _vr_p2e_geometry (NOT _vr_geometry) for this check.
+        # _vr_geometry is updated by the E2P branch above, so by the time we reach this
+        # point it always equals geometry.  A separate tracking attribute ensures the
+        # P2E converter is properly recreated when the geometry changes.
+        if self._vr_p2e_converter is None or self._vr_p2e_geometry != geometry:
             self._vr_p2e_converter = PerspectiveConverter(
-                img_numpy_rgb_uint8, device=self.worker.models_processor.device
+                img_numpy_rgb_uint8,
+                device=self.worker.models_processor.device,
+                geometry=geometry,
             )
-            self._vr_p2e_frame_size = _cur_frame_size
+            self._vr_p2e_geometry = geometry
         p2e_converter = self._vr_p2e_converter
 
         # VR-15: check stop_event in stitching loop so we can abort early
-        # VR-07: iterate over list of (eye_side, tensor, theta, phi, fov) tuples
+        # VR-07: iterate over list of (is_left_eye, tensor, theta, phi, fov) tuples
         for (
-            _eye_side,
+            _is_left_eye,
             _crop_tensor,
             _theta,
             _phi,
@@ -1226,7 +1200,7 @@ class VRProcessor:
                 theta=_theta,
                 phi=_phi,
                 fov=_fov,
-                is_left_eye=(None if vr_single_eye_mode else ("L" in _eye_side)),
+                is_left_eye=_is_left_eye,
             )
             # FW-MEM-02: release the crop tensor immediately after stitching
             del _crop_tensor

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -1,6 +1,8 @@
-from app.ui.widgets.actions import control_actions
-import cv2
 from typing import Any
+
+import cv2
+
+from app.ui.widgets.actions import control_actions
 
 EXPERIMENTAL_SETTINGS_CONTROL_KEYS = frozenset(
     {
@@ -18,7 +20,7 @@ EXPERIMENTAL_SETTINGS_CONTROL_KEYS = frozenset(
     }
 )
 
-SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
+SETTINGS_LAYOUT_DATA: Any = {
     "Appearance": {
         "ThemeSelection": {
             "level": 1,
@@ -322,16 +324,36 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
         },
         "VR180ModeEnableToggle": {
             "level": 1,
-            "label": "Enable VR180 Mode",
+            "label": "Enable VR Mode",
             "default": False,
-            "help": "Enable VR180 mode. This will treat the input video as an equirectangular VR180 video and apply face swapping within perspective crops.",
+            "help": "Enable VR mode. This will treat the input video as spherical VR footage and apply face swapping within undistorted perspective crops. Set the projection and coverage below to match your video — the defaults are standard VR180.",
         },
         "VR180EyeModeSelection": {
             "level": 1,
-            "label": "VR180 Eye Mode",
+            "label": "VR Eye Mode",
             "options": ["Both Eyes", "Single Eye"],
             "default": "Both Eyes",
-            "help": "Select 'Both Eyes' for standard VR180 video (left+right eye side-by-side). Select 'Single Eye' if the input video already contains only one eye's equirectangular view (full frame = one hemisphere).",
+            "help": "Select 'Both Eyes' for standard stereo VR video (left+right eye side-by-side). Select 'Single Eye' if the input video already contains only one eye's view (full frame = one view).",
+            "parentToggle": "VR180ModeEnableToggle",
+            "requiredToggleValue": True,
+        },
+        "VRProjectionSelection": {
+            "level": 1,
+            "label": "VR Projection",
+            "options": ["Equirectangular", "Fisheye (equidistant)"],
+            "default": "Equirectangular",
+            "help": "How each eye's view is stored in the video frame. 'Equirectangular' is a latitude/longitude grid — the usual output of stitching tools such as Mistika VR or Canon EOS VR Utility, and correct for standard VR180. 'Fisheye (equidistant)' is a circular lens image where distance from the centre is proportional to the angle from the lens axis — used by 200° lens formats (MKX200, VRCA220, Fisheye190) and typical of unstitched single-lens-per-eye footage. Picking the wrong one makes swapped faces land in visibly the wrong place, so if crops look misaligned, try the other.",
+            "parentToggle": "VR180ModeEnableToggle",
+            "requiredToggleValue": True,
+        },
+        "VRCoverageSlider": {
+            "level": 1,
+            "label": "VR Coverage (per eye)",
+            "min_value": "90",
+            "max_value": "360",
+            "default": "180",
+            "step": 5,
+            "help": "How many degrees of the sphere ONE eye's view covers horizontally. 180 = standard VR180 (the default, and identical to previous versions). 200 = 200° lens content such as MKX200. Use lower values for narrower footage, and 360 together with 'Single Eye' for a full monoscopic panorama. Vertical coverage is derived from this and the frame's aspect ratio, assuming square angular pixels, and is capped at 180° for equirectangular content. This is the coverage of the VIDEO, not the field of view you view it at — if your player recommends '110-150 FOV', that is a viewing zoom and does not necessarily mean the file covers 110-150°.",
             "parentToggle": "VR180ModeEnableToggle",
             "requiredToggleValue": True,
         },
@@ -345,7 +367,7 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
             # horizontal resolution. Power users can disable for max throughput
             # in scenes that don't need it.
             "default": False,
-            "help": "Run face detection on a grid of 24 undistorted perspective crops to catch faces missed by standard detection (faces near poles, the ±180° seam, head tilted back, or very close to the camera). Default ON — recommended for most VR content. Disable only when you are certain the standard detector finds every face you need.",
+            "help": "Run face detection on a grid of undistorted perspective crops covering the whole sphere your footage spans (24 crops at the default coverage) to catch faces missed by standard detection (faces near the poles, near an eye's edge, head tilted back, or very close to the camera). Recommended for most VR content. Disable only when you are certain the standard detector finds every face you need.",
             "parentToggle": "VR180ModeEnableToggle",
             "requiredToggleValue": True,
         },

--- a/tests/integration/test_vr_projection_pipeline.py
+++ b/tests/integration/test_vr_projection_pipeline.py
@@ -1,0 +1,324 @@
+"""VRPROJ-* integration tests for configurable VR coverage and projection.
+
+These exercise the real EquirectangularConverter → PerspectiveConverter path with
+tiny synthetic frames and no ML models.
+
+The property under test is *localisation*: a face at a known frame position must
+land in the centre of the extracted perspective crop, and the swapped crop must be
+stitched back onto that same position.  If the forward and inverse projections
+disagree, swapped faces appear offset — which is the failure mode a hardcoded
+180°/equirectangular assumption produces on 200° or fisheye footage.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from app.helpers.vr_geometry import (
+    PROJECTION_EQUIRECTANGULAR,
+    PROJECTION_FISHEYE,
+    VRGeometry,
+)
+from app.helpers.vr_utils import EquirectangularConverter, PerspectiveConverter
+
+CPU = torch.device("cpu")
+
+# Large enough that a few pixels of tolerance is a tight bound, small enough to
+# stay fast on CPU.
+FRAME_H, FRAME_W = 256, 512
+CROP = 64
+
+PROJECTIONS = [PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE]
+COVERAGES = [130.0, 180.0, 200.0]
+
+
+def geometry_for(projection: str, coverage: float, both_eyes: bool = True):
+    return VRGeometry(
+        frame_height=FRAME_H,
+        frame_width=FRAME_W,
+        both_eyes=both_eyes,
+        projection=projection,
+        coverage_deg=coverage,
+    )
+
+
+def frame_with_marker(x: int, y: int, radius: int = 5) -> np.ndarray:
+    """A mid-grey frame with one bright square, so the marker is unambiguous."""
+    img = np.full((FRAME_H, FRAME_W, 3), 40, dtype=np.uint8)
+    img[y - radius : y + radius + 1, x - radius : x + radius + 1] = 255
+    return img
+
+
+def bright_centroid(
+    chw_uint8: torch.Tensor, threshold: float = 160.0
+) -> tuple[float, float]:
+    """(x, y) centroid of the bright pixels of a CHW tensor.
+
+    A centroid rather than argmax: the marker is a saturated plateau, so argmax
+    would return its top-left corner and report a spurious offset.
+    """
+    luma = chw_uint8.float().mean(dim=0)
+    rows, columns = torch.nonzero(luma > threshold, as_tuple=True)
+    assert len(rows) > 0, "no bright pixels found at all"
+    return float(columns.float().mean()), float(rows.float().mean())
+
+
+def marker_positions(geometry: VRGeometry) -> list[tuple[int, int, bool]]:
+    """Well-inside-the-view sample points for each eye, as (x, y, is_left_eye).
+
+    Kept away from the edges so a 40° crop around the point stays inside the
+    view — the test is about localisation, not edge clamping.
+    """
+    points: list[tuple[int, int, bool]] = []
+    for is_left_eye in (True, False):
+        cx = geometry.eye_pixel_center(is_left_eye)
+        cy = (FRAME_H - 1) / 2.0
+        span = geometry.eye_pixel_span(is_left_eye)
+        for dx_fraction, dy_fraction in [(0.0, 0.0), (0.25, -0.2), (-0.3, 0.25)]:
+            points.append(
+                (
+                    round(cx + dx_fraction * span / 2.0),
+                    round(cy + dy_fraction * (FRAME_H - 1) / 2.0),
+                    is_left_eye,
+                )
+            )
+    return points
+
+
+# ---------------------------------------------------------------------------
+# VRPROJ-01: a marker at (x, y) lands at the centre of the crop aimed at it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("projection", PROJECTIONS)
+@pytest.mark.parametrize("coverage", COVERAGES)
+def test_crop_is_centred_on_the_direction_it_was_asked_for(projection, coverage):
+    geometry = geometry_for(projection, coverage)
+    converter = EquirectangularConverter(
+        frame_with_marker(FRAME_W // 4, FRAME_H // 2), CPU, geometry
+    )
+
+    for x, y, is_left_eye in marker_positions(geometry):
+        img = frame_with_marker(x, y)
+        converter.equirect_tensor_cxhxw_rgb_uint8.copy_(
+            torch.from_numpy(img).permute(2, 0, 1)
+        )
+        converter.e2p_instance._img_float = None
+
+        theta, phi = converter.calculate_theta_phi_from_bbox(
+            np.array([x - 5, y - 5, x + 5, y + 5], dtype=np.float32)
+        )
+        assert geometry.eye_of_pixel(x) is is_left_eye, "test point in the wrong eye"
+
+        crop = converter.get_perspective_crop(
+            40.0, theta, phi, CROP, CROP, is_left_eye=is_left_eye
+        )
+        found_x, found_y = bright_centroid(crop)
+        center = (CROP - 1) / 2.0
+        assert abs(found_x - center) <= 3, (
+            f"{projection} @{coverage}° marker at ({x},{y}) landed at x={found_x}, "
+            f"expected ~{center}"
+        )
+        assert abs(found_y - center) <= 3, (
+            f"{projection} @{coverage}° marker at ({x},{y}) landed at y={found_y}, "
+            f"expected ~{center}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# VRPROJ-02: the swapped crop is stitched back onto the position it came from
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("projection", PROJECTIONS)
+@pytest.mark.parametrize("coverage", COVERAGES)
+def test_stitch_lands_on_the_direction_it_came_from(projection, coverage):
+    geometry = geometry_for(projection, coverage)
+    stitcher = PerspectiveConverter(
+        np.zeros((FRAME_H, FRAME_W, 3), np.uint8), CPU, geometry
+    )
+
+    for x, y, is_left_eye in marker_positions(geometry):
+        theta, phi = geometry.pixel_to_theta_phi(x, y)
+        target = torch.zeros(3, FRAME_H, FRAME_W, dtype=torch.uint8)
+        stitcher.stitch_single_perspective(
+            target_equirect_torch_cxhxw_rgb_uint8=target,
+            processed_crop_torch_cxhxw_rgb_uint8=torch.full(
+                (3, CROP, CROP), 255, dtype=torch.uint8
+            ),
+            theta=theta,
+            phi=phi,
+            fov=40.0,
+            is_left_eye=is_left_eye,
+        )
+
+        written = target.float().mean(dim=0)
+        assert written[y, x] > 128, (
+            f"{projection} @{coverage}°: nothing stitched at ({x},{y})"
+        )
+
+        # The written region must be centred on the requested position, not merely
+        # touch it — an offset projection would still clip the point.
+        rows, columns = torch.nonzero(written > 32, as_tuple=True)
+        assert len(rows) > 0
+        assert abs(float(columns.float().mean()) - x) <= 4
+        assert abs(float(rows.float().mean()) - y) <= 4
+
+
+# ---------------------------------------------------------------------------
+# VRPROJ-03: stereo isolation — one eye's swap never touches the other eye
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("projection", PROJECTIONS)
+@pytest.mark.parametrize("coverage", COVERAGES)
+def test_stitch_never_crosses_into_the_other_eye(projection, coverage):
+    geometry = geometry_for(projection, coverage)
+    stitcher = PerspectiveConverter(
+        np.zeros((FRAME_H, FRAME_W, 3), np.uint8), CPU, geometry
+    )
+    half = FRAME_W // 2
+
+    for is_left_eye in (True, False):
+        # Deliberately near the eye's inner edge, where bleed would show up.
+        cx = geometry.eye_pixel_center(is_left_eye)
+        span = geometry.eye_pixel_span(is_left_eye)
+        x = round(cx + (0.8 if is_left_eye else -0.8) * span / 2.0)
+        theta, phi = geometry.pixel_to_theta_phi(x, FRAME_H // 2)
+
+        target = torch.zeros(3, FRAME_H, FRAME_W, dtype=torch.uint8)
+        stitcher.stitch_single_perspective(
+            target_equirect_torch_cxhxw_rgb_uint8=target,
+            processed_crop_torch_cxhxw_rgb_uint8=torch.full(
+                (3, CROP, CROP), 255, dtype=torch.uint8
+            ),
+            theta=theta,
+            phi=phi,
+            fov=60.0,
+            is_left_eye=is_left_eye,
+        )
+        other_half = target[:, :, half:] if is_left_eye else target[:, :, :half]
+        assert int(other_half.sum().item()) == 0, (
+            f"{projection} @{coverage}°: {'left' if is_left_eye else 'right'} eye "
+            "swap bled into the other eye"
+        )
+
+
+# ---------------------------------------------------------------------------
+# VRPROJ-04: an extract → stitch round trip restores the original pixels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("projection", PROJECTIONS)
+@pytest.mark.parametrize("coverage", COVERAGES)
+def test_extract_then_stitch_preserves_the_marker_position(projection, coverage):
+    """Pull a crop out, put it straight back, and the marker must not move.
+
+    This is the end-to-end version of the property: it fails if the forward and
+    inverse projections disagree even slightly.
+    """
+    geometry = geometry_for(projection, coverage)
+    x, y, is_left_eye = marker_positions(geometry)[0]
+    img = frame_with_marker(x, y, radius=8)
+
+    extractor = EquirectangularConverter(img, CPU, geometry)
+    stitcher = PerspectiveConverter(img, CPU, geometry)
+
+    theta, phi = geometry.pixel_to_theta_phi(x, y)
+    # A larger crop resolution keeps resampling loss from dominating.
+    crop = extractor.get_perspective_crop(
+        40.0, theta, phi, 128, 128, is_left_eye=is_left_eye
+    )
+
+    target = torch.zeros(3, FRAME_H, FRAME_W, dtype=torch.uint8)
+    stitcher.stitch_single_perspective(
+        target_equirect_torch_cxhxw_rgb_uint8=target,
+        processed_crop_torch_cxhxw_rgb_uint8=crop,
+        theta=theta,
+        phi=phi,
+        fov=40.0,
+        is_left_eye=is_left_eye,
+    )
+
+    restored_x, restored_y = bright_centroid(target)
+    assert abs(restored_x - x) <= 3, (
+        f"{projection} @{coverage}°: x moved from {x} to {restored_x:.1f}"
+    )
+    assert abs(restored_y - y) <= 3, (
+        f"{projection} @{coverage}°: y moved from {y} to {restored_y:.1f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# VRPROJ-05: the default settings reproduce the previous behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_default_geometry_matches_the_implicit_legacy_geometry():
+    """Passing no geometry must behave exactly like the VR180 default."""
+    img = frame_with_marker(FRAME_W // 4, FRAME_H // 2, radius=8)
+    theta, phi = -90.0, 0.0
+
+    legacy = EquirectangularConverter(img, CPU)  # geometry=None
+    explicit = EquirectangularConverter(
+        img, CPU, geometry_for(PROJECTION_EQUIRECTANGULAR, 180.0)
+    )
+
+    legacy_crop = legacy.get_perspective_crop(60.0, theta, phi, CROP, CROP)
+    explicit_crop = explicit.get_perspective_crop(
+        60.0, theta, phi, CROP, CROP, is_left_eye=True
+    )
+    assert torch.equal(legacy_crop, explicit_crop)
+
+
+def test_single_eye_stitch_still_covers_the_whole_frame():
+    """is_left_eye=None keeps meaning 'the frame is one view', as before."""
+    geometry = geometry_for(PROJECTION_EQUIRECTANGULAR, 180.0)
+    stitcher = PerspectiveConverter(
+        np.zeros((FRAME_H, FRAME_W, 3), np.uint8), CPU, geometry
+    )
+    half = FRAME_W // 2
+
+    single = torch.zeros(3, FRAME_H, FRAME_W, dtype=torch.uint8)
+    stitcher.stitch_single_perspective(
+        target_equirect_torch_cxhxw_rgb_uint8=single,
+        processed_crop_torch_cxhxw_rgb_uint8=torch.full(
+            (3, CROP, CROP), 255, dtype=torch.uint8
+        ),
+        theta=0.0,
+        phi=0.0,
+        fov=90.0,
+        is_left_eye=None,
+    )
+    # theta=0 is the seam between the eyes when the frame is one 360° view, so a
+    # 90° crop there must write to both halves.
+    assert int(single[:, :, :half].sum().item()) > 0
+    assert int(single[:, :, half:].sum().item()) > 0
+
+
+# ---------------------------------------------------------------------------
+# VRPROJ-06: coverage actually changes the mapping
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_changes_where_a_pixel_points():
+    """Otherwise the slider would be silently inert."""
+    at_180 = geometry_for(PROJECTION_EQUIRECTANGULAR, 180.0)
+    at_200 = geometry_for(PROJECTION_EQUIRECTANGULAR, 200.0)
+    x, y = FRAME_W // 8, FRAME_H // 2
+    theta_180, _ = at_180.pixel_to_theta_phi(x, y)
+    theta_200, _ = at_200.pixel_to_theta_phi(x, y)
+    assert theta_180 != pytest.approx(theta_200)
+
+
+def test_projection_changes_where_a_pixel_points():
+    equirect = geometry_for(PROJECTION_EQUIRECTANGULAR, 200.0)
+    fisheye = geometry_for(PROJECTION_FISHEYE, 200.0)
+    # Off-axis and off-centre, where the two projections genuinely diverge.
+    x = int(equirect.eye_pixel_center(True) + 0.6 * equirect.eye_pixel_span(True) / 2)
+    y = FRAME_H // 4
+    assert equirect.pixel_to_theta_phi(x, y) != pytest.approx(
+        fisheye.pixel_to_theta_phi(x, y)
+    )

--- a/tests/unit/helpers/test_vr_geometry.py
+++ b/tests/unit/helpers/test_vr_geometry.py
@@ -1,0 +1,539 @@
+"""VRGEO-* tests for VRGeometry — the pixel↔direction mapping for VR frames.
+
+The critical properties are:
+
+* the default geometry reproduces the old hardcoded VR180 formulas exactly, so
+  existing projects keep rendering the way they did, and
+* pixel → direction → pixel is a round trip for every projection and coverage,
+  because the forward mapping picks a crop's centre and the inverse mapping
+  decides where the swapped crop is pasted back.  If they disagree, faces land
+  in the wrong place.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from app.helpers.vr_geometry import (
+    COVERAGE_DEFAULT_DEG,
+    COVERAGE_MAX_DEG,
+    COVERAGE_MIN_DEG,
+    LAT_SPAN_MAX_DEG,
+    PROJECTION_EQUIRECTANGULAR,
+    PROJECTION_FISHEYE,
+    VRGeometry,
+    frame_pixel_rays,
+    rays_to_frame_pixels,
+)
+
+CPU = torch.device("cpu")
+
+# A standard VR180 side-by-side frame: 2:1 overall, so each eye is square.
+SBS_H, SBS_W = 180, 360
+
+
+def sbs(**kwargs) -> VRGeometry:
+    return VRGeometry(frame_height=SBS_H, frame_width=SBS_W, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-01: the default geometry is the old VR180 special case
+# ---------------------------------------------------------------------------
+
+
+def test_default_geometry_is_legacy_vr180():
+    geometry = sbs()
+    assert geometry.both_eyes is True
+    assert geometry.projection == PROJECTION_EQUIRECTANGULAR
+    assert geometry.coverage_deg == COVERAGE_DEFAULT_DEG
+    assert geometry.reproduces_legacy_vr180 is True
+    # The whole frame is a full 360°x180° equirect — the coincidence the original
+    # implementation relied on.
+    assert geometry.lon_span_deg == pytest.approx(360.0)
+    assert geometry.lat_span_deg == pytest.approx(180.0)
+    assert geometry.eye_width == SBS_W // 2
+
+
+def test_default_pixel_to_theta_phi_tracks_the_original_formula():
+    """The old bbox formula was theta = (x/W - 0.5)*360, phi = -(y/H - 0.5)*180.
+
+    It normalised by W and H while the projection code it fed normalised by W-1
+    and H-1, so the original code's two halves already disagreed with each other.
+    The geometry is internally consistent instead (see the round-trip test), which
+    necessarily means it cannot reproduce both.  It agrees with the old bbox
+    formula to within a pixel — far below detector precision, and the projection
+    side, which decides actual sampling, is reproduced exactly.
+    """
+    geometry = sbs()
+    deg_per_px = geometry.deg_per_pixel
+    for x, y in [(0, 0), (37, 12), (180, 90), (359, 179), (SBS_W / 2, SBS_H / 2)]:
+        theta, phi = geometry.pixel_to_theta_phi(x, y)
+        legacy_theta = (x / SBS_W - 0.5) * 360.0
+        legacy_phi = -(y / SBS_H - 0.5) * 180.0
+        assert abs(theta - legacy_theta) < deg_per_px, f"theta drift at x={x}"
+        assert abs(phi - legacy_phi) < deg_per_px, f"phi drift at y={y}"
+
+
+def test_default_rays_to_pixels_matches_original_formula_exactly():
+    """E2P used lon_px = (lon/pi)*cx + cx and lat_px = (-lat/(pi/2))*cy + cy.
+
+    This is the mapping that decides which source pixels a crop samples, so the
+    default geometry must reproduce it exactly or existing projects would
+    re-render differently.
+    """
+    geometry = sbs()
+    rays = torch.tensor(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.6, -0.5, 0.62449980],
+        ],
+        dtype=torch.float32,
+    )
+    rays = rays / rays.norm(dim=-1, keepdim=True)
+    # is_left_eye=None is how single-view (whole-frame) stitching has always been
+    # signalled, and is the case the old formula described.
+    x_px, y_px = rays_to_frame_pixels(rays, geometry, is_left_eye=None)
+
+    center_x = (SBS_W - 1) / 2.0
+    center_y = (SBS_H - 1) / 2.0
+    expected_x = []
+    expected_y = []
+    for ray in rays:
+        lon = math.atan2(float(ray[1]), float(ray[0]))
+        lat = math.asin(max(-1.0, min(1.0, float(ray[2]))))
+        expected_x.append((lon / math.pi) * center_x + center_x)
+        expected_y.append((-lat / (math.pi / 2.0)) * center_y + center_y)
+
+    assert x_px.tolist() == pytest.approx(expected_x, abs=1e-4)
+    assert y_px.tolist() == pytest.approx(expected_y, abs=1e-4)
+
+
+def test_default_both_eyes_pixel_mapping_matches_original_eye_placement():
+    """Each eye's 180° maps onto (W-1)/2 px, centred where the old code put it.
+
+    The original code addressed both eyes through one 360° formula over W-1
+    pixels, which placed the eye axes at (W-1)/4 and 3(W-1)/4 rather than at the
+    centres of the two integer halves.  Keeping that placement is what makes the
+    default path render identically.
+    """
+    geometry = sbs()
+    assert geometry.angular_pixel_span == pytest.approx((SBS_W - 1) / 2.0)
+    assert geometry.eye_pixel_center(True) == pytest.approx((SBS_W - 1) / 4.0)
+    assert geometry.eye_pixel_center(False) == pytest.approx(3 * (SBS_W - 1) / 4.0)
+
+    on_axis = torch.tensor([[1.0, 0.0, 0.0]], dtype=torch.float32)
+    for is_left_eye in (True, False):
+        x_px, y_px = rays_to_frame_pixels(on_axis, geometry, is_left_eye)
+        # The eye's optical axis is its own longitude, which the old whole-frame
+        # formula placed at exactly these columns.
+        expected = (SBS_W - 1) / 4.0 if is_left_eye else 3 * (SBS_W - 1) / 4.0
+        assert float(x_px[0]) == pytest.approx(expected, abs=1e-4)
+        assert float(y_px[0]) == pytest.approx((SBS_H - 1) / 2.0, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-02: spans scale with coverage and eye mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "coverage,expected_lon_span",
+    [(90.0, 180.0), (130.0, 260.0), (180.0, 360.0), (200.0, 400.0)],
+)
+def test_both_eyes_lon_span_is_twice_coverage(coverage, expected_lon_span):
+    geometry = sbs(coverage_deg=coverage)
+    assert geometry.lon_span_deg == pytest.approx(expected_lon_span)
+
+
+@pytest.mark.parametrize("coverage", [90.0, 130.0, 180.0, 200.0, 360.0])
+def test_single_eye_lon_span_equals_coverage(coverage):
+    geometry = VRGeometry(
+        frame_height=SBS_H, frame_width=SBS_H, both_eyes=False, coverage_deg=coverage
+    )
+    assert geometry.lon_span_deg == pytest.approx(coverage)
+    assert geometry.eye_width == SBS_H
+
+
+def test_lat_span_is_capped_for_equirectangular():
+    """A square eye at 200° coverage would need ±100° latitude, which lat/lon
+    cannot express, so the vertical span saturates at 180°."""
+    geometry = sbs(coverage_deg=200.0)
+    assert geometry.lat_span_deg == pytest.approx(LAT_SPAN_MAX_DEG)
+
+
+def test_lat_span_follows_aspect_ratio():
+    """A frame half as tall as its eyes are wide covers half the vertical angle."""
+    geometry = VRGeometry(frame_height=90, frame_width=360, coverage_deg=180.0)
+    assert geometry.eye_width == 180
+    assert geometry.lat_span_deg == pytest.approx(90.0)
+
+
+def test_only_a_full_circle_wraps_longitude():
+    """A view has to span the whole circle before running off its edge can wrap.
+
+    A 180° eye must clamp instead: the pixels past its inner edge belong to the
+    other eye, and sampling them was how the old whole-frame wrap could bleed one
+    eye's image into the other's crop.
+    """
+    assert sbs().wraps_longitude is False
+    assert sbs(coverage_deg=200.0).wraps_longitude is False
+    assert sbs(projection=PROJECTION_FISHEYE).wraps_longitude is False
+    assert (
+        VRGeometry(
+            frame_height=SBS_H, frame_width=SBS_W, both_eyes=False, coverage_deg=360.0
+        ).wraps_longitude
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-03: eye assignment is consistent between pixel space and angle space
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("coverage", [90.0, 130.0, 180.0, 200.0])
+@pytest.mark.parametrize("projection", [PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE])
+def test_eye_of_pixel_and_eye_of_theta_agree(coverage, projection):
+    geometry = sbs(coverage_deg=coverage, projection=projection)
+    for x in (5, 40, 179, 180, 200, 355):
+        y = SBS_H // 2
+        by_pixel = geometry.eye_of_pixel(x)
+        theta, _ = geometry.pixel_to_theta_phi(x, y)
+        assert geometry.eye_of_theta(theta) is by_pixel, (
+            f"x={x} theta={theta} disagrees for {projection} at {coverage}°"
+        )
+
+
+def test_single_eye_has_no_eye_split():
+    geometry = sbs(both_eyes=False)
+    assert geometry.eye_of_pixel(10) is None
+    assert geometry.eye_of_theta(-42.0) is None
+    assert geometry.eye_x_offset(None) == 0
+    assert geometry.eye_center_theta(None) == 0.0
+    assert geometry.partner_theta(17.0, None) == 17.0
+    assert geometry.rotation_theta(17.0, None) == 17.0
+
+
+@pytest.mark.parametrize("coverage", [90.0, 130.0, 180.0, 200.0])
+def test_partner_theta_is_one_coverage_away(coverage):
+    geometry = sbs(coverage_deg=coverage)
+    left_theta = -coverage / 2.0
+    right_theta = coverage / 2.0
+    assert geometry.partner_theta(left_theta, True) == pytest.approx(right_theta)
+    assert geometry.partner_theta(right_theta, False) == pytest.approx(left_theta)
+    # Round trip back to the original eye.
+    assert geometry.partner_theta(
+        geometry.partner_theta(left_theta, True), False
+    ) == pytest.approx(left_theta)
+
+
+def test_eye_bounds_partition_the_frame():
+    geometry = sbs()
+    left_min, left_max = geometry.eye_x_bounds(True)
+    right_min, right_max = geometry.eye_x_bounds(False)
+    assert (left_min, left_max) == (0.0, SBS_W / 2 - 1)
+    assert (right_min, right_max) == (SBS_W / 2, SBS_W - 1)
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-04: rotation frame differs per projection
+# ---------------------------------------------------------------------------
+
+
+def test_rotation_is_relative_to_the_eyes_optical_axis():
+    """Both projections rotate in the eye's own camera frame.
+
+    Doing this in a widened frame-level longitude range instead would break above
+    180° coverage, where the eyes' ranges pass ±180° and atan2 folds them onto
+    each other.
+    """
+    for projection in (PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE):
+        geometry = sbs(projection=projection)
+        # An on-axis face rotates by 0 regardless of which eye it is in.
+        assert geometry.rotation_theta(-90.0, True) == pytest.approx(0.0)
+        assert geometry.rotation_theta(90.0, False) == pytest.approx(0.0)
+        assert geometry.rotation_theta(-70.0, True) == pytest.approx(20.0)
+
+
+@pytest.mark.parametrize("coverage", [90.0, 130.0, 180.0, 200.0])
+@pytest.mark.parametrize("projection", [PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE])
+def test_rotation_theta_stays_representable(coverage, projection):
+    """Eye-relative longitude must stay inside the ±180° a direction vector can
+    represent, at every coverage.  This is the invariant a widened frame-level
+    longitude range violated above 180° coverage."""
+    geometry = sbs(coverage_deg=coverage, projection=projection)
+    for x in range(0, SBS_W, 7):
+        for y in (0, SBS_H // 2, SBS_H - 1):
+            theta, _phi = geometry.pixel_to_theta_phi(x, y)
+            local = geometry.rotation_theta(theta, geometry.eye_of_pixel(x))
+            assert abs(local) < 180.0, f"unrepresentable at x={x} y={y}: {local}"
+
+
+@pytest.mark.parametrize("coverage", [90.0, 130.0, 180.0, 200.0])
+def test_equirect_rotation_theta_stays_within_half_coverage(coverage):
+    """For a lat/lon grid the eye's columns map exactly onto ±coverage/2.
+
+    (A fisheye's corner pixels legitimately sit further off-axis than that — they
+    are outside the lens circle, and marked invalid rather than clamped.)
+    """
+    geometry = sbs(coverage_deg=coverage)
+    for x in range(0, SBS_W, 7):
+        theta, _phi = geometry.pixel_to_theta_phi(x, SBS_H // 2)
+        local = geometry.rotation_theta(theta, geometry.eye_of_pixel(x))
+        assert abs(local) <= coverage / 2.0 + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-05: fisheye mapping specifics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("coverage", [180.0, 200.0])
+@pytest.mark.parametrize("projection", [PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE])
+def test_eye_centre_pixel_looks_along_the_optical_axis(coverage, projection):
+    geometry = sbs(projection=projection, coverage_deg=coverage)
+    for is_left_eye in (True, False):
+        cx = geometry.eye_pixel_center(is_left_eye)
+        cy = (SBS_H - 1) / 2.0
+        theta, phi = geometry.pixel_to_theta_phi(cx, cy)
+        assert theta == pytest.approx(geometry.eye_center_theta(is_left_eye))
+        assert phi == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize("coverage", [130.0, 180.0, 200.0])
+@pytest.mark.parametrize("projection", [PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE])
+def test_eye_edge_is_half_the_coverage_off_axis(coverage, projection):
+    """At the horizontal edge of an eye the ray is coverage/2 off its axis."""
+    geometry = sbs(projection=projection, coverage_deg=coverage)
+    cy = (SBS_H - 1) / 2.0
+    cx = geometry.eye_pixel_center(True)
+    theta, phi = geometry.pixel_to_theta_phi(
+        cx + geometry.eye_pixel_span(True) / 2.0, cy
+    )
+    off_axis = theta - geometry.eye_center_theta(True)
+    assert off_axis == pytest.approx(coverage / 2.0, abs=1e-4)
+    assert phi == pytest.approx(0.0)
+
+
+def test_fisheye_scale_is_linear_in_angle():
+    """Equidistant means radius ∝ angle, so half the radius is half the angle."""
+    geometry = sbs(projection=PROJECTION_FISHEYE, coverage_deg=200.0)
+    cy = (SBS_H - 1) / 2.0
+    cx = geometry.eye_pixel_center(True)
+    span = geometry.eye_pixel_span(True)
+    quarter, _ = geometry.pixel_to_theta_phi(cx + span / 4.0, cy)
+    half, _ = geometry.pixel_to_theta_phi(cx + span / 2.0, cy)
+    center = geometry.eye_center_theta(True)
+    assert (quarter - center) == pytest.approx((half - center) / 2.0, abs=1e-4)
+
+
+def test_fisheye_marks_outside_the_lens_circle_invalid():
+    geometry = sbs(projection=PROJECTION_FISHEYE, coverage_deg=180.0)
+    _rays, valid = frame_pixel_rays(geometry, is_left_eye=True, device=CPU)
+    assert valid is not None
+    # The other eye's half is never writable from this eye's crop.
+    assert not bool(valid[:, geometry.eye_width :].any())
+    # The eye's own centre is inside the circle.
+    assert bool(valid[SBS_H // 2, geometry.eye_width // 2])
+    # A 180° circle inscribed in a square eye leaves the corners outside it.
+    assert not bool(valid[0, 0])
+
+
+def test_equirectangular_single_view_marks_every_pixel_usable():
+    geometry = sbs(both_eyes=False)
+    rays, valid = frame_pixel_rays(geometry, is_left_eye=None, device=CPU)
+    assert valid is None
+    assert rays.shape == (SBS_H, SBS_W, 3)
+    assert torch.allclose(rays.norm(dim=-1), torch.ones(SBS_H, SBS_W), atol=1e-5)
+
+
+def test_equirectangular_both_eyes_restricts_each_eye_to_its_own_half():
+    """The other eye's columns look the same way through a different optical
+    centre, so an eye's crop must never be written there."""
+    geometry = sbs()
+    half = SBS_W // 2
+    for is_left_eye in (True, False):
+        rays, valid = frame_pixel_rays(geometry, is_left_eye, CPU)
+        assert valid is not None
+        assert torch.allclose(rays.norm(dim=-1), torch.ones(SBS_H, SBS_W), atol=1e-5)
+        own = valid[:, :half] if is_left_eye else valid[:, half:]
+        other = valid[:, half:] if is_left_eye else valid[:, :half]
+        assert bool(own.all()), "an eye must own every column of its own half"
+        assert not bool(other.any()), "an eye must own no column of the other half"
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-06: pixel → ray → pixel round trip, the property that keeps faces
+# from being pasted back in the wrong place
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("coverage", [90.0, 130.0, 180.0, 200.0])
+@pytest.mark.parametrize("projection", [PROJECTION_EQUIRECTANGULAR, PROJECTION_FISHEYE])
+@pytest.mark.parametrize("is_left_eye", [True, False])
+def test_pixel_ray_pixel_round_trip(coverage, projection, is_left_eye):
+    geometry = sbs(coverage_deg=coverage, projection=projection)
+    rays, valid = frame_pixel_rays(geometry, is_left_eye, CPU)
+    x_px, y_px = rays_to_frame_pixels(rays, geometry, is_left_eye)
+
+    columns = torch.arange(SBS_W, dtype=torch.float32).unsqueeze(0).expand(SBS_H, SBS_W)
+    rows = torch.arange(SBS_H, dtype=torch.float32).unsqueeze(1).expand(SBS_H, SBS_W)
+
+    keep = valid if valid is not None else torch.ones_like(columns, dtype=torch.bool)
+    if not geometry.is_fisheye:
+        # Skip the exact poles, where longitude is degenerate: every longitude maps
+        # to the same point, so the inverse cannot recover the original column.
+        keep = keep & (rows > 0) & (rows < SBS_H - 1)
+
+    assert bool(keep.any()), "test would be vacuous — no pixels to check"
+    assert torch.allclose(x_px[keep], columns[keep], atol=0.02), (
+        f"x round trip drifted for {projection} at {coverage}°"
+    )
+    assert torch.allclose(y_px[keep], rows[keep], atol=0.02), (
+        f"y round trip drifted for {projection} at {coverage}°"
+    )
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-07: bounding-box angular size
+# ---------------------------------------------------------------------------
+
+
+def test_equirect_bbox_width_is_corrected_for_latitude():
+    geometry = sbs()
+    bbox = (100.0, 20.0, 120.0, 40.0)
+    at_equator, _ = geometry.bbox_angular_size_deg(bbox, phi_deg=0.0)
+    at_latitude, _ = geometry.bbox_angular_size_deg(bbox, phi_deg=60.0)
+    # cos(60°) = 0.5, so the correction is 2× — which is also the secondary cap.
+    assert at_latitude == pytest.approx(at_equator * 2.0)
+
+
+def test_equirect_bbox_latitude_correction_is_capped_at_2x():
+    geometry = sbs()
+    bbox = (100.0, 20.0, 120.0, 40.0)
+    at_equator, _ = geometry.bbox_angular_size_deg(bbox, phi_deg=0.0)
+    near_pole, _ = geometry.bbox_angular_size_deg(bbox, phi_deg=89.0)
+    assert near_pole == pytest.approx(at_equator * 2.0)
+
+
+def test_fisheye_bbox_size_needs_no_latitude_correction():
+    """A fisheye has a uniform angular scale, so elevation must not change the size."""
+    geometry = sbs(projection=PROJECTION_FISHEYE, coverage_deg=200.0)
+    bbox = (100.0, 20.0, 120.0, 40.0)
+    at_equator = geometry.bbox_angular_size_deg(bbox, phi_deg=0.0)
+    high_up = geometry.bbox_angular_size_deg(bbox, phi_deg=70.0)
+    assert at_equator == high_up
+    # 20 px at 200° spread over the eye's angular pixel span.
+    assert at_equator[0] == pytest.approx(20.0 * 200.0 / geometry.angular_pixel_span)
+
+
+def test_bbox_size_scales_with_coverage():
+    bbox = (100.0, 20.0, 120.0, 40.0)
+    at_180, _ = sbs(coverage_deg=180.0).bbox_angular_size_deg(bbox, 0.0)
+    at_200, _ = sbs(coverage_deg=200.0).bbox_angular_size_deg(bbox, 0.0)
+    assert at_200 == pytest.approx(at_180 * 200.0 / 180.0)
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-08: tiled-detection grid
+# ---------------------------------------------------------------------------
+
+
+def test_tile_grid_matches_the_previous_hardcoded_count_at_defaults():
+    grid = sbs().tile_grid()
+    assert len(grid) == 24
+    thetas_at_equator = sorted(t for t, p in grid if p == 0.0)
+    assert thetas_at_equator == pytest.approx([-150.0, -90.0, -30.0, 30.0, 90.0, 150.0])
+    assert sorted({p for _t, p in grid}) == pytest.approx(
+        [-70.0, -40.0, 0.0, 40.0, 70.0]
+    )
+
+
+@pytest.mark.parametrize("coverage", [90.0, 130.0, 180.0, 200.0])
+@pytest.mark.parametrize("both_eyes", [True, False])
+def test_tile_grid_stays_inside_the_covered_sphere(coverage, both_eyes):
+    geometry = VRGeometry(
+        frame_height=SBS_H,
+        frame_width=SBS_W,
+        both_eyes=both_eyes,
+        coverage_deg=coverage,
+    )
+    grid = geometry.tile_grid()
+    assert grid
+    for theta, phi in grid:
+        assert abs(theta) <= geometry.lon_span_deg / 2.0 + 1e-6
+        assert abs(phi) <= geometry.lat_span_deg / 2.0 + 1e-6
+
+
+def test_tile_grid_covers_both_eyes():
+    geometry = sbs(coverage_deg=200.0)
+    grid = geometry.tile_grid()
+    assert any(geometry.eye_of_theta(t) is True for t, _p in grid)
+    assert any(geometry.eye_of_theta(t) is False for t, _p in grid)
+
+
+# ---------------------------------------------------------------------------
+# VRGEO-09: building the geometry from the UI control dict
+# ---------------------------------------------------------------------------
+
+
+def test_from_control_defaults_to_legacy_vr180_when_keys_are_absent():
+    geometry = VRGeometry.from_control({}, frame_height=SBS_H, frame_width=SBS_W)
+    assert geometry == sbs()
+    assert geometry.reproduces_legacy_vr180 is True
+
+
+def test_from_control_reads_projection_coverage_and_eye_mode():
+    geometry = VRGeometry.from_control(
+        {
+            "VRProjectionSelection": PROJECTION_FISHEYE,
+            "VRCoverageSlider": 200,
+            "VR180EyeModeSelection": "Single Eye",
+        },
+        frame_height=SBS_H,
+        frame_width=SBS_W,
+    )
+    assert geometry.projection == PROJECTION_FISHEYE
+    assert geometry.coverage_deg == pytest.approx(200.0)
+    assert geometry.both_eyes is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (0, COVERAGE_MIN_DEG),
+        (10, COVERAGE_MIN_DEG),
+        (95, 95.0),
+        (500, COVERAGE_MAX_DEG),
+        ("200", 200.0),
+        (False, COVERAGE_MIN_DEG),  # transient value a mid-edit slider can hold
+        ("nonsense", COVERAGE_DEFAULT_DEG),
+        (None, COVERAGE_DEFAULT_DEG),
+    ],
+)
+def test_from_control_clamps_coverage(raw, expected):
+    geometry = VRGeometry.from_control(
+        {"VRCoverageSlider": raw}, frame_height=SBS_H, frame_width=SBS_W
+    )
+    assert geometry.coverage_deg == pytest.approx(expected)
+
+
+def test_from_control_rejects_unknown_projection():
+    geometry = VRGeometry.from_control(
+        {"VRProjectionSelection": "Cube Map"},
+        frame_height=SBS_H,
+        frame_width=SBS_W,
+    )
+    assert geometry.projection == PROJECTION_EQUIRECTANGULAR
+
+
+def test_geometry_is_hashable_so_it_can_key_the_projection_caches():
+    # The converters use it as an lru_cache / dict key.
+    assert hash(sbs()) == hash(sbs())
+    assert hash(sbs(coverage_deg=200.0)) != hash(sbs())
+    assert {sbs(): 1}[sbs()] == 1

--- a/tests/unit/processors/test_frame_worker_vr.py
+++ b/tests/unit/processors/test_frame_worker_vr.py
@@ -135,6 +135,10 @@ def _load_frame_worker_module():
 frame_worker_module = _load_frame_worker_module()
 FrameWorker = frame_worker_module.FrameWorker
 
+# The VR pipeline was split out of FrameWorker into its own module, so the
+# converters are patched there rather than on frame_worker.
+vr_module = importlib.import_module("app.processors.workers.frame_worker_vr")
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -191,6 +195,10 @@ def _make_worker(main_window):
         worker.video_processor = main_window.video_processor
         worker.frame_enhancers = MagicMock()
         worker.frame_edits = MagicMock()
+        # The VR path calls the detector through function_worker, which __init__
+        # would have wired up.
+        worker.function_worker = main_window.function_worker
+        worker.set_scaling_transforms = MagicMock()
         worker.frame_queue = None
         worker.worker_id = -1
         worker.frame = None
@@ -214,12 +222,7 @@ def _make_worker(main_window):
         worker.kernel_lap = None
         worker.kernel_sobel_x = None
         worker.kernel_sobel_y = None
-        worker._vr_converter = None
-        worker._vr_frame_size = None
-        worker._vr_p2e_converter = None  # Improvement K: cached PerspectiveConverter
-        worker._vr_p2e_frame_size = None
         worker._last_scaling_control = None
-        worker._last_vr_scaling_control = None
         worker._resize_cache = {}
         worker._gabor_kernels_cache = OrderedDict()
         # Q-QUAL-01 / Q-QUAL-03: EMA state dicts
@@ -240,6 +243,9 @@ def _make_worker(main_window):
         worker.t512_mask = MagicMock()
         worker.t128_mask = MagicMock()
         worker.t256_near = MagicMock()
+        # The VR pipeline lives on a VRProcessor that delegates back to the worker;
+        # it owns the converter caches that used to hang off FrameWorker directly.
+        worker.vr_processor = vr_module.VRProcessor(worker)
         return worker
 
 
@@ -327,7 +333,7 @@ def test_is_left_eye_is_none_for_single_eye_right():
 
 
 def test_empty_bboxes_returns_original(mock_main_window, small_equirect):
-    """When no faces are detected, _process_frame_vr180 returns the input tensor."""
+    """When no faces are detected, process_frame_vr180 returns the input tensor."""
     # mock run_detect to return empty
     mock_main_window.function_worker.run_detect.return_value = (
         np.empty((0, 5), dtype=np.float32),
@@ -360,11 +366,11 @@ def test_empty_bboxes_returns_original(mock_main_window, small_equirect):
         mock_ec.width = small_equirect.shape[1]
 
         with patch.object(
-            frame_worker_module,
+            vr_module,
             "EquirectangularConverter",
             return_value=mock_ec,
         ):
-            result = worker._process_frame_vr180(
+            result = worker.vr_processor.process_frame_vr180(
                 img_numpy_rgb_uint8=small_equirect,
                 original_equirect_tensor_for_vr=original_tensor,
                 control=control,
@@ -372,6 +378,113 @@ def test_empty_bboxes_returns_original(mock_main_window, small_equirect):
             )
 
     assert result is original_tensor
+
+
+# ---------------------------------------------------------------------------
+# FW-VR-07: the cached converter is keyed on the VR geometry
+# ---------------------------------------------------------------------------
+
+
+def _run_vr_frame(worker, small_equirect, control, converter_cls):
+    original_tensor = torch.from_numpy(small_equirect).permute(2, 0, 1).to(CPU)
+    base_control = {
+        "DetectorModelSelection": "RetinaFace",
+        "MaxFacesToDetectSlider": 10,
+        "DetectorScoreSlider": 50,
+        "LandmarkDetectModelSelection": "2dfan4",
+        "LandmarkDetectScoreSlider": 50,
+        "LandmarkMeanEyesToggle": False,
+        "VR180EyeModeSelection": "Both Eyes",
+    }
+    with patch.object(vr_module, "EquirectangularConverter", converter_cls):
+        worker.vr_processor.process_frame_vr180(
+            img_numpy_rgb_uint8=small_equirect,
+            original_equirect_tensor_for_vr=original_tensor,
+            control={**base_control, **control},
+            stop_event=threading.Event(),
+        )
+
+
+@pytest.mark.parametrize(
+    "changed_control",
+    [
+        {"VRCoverageSlider": 200},
+        {"VRProjectionSelection": "Fisheye (equidistant)"},
+        {"VR180EyeModeSelection": "Single Eye"},
+    ],
+    ids=["coverage", "projection", "eye_mode"],
+)
+def test_converter_is_rebuilt_when_the_geometry_changes(
+    mock_main_window, small_equirect, changed_control
+):
+    """Changing coverage/projection/eye mode must invalidate the cached converter.
+
+    The converter bakes in the pixel→direction mapping, so reusing one built for a
+    different geometry would silently keep rendering with the old settings.
+    """
+    mock_main_window.function_worker.run_detect.return_value = (
+        np.empty((0, 5), dtype=np.float32),
+        None,
+        None,
+    )
+    mock_ec = MagicMock()
+    mock_ec.height = small_equirect.shape[0]
+    mock_ec.width = small_equirect.shape[1]
+
+    with (
+        patch("app.helpers.vr_utils.E2P_Equirectangular", MagicMock()),
+        patch("app.helpers.vr_utils.P2E_Perspective", MagicMock()),
+    ):
+        worker = _make_worker(mock_main_window)
+        converter_cls = MagicMock(return_value=mock_ec)
+
+        _run_vr_frame(worker, small_equirect, {}, converter_cls)
+        assert converter_cls.call_count == 1
+
+        # Same settings again → the cached instance is reused.
+        _run_vr_frame(worker, small_equirect, {}, converter_cls)
+        assert converter_cls.call_count == 1, "converter rebuilt despite no change"
+
+        _run_vr_frame(worker, small_equirect, changed_control, converter_cls)
+        assert converter_cls.call_count == 2, (
+            f"converter not rebuilt after {changed_control}"
+        )
+
+
+def test_converter_receives_the_geometry_from_the_control_dict(
+    mock_main_window, small_equirect
+):
+    mock_main_window.function_worker.run_detect.return_value = (
+        np.empty((0, 5), dtype=np.float32),
+        None,
+        None,
+    )
+    mock_ec = MagicMock()
+    mock_ec.height = small_equirect.shape[0]
+    mock_ec.width = small_equirect.shape[1]
+
+    with (
+        patch("app.helpers.vr_utils.E2P_Equirectangular", MagicMock()),
+        patch("app.helpers.vr_utils.P2E_Perspective", MagicMock()),
+    ):
+        worker = _make_worker(mock_main_window)
+        converter_cls = MagicMock(return_value=mock_ec)
+        _run_vr_frame(
+            worker,
+            small_equirect,
+            {
+                "VRCoverageSlider": 200,
+                "VRProjectionSelection": "Fisheye (equidistant)",
+            },
+            converter_cls,
+        )
+
+    geometry = converter_cls.call_args.kwargs["geometry"]
+    assert geometry.coverage_deg == 200.0
+    assert geometry.is_fisheye is True
+    assert geometry.both_eyes is True
+    assert geometry.frame_height == small_equirect.shape[0]
+    assert geometry.frame_width == small_equirect.shape[1]
 
 
 # ---------------------------------------------------------------------------
@@ -411,13 +524,13 @@ def test_no_crops_skips_perspective_converter(mock_main_window, small_equirect):
 
         with (
             patch.object(
-                frame_worker_module,
+                vr_module,
                 "EquirectangularConverter",
                 return_value=mock_ec,
             ),
-            patch.object(frame_worker_module, "PerspectiveConverter") as mock_pc_cls,
+            patch.object(vr_module, "PerspectiveConverter") as mock_pc_cls,
         ):
-            worker._process_frame_vr180(
+            worker.vr_processor.process_frame_vr180(
                 img_numpy_rgb_uint8=small_equirect,
                 original_equirect_tensor_for_vr=original_tensor,
                 control=control,


### PR DESCRIPTION
VR mode only worked at 180°

Add a VR Coverage slider (90-360°, default 180) and a VR Projection selector (Equirectangular / Fisheye equidistant) so 200° lens formats and narrower footage work too.

Extract the pixel<->direction mapping into app/helpers/vr_geometry.py so the forward and inverse projections cannot drift apart. All ray maths now happens in the addressed eye's own camera frame, with is_left_eye threaded into the projection layer: an eye cannot be encoded as a longitude range, because both eyes look the same way and ranges past ±180° fold back onto each other under atan2. The tiled detector's grid is generated from the actual coverage instead of a fixed 24 tiles, and the converter caches are keyed on the geometry so changing a setting invalidates them.