### PR TITLE
Support macos

### DIFF
--- a/Start_mac.sh
+++ b/Start_mac.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# VisoMaster Fusion launcher for macOS.
+#
+# The Windows entry points (Start.bat / Start_Portable.bat) assume a portable
+# NVIDIA runtime that does not exist here. This script just activates the local
+# venv and runs the app from the repo root, which the Qt stylesheet loading in
+# main.py depends on.
+#
+# First-time setup:
+#   uv venv --python 3.12 .venv
+#   uv pip install --python .venv/bin/python -r requirements_mac.txt
+#   .venv/bin/python download_models.py
+#   brew install ffmpeg
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+if [[ ! -x .venv/bin/python ]]; then
+    echo "[FATAL] .venv not found. Run the first-time setup in the header of this script." >&2
+    exit 1
+fi
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "[WARN] ffmpeg not on PATH — recording and video export will fail." >&2
+    echo "       Install it with: brew install ffmpeg" >&2
+fi
+
+exec .venv/bin/python main.py "$@"

--- a/app/processors/face_swappers.py
+++ b/app/processors/face_swappers.py
@@ -1,5 +1,6 @@
 import torch
 import threading
+import weakref
 from skimage import transform as trans
 from torchvision.transforms import v2
 from app.processors.utils import faceutil
@@ -22,7 +23,19 @@ class FaceSwappers:
         self.function_worker = function_worker
         self.current_swapper_model = None
         self.current_arcface_model = None
-        self._session_io_name_cache: dict = {}  # FS-PERF-02: cache input/output names keyed by session id
+        # FS-PERF-02: cache input/output names per InferenceSession.
+        #
+        # Keyed by the session object itself, not id(session). Sessions are
+        # unloaded whenever the swapper or provider changes, and CPython reuses
+        # the freed address for the next allocation — so an id() key could hand a
+        # newly loaded model the previous model's IO names. That surfaced as
+        # "Failed to find input name in the mapping: input.1" when GhostArcFace
+        # (input "img") landed on the address of a released Inswapper128ArcFace
+        # (input "input.1"). A weak-keyed map drops entries as soon as the
+        # session is collected, so a stale name can never be read back.
+        self._session_io_name_cache: weakref.WeakKeyDictionary = (
+            weakref.WeakKeyDictionary()
+        )
         self._io_cache_lock = threading.Lock()
         self.resize_112 = v2.Resize(
             (112, 112), interpolation=v2.InterpolationMode.BILINEAR, antialias=False
@@ -211,15 +224,14 @@ class FaceSwappers:
         # --- INFERENCE ---
         img = torch.unsqueeze(img, 0).contiguous()
 
-        session_id = id(ort_session)
         with self._io_cache_lock:
-            if session_id not in self._session_io_name_cache:
-                self._session_io_name_cache[session_id] = {
+            if ort_session not in self._session_io_name_cache:
+                self._session_io_name_cache[ort_session] = {
                     "input": ort_session.get_inputs()[0].name,
                     "outputs": [o.name for o in ort_session.get_outputs()],
                 }
-            input_name = self._session_io_name_cache[session_id]["input"]
-            output_names = self._session_io_name_cache[session_id]["outputs"]
+            input_name = self._session_io_name_cache[ort_session]["input"]
+            output_names = self._session_io_name_cache[ort_session]["outputs"]
 
         io_binding = ort_session.io_binding()
         io_binding.bind_input(
@@ -691,14 +703,13 @@ class FaceSwappers:
             return
 
         # FS-ROBUST-02: introspect output name dynamically instead of hardcoding node IDs
-        session_id = id(ghostfaceswap_model)
         with self._io_cache_lock:
-            if session_id not in self._session_io_name_cache:
-                self._session_io_name_cache[session_id] = {
+            if ghostfaceswap_model not in self._session_io_name_cache:
+                self._session_io_name_cache[ghostfaceswap_model] = {
                     "input": ghostfaceswap_model.get_inputs()[0].name,
                     "outputs": [o.name for o in ghostfaceswap_model.get_outputs()],
                 }
-            output_name = self._session_io_name_cache[session_id]["outputs"][0]
+            output_name = self._session_io_name_cache[ghostfaceswap_model]["outputs"][0]
 
         io_binding = ghostfaceswap_model.io_binding()
         io_binding.bind_input(

--- a/app/processors/models_processor.py
+++ b/app/processors/models_processor.py
@@ -34,6 +34,7 @@ import onnx
 from torchvision.transforms import v2
 
 from app.processors.utils import faceutil
+from app.processors.utils import platform_support
 
 from PySide6 import QtCore
 
@@ -149,7 +150,7 @@ class ModelsProcessor(QtCore.QObject):
     # Signal to request the GUI thread to hide the build dialog
     hide_build_dialog = QtCore.Signal()
 
-    def __init__(self, main_window: "MainWindow", device: str = "cuda") -> None:
+    def __init__(self, main_window: "MainWindow", device: str = "") -> None:
         """
         Initialises the ModelsProcessor.
 
@@ -158,12 +159,14 @@ class ModelsProcessor(QtCore.QObject):
 
         Args:
             main_window: The application's MainWindow, used to access UI controls and signals.
-            device: Torch/ONNX device string — ``"cuda"`` or ``"cpu"``.
+            device: Torch/ONNX device string — ``"cuda"``, ``"mps"`` or ``"cpu"``.
+                Defaults to the best backend this machine actually has.
         """
         super().__init__()
         self.main_window = main_window
         self.gpu_id = getattr(main_window, "gpu_id", 0)
-        self.provider_name = "TensorRT"
+        device = device or platform_support.default_torch_device()
+        self.provider_name = platform_support.default_execution_provider()
 
         # NOTE: internal_deep_copied_kv_map / internal_kv_map_source_filename were
         # placeholder attributes for a planned per-session KV-map cache.  They are
@@ -174,9 +177,10 @@ class ModelsProcessor(QtCore.QObject):
             None
         )
         self.internal_kv_map_source_filename: str | None = None
-        self.device = f"{device}:{self.gpu_id}" if device != "cpu" else device
+        # Only CUDA has addressable per-index devices; "mps" and "cpu" are bare.
+        self.device = f"{device}:{self.gpu_id}" if device == "cuda" else device
         self.device_type = device
-        if self.gpu_id != 0 and device != "cpu":
+        if self.gpu_id != 0 and device == "cuda":
             torch.cuda.set_device(self.gpu_id)
         self.model_lock = threading.RLock()  # Reentrant lock for model access
 
@@ -211,14 +215,27 @@ class ModelsProcessor(QtCore.QObject):
             "trt_builder_optimization_level": 5,
         }
 
+        # Default CoreML options (macOS). MLProgram is the modern model format and
+        # is required for fp16 compute; ALL lets CoreML place ops on the Neural
+        # Engine / GPU / CPU as it sees fit.
+        #
+        # RequireStaticInputShapes is not optional. Several models here (RetinaFace
+        # / det_10g among them) have dynamic dimensions, and CoreML silently
+        # produces wrong-shaped outputs for those subgraphs — inference fails with
+        # "Invalid shape for output feature". Restricting CoreML to statically
+        # shaped subgraphs makes it hand the dynamic ones back to the CPU EP, which
+        # is both correct and, for those specific graphs, no slower.
+        self.coreml_ep_options: Dict[str, Any] = {
+            "ModelFormat": "MLProgram",
+            "MLComputeUnits": "ALL",
+            "RequireStaticInputShapes": "1",
+            "AllowLowPrecisionAccumulationOnGPU": "1",
+        }
+
         # A set to keep track of models that have been loaded but
         # have not had their engine built (lazy build).
         self.models_pending_build: set = set()
-        self.providers: list = [
-            ("TensorrtExecutionProvider", self.trt_ep_options),
-            ("CUDAExecutionProvider", {"device_id": self.gpu_id}),
-            ("CPUExecutionProvider"),
-        ]
+        self.providers: list = self._default_providers()
         self.syncvec = torch.empty((1, 1), dtype=torch.float32, device=self.device)
         self.nThreads = 1
 
@@ -1183,6 +1200,28 @@ class ModelsProcessor(QtCore.QObject):
                 return memory_used, memory_total_val
             return 0, 0
 
+    def _default_providers(self) -> list:
+        """ONNX Runtime provider list matching this machine's best provider."""
+        match platform_support.default_execution_provider():
+            case "TensorRT" | "TensorRT-Engine":
+                return [
+                    ("TensorrtExecutionProvider", self.trt_ep_options),
+                    ("CUDAExecutionProvider", {"device_id": self.gpu_id}),
+                    ("CPUExecutionProvider"),
+                ]
+            case "CUDA":
+                return [
+                    ("CUDAExecutionProvider", {"device_id": self.gpu_id}),
+                    ("CPUExecutionProvider"),
+                ]
+            case "CoreML":
+                return [
+                    ("CoreMLExecutionProvider", self.coreml_ep_options),
+                    ("CPUExecutionProvider"),
+                ]
+            case _:
+                return ["CPUExecutionProvider"]
+
     def update_provider_configuration(self, provider_name: str) -> str:
         """
         Updates the internal device and provider lists.
@@ -1213,7 +1252,30 @@ class ModelsProcessor(QtCore.QObject):
                 self.device = "cpu"
                 self.device_type = "cpu"
 
+            case "CoreML":
+                if not platform_support.has_coreml():
+                    raise RuntimeError(
+                        "CoreML execution provider is not available in this "
+                        "onnxruntime build."
+                    )
+                providers = [
+                    ("CoreMLExecutionProvider", self.coreml_ep_options),
+                    ("CPUExecutionProvider"),
+                ]
+                self.device, self.device_type = platform_support.torch_device_for_provider(
+                    "CoreML", self.gpu_id
+                )
+
             case "CUDA":
+                # A workspace saved on an NVIDIA machine can carry "CUDA" here.
+                # Without this check the device would be set to cuda:N on a host
+                # that has no CUDA, and the failure would surface later as an
+                # opaque crash on the first tensor allocation.
+                if not platform_support.has_cuda():
+                    raise RuntimeError(
+                        "CUDA execution provider requested but no CUDA device is "
+                        "available on this machine."
+                    )
                 providers = [
                     ("CUDAExecutionProvider", {"device_id": self.gpu_id}),
                     ("CPUExecutionProvider"),

--- a/app/processors/utils/platform_support.py
+++ b/app/processors/utils/platform_support.py
@@ -1,0 +1,166 @@
+"""Execution-provider capability detection.
+
+VisoMaster Fusion targets Windows/Linux with NVIDIA hardware, where the
+TensorRT and CUDA execution providers are always assumed present. macOS has
+neither, so every code path that hard-codes ``"cuda"`` needs a way to ask what
+this machine can actually do.
+
+This module is the single source of truth for that question. It reports the
+execution providers that are genuinely usable here (in priority order) and maps
+each one to the torch device the rest of the pipeline should run tensors on.
+
+Provider names are the user-facing strings stored in
+``control["ProvidersPrioritySelection"]`` and matched in
+``ModelsProcessor.update_provider_configuration``.
+"""
+
+import platform
+import sys
+
+import torch
+
+SYSTEM_PLATFORM = platform.system()
+IS_MACOS = sys.platform == "darwin"
+
+
+def _onnxruntime_providers() -> list:
+    """Available ONNX Runtime EPs, or an empty list if ORT cannot be queried."""
+    try:
+        import onnxruntime
+
+        return list(onnxruntime.get_available_providers())
+    except Exception:
+        return []
+
+
+def has_cuda() -> bool:
+    """True when a usable CUDA device is present."""
+    try:
+        return torch.cuda.is_available()
+    except Exception:
+        return False
+
+
+def has_mps() -> bool:
+    """True when torch can run on Apple's Metal Performance Shaders backend."""
+    try:
+        return torch.backends.mps.is_available()
+    except Exception:
+        return False
+
+
+def has_tensorrt() -> bool:
+    """True when the TensorRT python bindings import."""
+    try:
+        import tensorrt  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def has_coreml() -> bool:
+    """True when ONNX Runtime exposes the CoreML execution provider."""
+    return "CoreMLExecutionProvider" in _onnxruntime_providers()
+
+
+def has_neural_engine() -> bool:
+    """True on Apple Silicon, which is the only Mac hardware with a Neural Engine.
+
+    Intel Macs expose the CoreML EP too, but it can only fall back to their CPU
+    and (via MPSGraph) an integrated/AMD GPU that CoreML drives poorly.
+    """
+    return IS_MACOS and platform.machine() == "arm64"
+
+
+def available_execution_providers() -> list:
+    """Execution providers usable on this machine, best first.
+
+    Always ends with ``"CPU"``, which is available everywhere and is the
+    guaranteed-working fallback.
+
+    On Intel Macs CoreML is offered but deliberately ranked *below* CPU. Measured
+    on an i7-9750H / Radeon Pro 5300M across the per-frame hot path
+    (det_10g 62ms vs 65ms, w600k_r50 84ms vs 89ms, inswapper_128 1021ms vs
+    1244ms), CoreML lost every time: the models carry dynamic dimensions, and
+    RequireStaticInputShapes — which is mandatory for correct output, see
+    ``ModelsProcessor.coreml_ep_options`` — hands those subgraphs back to the CPU
+    EP anyway, leaving only partitioning overhead. Apple Silicon has the Neural
+    Engine and a very different profile, so CoreML leads there.
+    """
+    providers = []
+    if has_cuda():
+        if has_tensorrt():
+            providers.extend(["TensorRT", "TensorRT-Engine"])
+        providers.append("CUDA")
+    if has_coreml() and has_neural_engine():
+        providers.append("CoreML")
+    providers.append("CPU")
+    if has_coreml() and not has_neural_engine():
+        providers.append("CoreML")
+    return providers
+
+
+def default_execution_provider() -> str:
+    """The provider to select when the user has not chosen one."""
+    return available_execution_providers()[0]
+
+
+def torch_device_for_provider(provider_name: str, gpu_id: int = 0) -> tuple:
+    """Map a provider name to ``(device, device_type)`` for torch tensors.
+
+    ``device`` is the string handed to ``torch.Tensor.to()``; ``device_type`` is
+    the bare backend name used for ``torch.autocast`` and for the ``!= "cpu"``
+    checks scattered through the pipeline.
+    """
+    if provider_name in ("TensorRT", "TensorRT-Engine", "CUDA"):
+        return f"cuda:{gpu_id}", "cuda"
+    if provider_name == "CoreML":
+        # Torch stays on CPU even though MPS exists. The inference path binds
+        # torch tensors straight into ONNX Runtime via io_binding
+        # (device_type=..., buffer_ptr=tensor.data_ptr()). ORT has no "mps"
+        # device and cannot dereference a Metal buffer pointer, so an MPS tensor
+        # would be bound as garbage. CoreML still runs the model itself on the
+        # GPU/Neural Engine — only the pre/post-processing is CPU-side.
+        return "cpu", "cpu"
+    return "cpu", "cpu"
+
+
+def default_torch_device() -> str:
+    """Torch device matching this machine's default execution provider.
+
+    Deliberately derived from the provider rather than from raw hardware
+    capability, so torch tensors always live somewhere the active ONNX Runtime
+    provider can bind them.
+    """
+    return torch_device_for_provider(default_execution_provider())[0]
+
+
+def supports_fp16(device_type: str) -> bool:
+    """Whether half precision is worth using on this backend.
+
+    CUDA has fast fp16 throughout. MPS supports fp16 but several ops used by the
+    swapper pipeline fall back to (or outright fail on) fp32, so fp16 is only
+    enabled for CUDA.
+    """
+    return device_type == "cuda"
+
+
+def sync_device(device_type: str) -> None:
+    """Block until queued work on ``device_type`` has completed.
+
+    Replaces bare ``torch.cuda.current_stream().synchronize()`` calls, which
+    raise on machines without CUDA.
+    """
+    if device_type == "cuda" and has_cuda():
+        torch.cuda.current_stream().synchronize()
+    elif device_type == "mps" and has_mps():
+        torch.mps.synchronize()
+
+
+def empty_cache(device_type: str = "") -> None:
+    """Release cached allocator memory on whichever backend is active."""
+    if has_cuda():
+        torch.cuda.empty_cache()
+    elif has_mps():
+        torch.mps.empty_cache()

--- a/app/processors/workers/frame_worker_vr.py
+++ b/app/processors/workers/frame_worker_vr.py
@@ -9,6 +9,7 @@ import torch
 import torchvision
 from torchvision.transforms import v2
 
+from app.processors.utils import platform_support
 from app.helpers.vr_utils import EquirectangularConverter, PerspectiveConverter
 from app.helpers.miscellaneous import (
     ParametersDict,
@@ -1258,7 +1259,7 @@ class VRProcessor:
         # Python cyclic garbage that may hold tensor references.
         self._vr_processed_count += 1
         if self._vr_processed_count % 300 == 0:
-            torch.cuda.empty_cache()
+            platform_support.empty_cache()
             gc.collect()
 
         # --- VR Compare/Mask view ---

--- a/app/ui/main_ui.py
+++ b/app/ui/main_ui.py
@@ -23,6 +23,7 @@ from app.ui.widgets.advanced_embedding_editor import EmbeddingGUI
 import app.ui.widgets.actions.control_actions as control_actions
 from app.processors.video_processor import VideoProcessor
 from app.processors.models_processor import ModelsProcessor
+from app.processors.utils import platform_support
 from app.processors.workers.function_worker import FunctionWorker
 from app.ui.widgets import widget_components
 from app.ui.widgets.event_filters import (
@@ -1049,14 +1050,28 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 load_dialog.exec_()
         else:
             # First launch or no workspace: Prompt for execution provider
-            options = ["CUDA", "TensorRT", "TensorRT-Engine", "CPU"]
+            options = platform_support.available_execution_providers()
+            default_index = options.index(
+                platform_support.default_execution_provider()
+            )
+
+            prompt = (
+                "No previous workspace found.\n\n"
+                "Please select your preferred execution provider."
+            )
+            # The TensorRT warning only makes sense where TensorRT is an option.
+            if any(o.startswith("TensorRT") for o in options):
+                prompt += (
+                    "\n(Select 'CUDA' or 'CPU' to avoid generating TensorRT "
+                    "engines on this launch):"
+                )
 
             provider, ok = QtWidgets.QInputDialog.getItem(
                 self,
                 "Initial Setup: Execution Provider",
-                "No previous workspace found.\n\nPlease select your preferred execution provider.\n(Select 'CUDA' or 'CPU' to avoid generating TensorRT engines on this launch):",
+                prompt,
                 options,
-                1,  # Default index (1 = TensorRT)
+                default_index,
                 False,  # Non-editable dropdown
             )
 

--- a/app/ui/widgets/actions/control_actions.py
+++ b/app/ui/widgets/actions/control_actions.py
@@ -12,6 +12,7 @@ import qdarktheme
 
 if TYPE_CHECKING:
     from app.ui.main_ui import MainWindow
+from app.processors.utils import platform_support
 from app.ui.widgets.actions import common_actions as common_widget_actions
 
 #'''
@@ -42,11 +43,31 @@ def change_execution_provider(
     Changes the global execution provider.
     If new_provider is omitted (e.g., during startup initialization), it safely
     falls back to reading the current state from the main_window's control dictionary.
+
+    A provider the current machine cannot supply is downgraded to the best local
+    one rather than raising. Workspaces are portable, so a file saved on an
+    NVIDIA box will ask a Mac for "TensorRT" or "CUDA"; that should not be fatal.
     """
+    supported = platform_support.available_execution_providers()
+    fallback = platform_support.default_execution_provider()
+
     if new_provider is None:
         new_provider = str(
-            main_window.control.get("ProvidersPrioritySelection", "TensorRT")
+            main_window.control.get("ProvidersPrioritySelection", fallback)
         )
+
+    if new_provider not in supported:
+        print(
+            f"[WARN] Execution provider '{new_provider}' is not available on this "
+            f"machine. Falling back to '{fallback}'."
+        )
+        new_provider = fallback
+        main_window.control["ProvidersPrioritySelection"] = new_provider
+        provider_widget = main_window.parameter_widgets.get(
+            "ProvidersPrioritySelection"
+        )
+        if provider_widget and hasattr(provider_widget, "setCurrentText"):
+            provider_widget.setCurrentText(new_provider)
 
     main_window.video_processor.stop_processing()
     main_window.function_worker.switch_providers_priority(new_provider)
@@ -56,7 +77,7 @@ def change_execution_provider(
 
 def change_threads_number(main_window: "MainWindow", new_threads_number: int) -> None:
     main_window.video_processor.set_number_of_threads(new_threads_number)
-    torch.cuda.empty_cache()
+    platform_support.empty_cache()
     common_widget_actions.update_gpu_memory_progressbar(main_window)
 
 

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -1,4 +1,5 @@
 from app.ui.widgets.actions import control_actions
+from app.processors.utils import platform_support
 import cv2
 from typing import Any
 
@@ -47,8 +48,8 @@ SETTINGS_LAYOUT_DATA: Any = {  # noqa: F811
         "ProvidersPrioritySelection": {
             "level": 1,
             "label": "Providers Priority",
-            "options": ["CUDA", "TensorRT", "TensorRT-Engine", "CPU"],
-            "default": "TensorRT",
+            "options": platform_support.available_execution_providers(),
+            "default": platform_support.default_execution_provider(),
             "help": "Select the providers priority to be used with the system.",
             "exec_function": control_actions.change_execution_provider,
             "exec_function_args": [],

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,122 @@
+# Running VisoMaster Fusion on macOS
+
+The supported configuration for VisoMaster Fusion is Windows/Linux with an
+NVIDIA GPU, using TensorRT or CUDA. macOS has neither, so this is a CPU/CoreML
+port. It runs, and it produces correct output, but it is **much** slower than a
+supported NVIDIA setup — see [Performance](#performance) before committing to it.
+
+## Setup
+
+```bash
+brew install ffmpeg
+
+uv venv --python 3.12 .venv
+uv pip install --python .venv/bin/python -r requirements_mac.txt
+.venv/bin/python download_models.py    # ~16 GB
+
+./Start_mac.sh
+```
+
+`Start.bat` / `Start_Portable.bat` are Windows-only and assume a portable NVIDIA
+runtime; `Start_mac.sh` replaces both.
+
+## Why a separate requirements file
+
+`requirements_cu13.txt` cannot be installed on macOS. It pins `torch==2.11.0+cu130`,
+`onnxruntime-gpu`, `tensorrt-cu13`, and the `nvidia-*` CUDA runtime wheels, none
+of which publish macOS builds.
+
+`requirements_mac.txt` also has hard version ceilings that do not exist on other
+platforms:
+
+| Package | macOS x86_64 ceiling | Reason |
+| --- | --- | --- |
+| `torch` / `torchvision` | 2.2.2 / 0.17.2 | PyTorch stopped publishing x86_64 macOS wheels after 2.2.2 |
+| `onnxruntime` | 1.23.2 | latest with macOS wheels; replaces `onnxruntime-gpu` |
+| TensorRT | unavailable | NVIDIA-only |
+
+The app already treats TensorRT as optional (`[WARN] No TensorRT Found`), so its
+absence is not fatal.
+
+`tensorflow`, `keras`, and `lightning` appear in `requirements_cu13.txt` but are
+never imported by `app/`, so they are omitted here.
+
+## Execution providers
+
+Provider choice is no longer a hardcoded list. `app/processors/utils/platform_support.py`
+detects what the machine actually supports and the UI offers only those, so on a
+Mac the "Providers Priority" dropdown shows `CPU` and `CoreML` rather than
+CUDA/TensorRT options that would crash.
+
+A workspace saved on an NVIDIA machine will request `TensorRT` or `CUDA`. Rather
+than failing, that is downgraded to the best locally available provider with a
+warning.
+
+### CoreML
+
+CoreML is wired up and selectable, but on **Intel** Macs it defaults to second
+place behind CPU. Two findings drove that:
+
+1. **Correctness.** CoreML must run with `RequireStaticInputShapes=1`. Several
+   models here (RetinaFace, `det_10g`) have dynamic dimensions, and without that
+   flag CoreML returns wrong-shaped outputs — inference dies with
+   `Invalid shape for output feature`.
+2. **Speed.** With that flag set, CoreML hands the dynamic subgraphs back to the
+   CPU EP, so it contributes little and adds partitioning overhead. Measured on
+   an i7-9750H / Radeon Pro 5300M:
+
+   | Model | CPU | CoreML |
+   | --- | --- | --- |
+   | `det_10g` (detect) | 62 ms | 65 ms |
+   | `w600k_r50` (recognize) | 84 ms | 89 ms |
+   | `inswapper_128.fp16` (swap) | 1021 ms | 1244 ms |
+
+   CoreML does win on fully static graphs (`vgg_combo_relu3_3_relu3_1`:
+   108 ms vs 284 ms), which is why it stays available.
+
+On **Apple Silicon** CoreML is ranked first, since the Neural Engine changes the
+picture entirely. That path is untested — the port was developed and verified on
+an Intel Mac.
+
+## Performance
+
+Roughly **1.2 s per face swap** on an i7-9750H. That is usable for single images
+and fine for experimenting, but it makes video work impractical: a 30-second
+30 fps clip is ~900 frames, or around 20 minutes of processing before restorers
+and enhancers are enabled.
+
+There is no way around this on Intel Mac hardware. Torch is capped at 2.2.2, there
+is no CUDA, and MPS cannot be used for the model inference itself (see below).
+
+## Why torch runs on CPU and not MPS
+
+MPS *is* available on Metal 3 Macs, including Intel ones with an AMD GPU, and
+plain torch ops do run on it. The pipeline still keeps tensors on the CPU because
+inference binds torch tensors directly into ONNX Runtime:
+
+```python
+io_binding.bind_input(
+    device_type=self.models_processor.device_type,
+    buffer_ptr=image.data_ptr(),
+    ...
+)
+```
+
+There are ~74 such bindings. ONNX Runtime has no `mps` device and cannot
+dereference a Metal buffer pointer, so an MPS tensor would be bound as garbage
+rather than failing loudly. Moving torch to MPS would require staging every
+bound tensor through the CPU each frame, which would cost more in transfers than
+it saves.
+
+`platform_support.torch_device_for_provider()` is the single place that decides
+this, if someone wants to revisit it.
+
+## Known limitations
+
+- **Virtual camera** — `pyvirtualcam` needs OBS's virtual camera installed on
+  macOS. The rest of the app works without it.
+- **TensorRT features** — engine building, the TensorRT cache manager, and the
+  "TensorRT-Engine" provider are all inert.
+- **Unrelated test failures** — `tests/unit` reports 50 failures on macOS. These
+  are pre-existing and reproduce identically on a clean checkout of `main`; they
+  are not caused by this port.

--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -1,0 +1,51 @@
+# VisoMaster Fusion — macOS (Intel x86_64) requirements
+#
+# macOS x86_64 has hard upper bounds that do not exist on Windows/Linux:
+#   * torch/torchvision: last x86_64 macOS wheels are 2.2.2 / 0.17.2
+#   * no CUDA, no TensorRT, no onnxruntime-gpu
+#
+# Inference runs on the CPUExecutionProvider (or CoreMLExecutionProvider
+# where the model is supported). Use requirements_cu13.txt on Windows/Linux
+# with an NVIDIA GPU.
+
+# --- Core inference ---
+torch==2.2.2
+torchvision==0.17.2
+onnx==1.17.0
+onnxruntime==1.23.2
+numpy==1.26.4
+
+# --- Vision / math ---
+opencv-python==4.10.0.84
+# >=0.25 required: face_swappers.py and faceutil.py call
+# SimilarityTransform.from_estimate() unguarded, which 0.24 does not have.
+# Pinned to match requirements_cu13.txt.
+scikit-image==0.26.0
+scipy==1.14.1
+kornia==0.7.3
+einops==0.8.0
+pillow==10.4.0
+
+# --- UI ---
+pyside6==6.7.3
+pyside6-addons==6.7.3
+pyside6-essentials==6.7.3
+shiboken6==6.7.3
+qdarkstyle==3.2.3
+pyqtdarktheme==2.1.0
+pyqt-toast-notification==1.3.3
+darkdetect==0.7.1
+
+# --- Support ---
+omegaconf==2.3.0
+ftfy==6.2.3
+regex==2024.9.11
+requests==2.32.3
+psutil==6.0.0
+tqdm==4.66.5
+send2trash==1.8.3
+packaging==24.1
+colorama==0.4.6
+rich==13.8.1
+protobuf==4.25.5
+pyvirtualcam==0.12.1


### PR DESCRIPTION
# Add macOS support (CPU / CoreML)

Makes VisoMaster Fusion run on macOS. The Windows/Linux + NVIDIA path is
untouched — no behaviour changes on a CUDA machine.

Developed and verified on an Intel Mac (i7-9750H, Radeon Pro 5300M, macOS 26.5).

## Two bugs worth reviewing first

Both were found while testing every swapper. **Neither is macOS-specific — the
second affects Windows/CUDA too.**

**1. Stale ONNX session IO-name cache** (`face_swappers.py`)

`_session_io_name_cache` was keyed by `id(session)` and never invalidated on
unload. CPython reuses freed addresses, so a newly loaded model could read back
the previous model's input/output names:

```
Inswapper128ArcFace  input = "input.1"
GhostArcFace         input = "img"
cache entries kept after unload: 3
```

This surfaced as `Failed to find input name in the mapping: input.1` when
GhostArcFace was allocated at a released Inswapper128ArcFace's address. It is
nondeterministic — GhostFace passed one run and failed the next — and triggers
on ordinary swapper switching.

Fixed with `weakref.WeakKeyDictionary`, which drops entries as soon as the
session is collected. One change, rather than hooking every unload path.

**2. `SimilarityTransform.from_estimate` requires scikit-image >= 0.25**

`face_swappers.py:253` and `faceutil.py:606` call it unguarded, while other call
sites check `hasattr` first. Only relevant to the new macOS requirements file
(pinned to 0.26.0 to match `requirements_cu13.txt`), but the inconsistency is
worth a look.

## Changes

**`app/processors/utils/platform_support.py`** (new) — single source of truth for
what the machine supports: available execution providers, provider→torch-device
mapping, and CUDA-safe `empty_cache()` / `sync_device()`.

**Provider selection is now detected, not hardcoded.** The list
`["CUDA", "TensorRT", "TensorRT-Engine", "CPU"]` appeared in `settings_layout_data.py`
and `main_ui.py`; both now derive from the host. A Mac sees `CPU` and `CoreML`
instead of options that would crash.

**Workspaces are now portable.** A workspace saved on an NVIDIA machine requests
`TensorRT`/`CUDA`; that is downgraded to the best local provider with a warning
instead of setting `device="cuda:0"` on a host with no CUDA. `update_provider_configuration`
also rejects `CUDA` outright when unavailable, so the failure is a clear error
rather than an opaque crash at first allocation.

**Two unguarded `torch.cuda.empty_cache()` calls fixed** — `control_actions.py:59`
and `frame_worker_vr.py:1261`. The other ~146 CUDA references were already guarded.

**Packaging** — `requirements_mac.txt` and `Start_mac.sh` (the `.bat` launchers
assume a portable NVIDIA runtime). Docs in `docs/macos.md`.

## Notes on the macOS requirements file

`requirements_cu13.txt` cannot be installed on macOS — it pins `torch==2.11.0+cu130`,
`onnxruntime-gpu`, `tensorrt-cu13` and the `nvidia-*` wheels. The mac file also
carries ceilings that don't exist elsewhere: **torch is capped at 2.2.2**, the
last x86_64 macOS release. The code imports and runs clean on it.

`tensorflow`, `keras` and `lightning` are omitted — they are in
`requirements_cu13.txt` but never imported by `app/`.

## CoreML

Wired up and selectable, but ranked *below* CPU on Intel Macs.

`RequireStaticInputShapes=1` is mandatory for correctness: RetinaFace and
`det_10g` have dynamic dimensions, and without it CoreML returns wrong-shaped
outputs (`Invalid shape for output feature`). With it set, CoreML hands those
subgraphs back to the CPU EP and mostly contributes overhead:

| Model | CPU | CoreML |
| --- | --- | --- |
| `det_10g` | 62 ms | 65 ms |
| `w600k_r50` | 84 ms | 89 ms |
| `inswapper_128.fp16` | 1021 ms | 1244 ms |

It does win on fully static graphs (`vgg_combo_relu3_3_relu3_1`: 108 ms vs 284 ms),
so it stays available. CoreML is ranked first on Apple Silicon, where the Neural
Engine changes the picture — **that path is untested.**

## Testing

- **All 9 ONNX swappers pass** through their real `run_*` methods (detect →
  recognize → latent → swap), verified over three consecutive runs since the
  cache bug was nondeterministic.
- Full pipeline produces a correct swapped face, not just correct shapes.
- `tests/unit`: **50 failed / 471 passed** — identical to a clean checkout of
  `main` on this machine. All 50 are pre-existing and unrelated.
- Lint unchanged from baseline on every touched file.

## Limitations

- **~1 s per swap** on this hardware. Fine for images; impractical for video
  (a 30 s 30 fps clip is ~20 min). Not fixable on Intel Macs — torch is capped
  at 2.2.2 and there is no CUDA.
- **MPS is not used for inference.** It works for plain torch ops, but the
  pipeline binds torch tensors into ONNX Runtime via `buffer_ptr=tensor.data_ptr()`
  at ~74 sites, and ORT has no `mps` device — a Metal pointer would bind as
  garbage rather than fail loudly. `torch_device_for_provider()` is the single
  place to revisit this.
- **DeepFaceLive (DFM) untested** — `model_assets/dfm_models/` is empty; those are
  user-supplied `.dfm` files.
- **Apple Silicon untested.**
- Virtual camera needs OBS's virtual camera installed on macOS.