### PR TITLE
Add profile safeguard for Occluder/XSeg masks and YawNet head-pose model

### DIFF
--- a/app/helpers/miscellaneous.py
+++ b/app/helpers/miscellaneous.py
@@ -1,3 +1,4 @@
+import math
 import os
 import shutil
 import cv2
@@ -1609,6 +1610,86 @@ def draw_bounding_boxes_on_detected_faces(
         img[:, y_max - thickness + 1 : y_max + 1, x_min : x_max + 1] = color_tensor_c11
         img[:, y_min : y_max + 1, x_min : x_min + thickness] = color_tensor_c11
         img[:, y_min : y_max + 1, x_max - thickness + 1 : x_max + 1] = color_tensor_c11
+
+    return img
+
+
+def draw_head_yaw_ring_on_faces(
+    img: torch.Tensor,
+    det_faces_data: list,
+    color_rgb: list | None = None,
+) -> torch.Tensor:
+    """
+    Draw a YawNet head-orientation ring per face, after the ring in the upstream demo.
+
+    img is (C, H, W) uint8 and is modified in place. Faces without a "yawnet_deg" key
+    are skipped, so this is safe to call when only some faces were measured.
+
+    The needle points the way the head faces, in the ring convention: 0 = toward the
+    camera (drawn DOWN, out of the screen toward the viewer), 90 = right, 180 = away
+    (up), 270 = left. In image axes (x right, y down) that is
+    dx = sin(theta), dy = cos(theta).
+    """
+    _color = color_rgb if color_rgb is not None else [0, 200, 255]
+    _, h, w = img.shape
+    max_dimension = max(h, w)
+
+    color_tensor = torch.tensor(_color, dtype=img.dtype, device=img.device).view(
+        -1, 1, 1
+    )
+
+    for fface in det_faces_data:
+        deg = fface.get("yawnet_deg")
+        if deg is None:
+            continue
+
+        bbox = fface.get("bbox")
+        if bbox is None:
+            continue
+        x_min, y_min, x_max, y_max = (float(v) for v in bbox[:4])
+
+        # Radius tracks the face so the ring stays legible at any resolution, with a
+        # floor for tiny faces and a cap so it never dominates the frame.
+        radius = int(
+            min(
+                max(0.22 * max(x_max - x_min, y_max - y_min), 12.0),
+                max_dimension * 0.08,
+            )
+        )
+        thickness = max(1, radius // 8)
+
+        # Anchored just above the face box, pulled inside the frame if it would clip.
+        cx = int(round((x_min + x_max) * 0.5))
+        cy = int(round(y_min - radius - thickness - 2))
+        cx = min(max(cx, radius + thickness), w - radius - thickness - 1)
+        cy = min(max(cy, radius + thickness), h - radius - thickness - 1)
+        if cx - radius - thickness < 0 or cy - radius - thickness < 0:
+            continue
+
+        lo_y, hi_y = cy - radius - thickness, cy + radius + thickness + 1
+        lo_x, hi_x = cx - radius - thickness, cx + radius + thickness + 1
+        if hi_y > h or hi_x > w:
+            continue
+
+        yy = torch.arange(lo_y, hi_y, device=img.device, dtype=torch.float32) - cy
+        xx = torch.arange(lo_x, hi_x, device=img.device, dtype=torch.float32) - cx
+        dist = torch.sqrt(yy.view(-1, 1) ** 2 + xx.view(1, -1) ** 2)
+
+        ring = (dist >= radius - thickness) & (dist <= radius + thickness)
+
+        # Needle: the set of points within `thickness` of the centre->direction segment.
+        theta = math.radians(float(deg))
+        dx, dy = math.sin(theta), math.cos(theta)
+        # Projection of each pixel onto the unit direction, clamped to the segment.
+        proj = (xx.view(1, -1) * dx + yy.view(-1, 1) * dy).clamp(0.0, float(radius))
+        perp = torch.sqrt(
+            (xx.view(1, -1) - proj * dx) ** 2 + (yy.view(-1, 1) - proj * dy) ** 2
+        )
+        needle = perp <= thickness
+
+        mask = (ring | needle).unsqueeze(0)
+        region = img[:, lo_y:hi_y, lo_x:hi_x]
+        img[:, lo_y:hi_y, lo_x:hi_x] = torch.where(mask, color_tensor, region)
 
     return img
 

--- a/app/processors/face_landmark_detectors.py
+++ b/app/processors/face_landmark_detectors.py
@@ -1008,7 +1008,7 @@ class FaceLandmarkDetectors:
         the resident face detector (FaceDetectors.current_detector_model keeps only one
         alive at a time).
         """
-        empty = np.empty((0, 5), dtype=np.float32)
+        empty: np.ndarray = np.empty((0, 5), dtype=np.float32)
         model_name = "DEIMv2Wholebody49Head"
 
         if not self.models_processor.models.get(model_name):
@@ -1050,7 +1050,12 @@ class FaceLandmarkDetectors:
         )
         # RGB in [0, 1]; this graph applies no mean/std of its own.
         det_img = (
-            torch.div(det_img.to(dtype=torch.float32), 255.0).unsqueeze(0).contiguous()
+            torch.div(
+                det_img.to(dtype=torch.float32, device=self.models_processor.device),
+                255.0,
+            )
+            .unsqueeze(0)
+            .contiguous()
         )
 
         feed: Dict[str, torch.Tensor] = {inp.name: det_img}
@@ -1250,7 +1255,12 @@ class FaceLandmarkDetectors:
             antialias=True,
         )
         # center05: (x/255 - 0.5) / 0.5, identical to the x/127.5 - 1 in the README.
-        crop = crop.to(dtype=torch.float32).div_(255.0).sub_(0.5).div_(0.5)
+        crop = (
+            crop.to(dtype=torch.float32, device=self.models_processor.device)
+            .div_(255.0)
+            .sub_(0.5)
+            .div_(0.5)
+        )
         crop = crop.unsqueeze(0).contiguous()
 
         net_outs = self._run_onnx_binding(

--- a/app/processors/face_landmark_detectors.py
+++ b/app/processors/face_landmark_detectors.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from itertools import product as product
 from typing import TYPE_CHECKING, List, Dict, Optional, Any, Callable
@@ -12,6 +13,8 @@ if TYPE_CHECKING:
     from app.processors.workers.function_worker import FunctionWorker
 from app.processors.models_data import models_dir
 from app.processors.utils import faceutil
+
+logger = logging.getLogger(__name__)
 
 
 def _kps5_is_degenerate(kps5: np.ndarray, detect_mode: str = "203") -> bool:
@@ -1144,6 +1147,146 @@ class FaceLandmarkDetectors:
         cx, cy = (fx1 + fx2) / 2.0, (fy1 + fy2) / 2.0 - 0.08 * h
         half = 0.5 * 1.5 * max(w, h)
         return np.array([cx - half, cy - half, cx + half, cy + half], dtype=np.float32)
+
+    # --- YawNet -------------------------------------------------------------
+    # Full-circle head yaw. Unlike faceutil.calc_face_yaw_pitch (a 5-landmark nose-offset
+    # ratio that saturates near +-90 deg and reads a rear view as roughly frontal), this
+    # distinguishes "profile" from "facing away", and reports its own confidence.
+    #
+    # Returned angles use the ring convention documented on the YawNet entry in
+    # models_data: 0 = facing camera, 90 = subject's right, 180 = facing away, 270 =
+    # left. Callers that want "how far from frontal" should use yaw_from_frontal().
+
+    # Minimum von Mises concentration to act on an angle. DEFAULT 0.0 = accept every
+    # reading, which is deliberate and not laziness:
+    #
+    # kappa is softplus(logit).clamp(1e-3, 100) (scripts/yawnet.py), and the kappa head's
+    # bias is initialised so softplus(1.85) ~= 2.0 "the same as the previous FIXED
+    # kappa" -- i.e. 2.0 is the model's NEUTRAL PRIOR, not a confidence floor. A
+    # threshold anywhere near it would reject ordinary predictions. Upstream's own demo
+    # reads only cos_sin and ignores kappa entirely, so there is no reference value to
+    # copy, and calibrating one needs real in-distribution footage we do not have here.
+    # Rather than ship an invented constant, the gate is off and every reading is logged
+    # at debug level so a threshold can be chosen from real material later.
+    #
+    # Leaving it off is safe for the occluder/XSeg bypass because that path already
+    # requires a COLLAPSED MASK as well as an extreme angle, so a spurious yaw on its
+    # own cannot trigger it.
+    YAWNET_MIN_KAPPA = 0.0
+
+    @staticmethod
+    def yaw_from_frontal(orientation_deg: float) -> float:
+        """
+        Fold a 0..360 ring angle onto 0..180 "degrees away from facing the camera".
+
+        0 = facing the camera, 90 = full profile (either side), 180 = facing away.
+        Side is deliberately discarded: every consumer here is symmetric, and folding
+        removes the wrap-around bug of comparing raw ring degrees against a threshold
+        (350 deg is 10 deg off frontal, not 350).
+        """
+        d = abs(float(orientation_deg)) % 360.0
+        return 360.0 - d if d > 180.0 else d
+
+    def estimate_head_yaw_yawnet(
+        self,
+        img: torch.Tensor,
+        bbox: np.ndarray,
+        head_bboxes: np.ndarray | list | None = None,
+        min_kappa: float | None = None,
+    ) -> tuple[float, float] | None:
+        """
+        Full-circle head yaw for one face, via YawNet.
+
+        img is the whole frame (3, H, W) uint8/float RGB; bbox is that face's box in
+        frame pixels. head_bboxes is the frame's DEIMv2 head boxes when the caller
+        already has them ('hrffa' landmark mode); pass None and one is detected here.
+        min_kappa overrides YAWNET_MIN_KAPPA, normally from the UI.
+
+        Returns (orientation_deg, kappa) in the ring convention, or None when the model
+        is unavailable or the prediction is too uncertain to use. None means "no
+        opinion" and callers must keep their previous behaviour -- never treat it as 0.
+        """
+        model_name = "YawNet"
+
+        if not self.models_processor.models.get(model_name):
+            if not self.models_processor.load_model(model_name):
+                print(
+                    f"[ERROR] Failed to load '{model_name}'. Head-yaw estimation is "
+                    "disabled; run download_models.py if the file is missing."
+                )
+                return None
+
+        # Re-registered every call for the same reason as DEIMv2Wholebody49Head: a
+        # deferred unload drops the name while the session is still resident.
+        self.active_landmark_models.add(model_name)
+
+        session = self.models_processor.models.get(model_name)
+        if session is None:
+            return None
+
+        if head_bboxes is None:
+            head_bboxes = self.detect_head_bboxes_wholebody49(img)
+        head_bbox = self._head_bbox_for_face(head_bboxes, bbox)
+
+        inp = session.get_inputs()[0]
+        shape = inp.shape
+        size = shape[2] if isinstance(shape[2], int) else 128
+
+        img_h, img_w = int(img.shape[1]), int(img.shape[2])
+        x1 = int(np.floor(np.clip(head_bbox[0], 0, img_w - 1)))
+        y1 = int(np.floor(np.clip(head_bbox[1], 0, img_h - 1)))
+        x2 = int(np.ceil(np.clip(head_bbox[2], 0, img_w)))
+        y2 = int(np.ceil(np.clip(head_bbox[3], 0, img_h)))
+        if x2 - x1 < 2 or y2 - y1 < 2:
+            return None
+
+        crop = img[:, y1:y2, x1:x2]
+        # A DIRECT squash to the square, aspect ratio NOT preserved -- this is what
+        # upstream's orientation.ts feeds the model, so a letterbox would be OOD.
+        crop = v2.functional.resize(
+            crop,
+            [size, size],
+            interpolation=v2.InterpolationMode.BILINEAR,
+            antialias=True,
+        )
+        # center05: (x/255 - 0.5) / 0.5, identical to the x/127.5 - 1 in the README.
+        crop = crop.to(dtype=torch.float32).div_(255.0).sub_(0.5).div_(0.5)
+        crop = crop.unsqueeze(0).contiguous()
+
+        net_outs = self._run_onnx_binding(
+            model_name, {inp.name: crop}, ["cos_sin", "kappa"]
+        )
+        if not net_outs or len(net_outs) < 2:
+            return None
+
+        cos_sin = np.asarray(net_outs[0], dtype=np.float32).reshape(-1)
+        kappa = float(np.asarray(net_outs[1], dtype=np.float32).reshape(-1)[0])
+        if cos_sin.size < 2:
+            return None
+        if not np.isfinite(cos_sin[:2]).all() or not np.isfinite(kappa):
+            return None
+
+        # atan2(sin, cos) -> 0..360, then MIRROR: YawNet emits the yawpose convention
+        # (+90 = screen left) and the ring convention is its mirror. Dropping this step
+        # silently flips left and right. See models_data's YawNet entry.
+        deg = (np.degrees(np.arctan2(cos_sin[1], cos_sin[0])) + 360.0) % 360.0
+        deg = (360.0 - deg) % 360.0
+
+        threshold = self.YAWNET_MIN_KAPPA if min_kappa is None else float(min_kappa)
+        # Logged before the gate, and unconditionally, so that raising the threshold
+        # from the UI is an informed choice rather than a guess: the readings you need
+        # in order to pick a value are the ones a gate would have thrown away.
+        logger.debug(
+            "YawNet: %.1f deg (kappa %.3f, min %.3f)%s",
+            deg,
+            kappa,
+            threshold,
+            " -> rejected" if threshold > 0.0 and kappa < threshold else "",
+        )
+        if threshold > 0.0 and kappa < threshold:
+            return None
+
+        return float(deg), kappa
 
     def detect_face_landmark_hrffa(
         self, img, bbox, det_kpss, from_points=False, **kwargs

--- a/app/processors/face_landmark_detectors.py
+++ b/app/processors/face_landmark_detectors.py
@@ -1255,9 +1255,11 @@ class FaceLandmarkDetectors:
             antialias=True,
         )
         # center05: (x/255 - 0.5) / 0.5, identical to the x/127.5 - 1 in the README.
+        # Resize and to() can retain the frame's storage for a 128px float crop.
+        # Allocate on the first division before normalizing in place.
         crop = (
             crop.to(dtype=torch.float32, device=self.models_processor.device)
-            .div_(255.0)
+            .div(255.0)
             .sub_(0.5)
             .div_(0.5)
         )

--- a/app/processors/face_masks.py
+++ b/app/processors/face_masks.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING, Dict
 
 import torch
@@ -15,8 +16,37 @@ if TYPE_CHECKING:
     from app.processors.models_processor import ModelsProcessor
     from app.processors.workers.function_worker import FunctionWorker
 
+logger = logging.getLogger(__name__)
+
 _VGG_MEAN = torch.tensor([0.485, 0.456, 0.406]).view(3, 1, 1)
 _VGG_STD = torch.tensor([0.229, 0.224, 0.225]).view(3, 1, 1)
+
+# --- SEGMENTATION DEGRADATION GUARD ---
+# The Occluder and DFL XSeg models are trained on mostly-frontal faces and can
+# collapse on extreme profiles, labelling the whole crop as "occluded". That zeroes
+# swap_mask and the swap silently disappears for those frames.
+#
+# Both conditions must hold before we bypass a model, because a low face ratio on
+# its own is ambiguous: it is also exactly what a correct prediction looks like when
+# a hand or microphone really does cover most of the face. Only the combination of
+# "extreme head angle" AND "almost nothing left of the face" indicates model failure
+# rather than genuine heavy occlusion.
+#
+# yaw_deg is "degrees away from facing the camera" and may arrive on either of two
+# scales: the 5-landmark pseudo-degrees from faceutil.calc_face_yaw_pitch(), or YawNet's
+# true full-circle degrees folded by yaw_from_frontal(). One threshold serves both
+# because they share their anchors -- 0 is frontal and ~90 is full profile in each -- and
+# differ only in curvature between them. The codebase already treats >20 pseudo-degrees
+# as the onset of profile (ProfileAngleMaskThresholdSlider), so 40 is clearly not
+# frontal on either scale. YawNet additionally reports 90..180 for heads turned away,
+# which can only make the guard more willing to fire on a head that really is facing
+# away -- the case it exists for.
+#
+# NOT CALIBRATED against real footage: this is a plausible value, not a measured one.
+# Both this and YAWNET_MIN_KAPPA want tuning on real material before being trusted.
+_SEG_GUARD_MIN_ABS_YAW = 40.0
+# Fraction of the 256x256 crop a valid face prediction is expected to keep.
+_SEG_GUARD_MIN_FACE_RATIO = 0.30
 
 
 class FaceMasks:
@@ -647,6 +677,9 @@ class FaceMasks:
 
         if need_occluder:
             # apply_occlusion returns 1 for Face, 0 for Obstacle. We keep areas > 0.5.
+            # No yaw_deg here: this mask only gates inner-mouth restoration, not the
+            # blend mask, so a collapsed model cannot make the swap disappear. Omitting
+            # it leaves the profile bypass off and this path's behaviour unchanged.
             occ_mask = self.apply_occlusion(img_256, amount=1, parameters=parameters)
             combined_mask_256 = (occ_mask > 0.5).squeeze(0)
 
@@ -1121,11 +1154,92 @@ class FaceMasks:
 
     # --- Occluder & XSeg ---
 
+    @staticmethod
+    def _seg_guard_settings(parameters: dict | None) -> tuple[bool, float, float]:
+        """
+        Resolve the profile-safeguard settings from the UI, falling back to the module
+        defaults when a key is absent -- which is the normal case for workspaces saved
+        before these controls existed, and for internal callers that pass no parameters
+        at all. The fallbacks preserve the previous always-on behaviour.
+
+        Min Face Area is a UI percentage; it is returned as a 0..1 fraction to match
+        the mask mean it is compared against.
+        """
+        p = parameters or {}
+        enabled = bool(p.get("SegGuardEnableToggle", True))
+        min_yaw = float(p.get("SegGuardMinYawSlider", _SEG_GUARD_MIN_ABS_YAW))
+        min_ratio = (
+            float(
+                p.get(
+                    "SegGuardMinFaceRatioSlider",
+                    _SEG_GUARD_MIN_FACE_RATIO * 100.0,
+                )
+            )
+            / 100.0
+        )
+        return enabled, min_yaw, min_ratio
+
+    @staticmethod
+    def _seg_model_degraded(
+        face_mask: torch.Tensor,
+        yaw_deg: float | None,
+        model: str,
+        parameters: dict | None = None,
+    ) -> bool:
+        """
+        Decides whether a segmentation model has collapsed on an extreme head angle
+        and should be bypassed. See _SEG_GUARD_MIN_ABS_YAW for the rationale, and
+        _seg_guard_settings for the UI overrides.
+
+        face_mask must be binarized with 1 = face, so mean() is a true area fraction.
+        yaw_deg of None means the caller cannot supply a head angle; we then never
+        bypass, keeping the model's own output authoritative.
+
+        The cheap host-side tests are checked first on purpose: frontal faces (the
+        overwhelming majority of frames) never reach the .item() call and so never pay
+        for a device sync.
+        """
+        enabled, min_yaw, min_ratio = FaceMasks._seg_guard_settings(parameters)
+
+        # min_ratio of 0 can never be undercut by a mean, so treat it as off and skip
+        # the sync rather than reading the mask to compare against an impossible bar.
+        if not enabled or min_ratio <= 0.0:
+            return False
+
+        if yaw_deg is None or abs(yaw_deg) < min_yaw:
+            return False
+
+        face_ratio = face_mask.mean().item()
+        if face_ratio >= min_ratio:
+            return False
+
+        logger.debug(
+            "%s bypassed: face ratio %.3f < %.2f at yaw %.1f deg (min angle %.1f; "
+            "model likely collapsed on profile); applying swap unmasked for this frame.",
+            model,
+            face_ratio,
+            min_ratio,
+            yaw_deg,
+            min_yaw,
+        )
+        return True
+
     @torch.no_grad()
-    def apply_occlusion(self, img, amount, parameters=None, original_face_512=None):
+    def apply_occlusion(
+        self,
+        img,
+        amount,
+        parameters=None,
+        original_face_512=None,
+        yaw_deg: float | None = None,
+    ):
         """
         Runs the Occluder model to mask out obstacles (hands, microphones, etc.).
         Includes logic to protect the inner mouth (tongue/teeth) from being occluded.
+
+        If the model collapses on an extreme profile (see _seg_model_degraded) it is
+        bypassed and a full clear mask (1.0) is returned, so the swap is still applied
+        instead of silently vanishing. Pass yaw_deg to enable that guard.
         """
         img = torch.div(img, 255)
         img = torch.unsqueeze(img, 0).contiguous()
@@ -1139,8 +1253,12 @@ class FaceMasks:
 
         outpred = torch.squeeze(outpred)
         # Binarize: True(1) = Face, False(0) = Occlusion
-        outpred = outpred > 0
-        outpred = torch.unsqueeze(outpred, 0).type(torch.float32)
+        outpred_binary = (outpred > 0).type(torch.float32)
+
+        if self._seg_model_degraded(outpred_binary, yaw_deg, "Occluder", parameters):
+            return torch.ones_like(outpred_binary).unsqueeze(0)
+
+        outpred = torch.unsqueeze(outpred_binary, 0)
 
         # --- TONGUE PRIORITY LOGIC ---
         # Ensures that objects inside the mouth (tongue, smoke) are not masked out
@@ -1260,7 +1378,15 @@ class FaceMasks:
         mouth: torch.Tensor,
         parameters: dict,
         inner_mouth_mask: torch.Tensor | None = None,
+        yaw_deg: float | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Runs DFL XSeg and returns (mask, calc, calc_dilated, mask_noFP), all inverted
+        so 0 = Face and 1 = Background/Obstacle.
+
+        Pass yaw_deg to enable the profile-collapse bypass described on
+        _SEG_GUARD_MIN_ABS_YAW.
+        """
         import cv2
 
         # FM-07: use .get() for all parameter accesses to avoid KeyError
@@ -1281,7 +1407,26 @@ class FaceMasks:
 
         outpred = torch.clamp(outpred, min=0.0, max=1.0)
         outpred[outpred < 0.1] = 0
-        outpred_calc = outpred.clone()
+
+        # Bypass a collapsed XSeg on extreme profiles (see _seg_model_degraded). The raw
+        # output is a probability map, so it must be thresholded before measuring area --
+        # mean() over soft values is probability mass, not the fraction of face pixels.
+        # All four returns use the inverted convention (0 = Face), so an all-zero result
+        # makes every consumer's (1.0 - mask) a no-op and preserves the swap.
+        if self._seg_model_degraded(
+            (outpred > 0.5).type(torch.float32), yaw_deg, "DFL XSeg", parameters
+        ):
+            # Four independent tensors, not four references to one: callers apply
+            # in-place mask math (mul_) and aliasing here would corrupt the others.
+            bypass = [
+                torch.zeros(
+                    (1, 256, 256),
+                    dtype=torch.float32,
+                    device=self.models_processor.device,
+                )
+                for _ in range(4)
+            ]
+            return bypass[0], bypass[1], bypass[2], bypass[3]
 
         # Invert: Face becomes 0, Background/Obstacles become 1
         outpred = 1.0 - outpred
@@ -1638,8 +1783,11 @@ class FaceMasks:
         feather_radius=None,
         device=None,
     ):
+        rx = max(int(radius_x), 1)
+        ry = max(int(radius_y), 1)
         if feather_radius is None:
-            feather_radius = max(radius_x, radius_y) // 2
+            feather_radius = max(rx, ry) // 2
+        fr = max(int(feather_radius), 1)
 
         # FM-09: include device in the cache key and create tensors on the correct device
         _device = device if device is not None else self.models_processor.device
@@ -1658,11 +1806,9 @@ class FaceMasks:
                 self._meshgrid_cache[cache_key] = (y, x)
 
         normalized_distance = torch.sqrt(
-            ((x - center[0]) / radius_x) ** 2 + ((y - center[1]) / radius_y) ** 2
+            ((x - center[0]) / rx) ** 2 + ((y - center[1]) / ry) ** 2
         )
-        mask = torch.clamp(
-            (1 - normalized_distance) * (radius_x / feather_radius), 0, 1
-        )
+        mask = torch.clamp((1 - normalized_distance) * (rx / fr), 0, 1)
         return mask
 
     @torch.no_grad()

--- a/app/processors/face_masks.py
+++ b/app/processors/face_masks.py
@@ -1227,12 +1227,12 @@ class FaceMasks:
     @torch.no_grad()
     def apply_occlusion(
         self,
-        img,
-        amount,
-        parameters=None,
-        original_face_512=None,
+        img: torch.Tensor,
+        amount: float,
+        parameters: dict | None = None,
+        original_face_512: torch.Tensor | None = None,
         yaw_deg: float | None = None,
-    ):
+    ) -> torch.Tensor:
         """
         Runs the Occluder model to mask out obstacles (hands, microphones, etc.).
         Includes logic to protect the inner mouth (tongue/teeth) from being occluded.
@@ -1241,7 +1241,9 @@ class FaceMasks:
         bypassed and a full clear mask (1.0) is returned, so the swap is still applied
         instead of silently vanishing. Pass yaw_deg to enable that guard.
         """
-        img = torch.div(img, 255)
+        img = torch.div(
+            img.to(dtype=torch.float32, device=self.models_processor.device), 255
+        )
         img = torch.unsqueeze(img, 0).contiguous()
 
         # Output initialisation
@@ -1375,7 +1377,7 @@ class FaceMasks:
         self,
         img: torch.Tensor,
         amount: float,
-        mouth: torch.Tensor,
+        mouth: torch.Tensor | int | float,
         parameters: dict,
         inner_mouth_mask: torch.Tensor | None = None,
         yaw_deg: float | None = None,
@@ -1396,7 +1398,7 @@ class FaceMasks:
         # Check if obstacle protection is enabled
         exclude_obstacles = parameters.get("XSegExcludeInnerObstaclesToggle", False)
 
-        img = img.type(torch.float32)
+        img = img.to(dtype=torch.float32, device=self.models_processor.device)
         img = torch.div(img, 255)
         img = torch.unsqueeze(img, 0).contiguous()
         outpred = torch.ones(

--- a/app/processors/models_data.py
+++ b/app/processors/models_data.py
@@ -35,6 +35,10 @@ hrffa_repo = (
     "https://github.com/PINTO0309/High-Angle_Robust_Fast_FaceAlignment"
     "/releases/download/weights"
 )
+# YawNet, by the same author, linked upstream for the same reason as hrffa_repo.
+# MIT, and trained purely on a synthetic 42k-image set (CC BY 4.0), so unlike the
+# HRFFA students there is no teacher-licence question to inherit. See docs/yawnet.md.
+yawnet_repo = "https://github.com/PINTO0309/YawNet/releases/download/resources"
 
 ARCFACE_DST = np.array(
     [
@@ -315,6 +319,9 @@ restorer_model_mapping: dict[str, str] = {
 # fails silently for TUFA) and DEIMv2 is a DETR-style decoder (the shape whose fp16
 # build killed ORFormer). Both are cheap enough in fp32 that guessing is not worth the
 # risk of a silent ~70 px error. Measure before adding either.
+# YawNet is absent on the same unmeasured grounds: it is a tiny CNN, but its output is
+# a unit biternion whose ANGLE is the product, so a small fp16 drift in (cos, sin) is a
+# silently wrong pose rather than a visible artefact. It costs ~0.3 ms in fp32.
 fp16_safe_models_list = [
     # --- LivePortrait ---
     "LivePortraitAppearanceFeatureExtractor",
@@ -641,6 +648,39 @@ models_list: list[dict[str, Any]] = [
         ),
         "hash": "f24d8fa18583c75ce8d802e3d983af9d13a07fdc294267968a206dc79df85d36",
         "url": (f"{hrffa_repo}/deimv2_hgnetv2_n_wholebody49_boxes_only_webgpu.onnx"),
+    },
+    {
+        # YawNet — FULL-CIRCLE (360 deg) head-yaw regression. This is the only pose
+        # estimate here that can tell a profile from a head facing AWAY; the 5-landmark
+        # faceutil.calc_face_yaw_pitch cannot, because it is a nose-offset ratio that
+        # saturates near +-90 and reads a rear view as roughly frontal.
+        # Like HRFFA it wants a WHOLE-HEAD crop and shares the DEIMv2Wholebody49Head
+        # dependency, so enabling it outside 'hrffa' landmark mode force-loads that
+        # detector (FaceLandmarkDetectors.estimate_head_yaw_yawnet).
+        #
+        # This is the 128 px `kappa` student (0.77M params, MAAE 12.62 deg, the most
+        # accurate of the three students; 64/96 differ by <0.4 deg). The `kappa` export
+        # adds a von Mises concentration output at no measurable cost, and callers need
+        # it: acting on a low-confidence angle is worse than not acting.
+        # Input "images": RGB float32, NCHW 1x3x128x128, center05 normalised
+        # ((x/255 - 0.5) / 0.5), from the head box squashed to the square WITHOUT
+        # preserving aspect ratio (upstream's demo/web/src/hrffa/orientation.ts does the
+        # same; a letterbox is out of distribution).
+        # Outputs: "cos_sin" (1,2) unit biternion and "kappa" (1) confidence.
+        # NOTE the angle convention, which is easy to get wrong -- YawNet emits the
+        # `yawpose` convention and needs a MIRROR to become the documented ring:
+        #   deg = (degrees(atan2(sin, cos)) + 360) % 360; deg = (360 - deg) % 360
+        # giving 0 = facing camera, 90 = subject's right, 180 = facing away, 270 = left.
+        # NOT fp16-safe: unmeasured, like HRFFA. A biternion unit-vector head is exactly
+        # the precision-sensitive shape that fails SILENTLY for TUFA, and a quietly
+        # wrong angle here would mis-trigger the occluder/XSeg bypass rather than crash.
+        # Measure before adding it to fp16_safe_models_list.
+        "model_name": "YawNet",
+        "local_path": (
+            f"{models_dir}/yawnet_distill_128_unified_v6u_kappa_1x3x128x128.onnx"
+        ),
+        "hash": "08e5ecf68e6688fac5fba1de997f283fbd71cd3fdd2794261dc57e2de55314f8",
+        "url": (f"{yawnet_repo}/yawnet_distill_128_unified_v6u_kappa_1x3x128x128.onnx"),
     },
     {
         "model_name": "FaceBlendShapes",

--- a/app/processors/workers/frame_worker_pipeline.py
+++ b/app/processors/workers/frame_worker_pipeline.py
@@ -1822,6 +1822,7 @@ class PipelineProcessor:
         dfm_model_name: str | None = None,
         is_perspective_crop: bool = False,
         kv_map: dict[str, Any] | None = None,
+        yawnet_deg: float | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         """
         Core function for face swapping. Handles:
@@ -2265,6 +2266,19 @@ class PipelineProcessor:
         # --- DYNAMIC MASKS INITIALIZATION ---
         current_swap_h, current_swap_w = swap.shape[1], swap.shape[2]
         yaw_deg, pitch_deg = faceutil.calc_face_yaw_pitch(kps_5)
+
+        # Degrees away from facing the camera, for the occluder / XSeg profile safeguard
+        # only. When YawNet ran for this face we use its true full-circle angle; without
+        # it we fall back to the 5-landmark pseudo-degrees.
+        #
+        # Deliberately NOT substituted into yaw_deg itself: yaw_deg feeds
+        # get_dynamic_side_mask, whose ProfileAngleMaskThresholdSlider is calibrated in
+        # those pseudo-degrees, so swapping the scale underneath it would silently change
+        # what every saved user setting means.
+        if yawnet_deg is not None:
+            guard_yaw_deg = self.worker.function_worker.yaw_from_frontal(yawnet_deg)
+        else:
+            guard_yaw_deg = abs(float(yaw_deg))
         side_mask = self.get_dynamic_side_mask(
             yaw_deg,
             pitch_deg,
@@ -2456,6 +2470,7 @@ class PipelineProcessor:
                 parameters["OccluderSizeSlider"],
                 parameters=parameters,
                 original_face_512=swap_restorecalc,
+                yaw_deg=guard_yaw_deg,
             )
             if mask.shape[-1] != swap_mask.shape[-1]:
                 mask = _resize_func(
@@ -2648,6 +2663,7 @@ class PipelineProcessor:
                     mouth_256 if mouth_256 is not None else 0,
                     parameters,
                     inner_mouth_mask=inner_mouth_protection_256,
+                    yaw_deg=guard_yaw_deg,
                 )
             )
 

--- a/app/processors/workers/frame_worker_standard.py
+++ b/app/processors/workers/frame_worker_standard.py
@@ -420,7 +420,10 @@ class StandardProcessor:
         # (the same reasoning as the hrffa pass in STEP 3 above: heads belong to the
         # frame). Reuses the boxes from that pass when it already ran, so 'hrffa'
         # landmark mode pays nothing extra and other modes pay one inference per frame.
-        yawnet_enabled: bool = control.get("YawNetEnableToggle", False)
+        yawnet_enabled: bool = bool(
+            control.get("LandmarkDetectToggle", True)
+            and control.get("YawNetEnableToggle", False)
+        )
         yawnet_min_kappa: float = float(
             control.get("YawNetMinKappaDecimalSlider", 0.0) or 0.0
         )
@@ -898,7 +901,7 @@ class StandardProcessor:
 
         if (
             control.get("ShowYawNetRingToggle", False)
-            and control.get("YawNetEnableToggle", False)
+            and yawnet_enabled
             and det_faces_data_for_display
         ):
             processed_tensor_rgb_uint8 = draw_head_yaw_ring_on_faces(

--- a/app/processors/workers/frame_worker_standard.py
+++ b/app/processors/workers/frame_worker_standard.py
@@ -420,13 +420,29 @@ class StandardProcessor:
         # (the same reasoning as the hrffa pass in STEP 3 above: heads belong to the
         # frame). Reuses the boxes from that pass when it already ran, so 'hrffa'
         # landmark mode pays nothing extra and other modes pay one inference per frame.
-        # None is a valid value throughout: estimate_head_yaw falls back to a head box
-        # synthesised from the face box.
-        yawnet_enabled = control.get("YawNetEnableToggle", False)
-        yawnet_min_kappa = float(control.get("YawNetMinKappaDecimalSlider", 0.0) or 0.0)
+        yawnet_enabled: bool = control.get("YawNetEnableToggle", False)
+        yawnet_min_kappa: float = float(
+            control.get("YawNetMinKappaDecimalSlider", 0.0) or 0.0
+        )
         head_bboxes_frame = head_bboxes
-        if yawnet_enabled and head_bboxes_frame is None:
+        if yawnet_enabled and det_faces_data_for_display and head_bboxes_frame is None:
             head_bboxes_frame = self.worker.function_worker.run_detect_head_bboxes(img)
+
+        # Pre-calculate YawNet while img, face boxes, and head boxes are all still in
+        # the same rotated/scaled working coordinate space. The overlay later draws
+        # from these cached values after display-space transforms have been reversed.
+        if yawnet_enabled and det_faces_data_for_display:
+            for _fface in det_faces_data_for_display:
+                if _fface.get("bbox") is None:
+                    continue
+                _yaw_res = self.worker.function_worker.estimate_head_yaw(
+                    img,
+                    _fface["bbox"],
+                    head_bboxes=head_bboxes_frame,
+                    min_kappa=yawnet_min_kappa,
+                )
+                if _yaw_res is not None:
+                    _fface["yawnet_deg"] = _yaw_res[0]
 
         # Swapping / Editing Loop
         if det_faces_data_for_display:
@@ -559,21 +575,7 @@ class StandardProcessor:
                             target_face,
                             face_bbox=best_fface["bbox"],
                         )
-                        # Full-circle head yaw for the occluder / XSeg profile
-                        # safeguard. Computed before the swap so it reads the real head
-                        # pose; the swap preserves pose, so an earlier face already
-                        # composited into img does not affect this one.
-                        _yawnet_deg = None
-                        if yawnet_enabled:
-                            _yaw = self.worker.function_worker.estimate_head_yaw(
-                                img,
-                                best_fface["bbox"],
-                                head_bboxes=head_bboxes_frame,
-                                min_kappa=yawnet_min_kappa,
-                            )
-                            if _yaw is not None:
-                                _yawnet_deg = _yaw[0]
-                                best_fface["yawnet_deg"] = _yawnet_deg
+                        _yawnet_deg: float | None = best_fface.get("yawnet_deg")
                         try:
                             (
                                 img,
@@ -722,18 +724,7 @@ class StandardProcessor:
                             best_target,
                             face_bbox=fface["bbox"],
                         )
-                        # See the matching block in the best-match branch above.
-                        _yawnet_deg_b = None
-                        if yawnet_enabled:
-                            _yaw_b = self.worker.function_worker.estimate_head_yaw(
-                                img,
-                                fface["bbox"],
-                                head_bboxes=head_bboxes_frame,
-                                min_kappa=yawnet_min_kappa,
-                            )
-                            if _yaw_b is not None:
-                                _yawnet_deg_b = _yaw_b[0]
-                                fface["yawnet_deg"] = _yawnet_deg_b
+                        _yawnet_deg_b: float | None = fface.get("yawnet_deg")
                         try:
                             img, fface["original_face"], fface["swap_mask"] = (
                                 self.worker.swap_core(
@@ -910,19 +901,6 @@ class StandardProcessor:
             and control.get("YawNetEnableToggle", False)
             and det_faces_data_for_display
         ):
-            # Measure any face the swap loop skipped (unmatched faces still get a
-            # ring), then draw. draw_head_yaw_ring_on_faces ignores faces with no
-            # angle, so a failed estimate simply draws nothing for that face.
-            for _fface in det_faces_data_for_display:
-                if _fface.get("yawnet_deg") is None and _fface.get("bbox") is not None:
-                    _yaw_v = self.worker.function_worker.estimate_head_yaw(
-                        processed_tensor_rgb_uint8,
-                        _fface["bbox"],
-                        head_bboxes=head_bboxes_frame,
-                        min_kappa=yawnet_min_kappa,
-                    )
-                    if _yaw_v is not None:
-                        _fface["yawnet_deg"] = _yaw_v[0]
             processed_tensor_rgb_uint8 = draw_head_yaw_ring_on_faces(
                 processed_tensor_rgb_uint8, det_faces_data_for_display
             )

--- a/app/processors/workers/frame_worker_standard.py
+++ b/app/processors/workers/frame_worker_standard.py
@@ -11,6 +11,7 @@ from app.processors.models_data import landmark_point_counts
 from app.helpers.miscellaneous import (
     ParametersDict,
     draw_bounding_boxes_on_detected_faces,
+    draw_head_yaw_ring_on_faces,
     paint_landmarks_on_image,
     is_detected_face_eligible_for_matching,
     keypoints_adjustments,
@@ -153,6 +154,11 @@ class StandardProcessor:
 
         # FW-ARCH-FIX: Flag to know if faces were vetted by the Sequential Detector
         is_sequentially_tracked = not self.worker.is_single_frame
+
+        # Whole-head boxes for this frame, shared by the 'hrffa' landmark pass and
+        # YawNet. Bound here rather than inside the branch that fills it because only
+        # one of the paths below runs, and the YawNet block later reads it either way.
+        head_bboxes = None
 
         if is_sequentially_tracked:
             # 1. Primary Path (Video/Webcam): Use the sequentially precomputed detections
@@ -317,7 +323,6 @@ class StandardProcessor:
                 # 'hrffa' predicts on a whole-head crop, so it needs
                 # DEIMv2-Wholebody49 head boxes. Those belong to the frame, not to a
                 # face, so run the head detector once here instead of once per face.
-                head_bboxes = None
                 if landmark_mode == "hrffa":
                     head_bboxes = self.worker.function_worker.run_detect_head_bboxes(
                         img
@@ -410,6 +415,18 @@ class StandardProcessor:
                         "matched_target": None,
                     }
                 )
+
+        # Whole-head boxes for YawNet, detected once per FRAME rather than once per face
+        # (the same reasoning as the hrffa pass in STEP 3 above: heads belong to the
+        # frame). Reuses the boxes from that pass when it already ran, so 'hrffa'
+        # landmark mode pays nothing extra and other modes pay one inference per frame.
+        # None is a valid value throughout: estimate_head_yaw falls back to a head box
+        # synthesised from the face box.
+        yawnet_enabled = control.get("YawNetEnableToggle", False)
+        yawnet_min_kappa = float(control.get("YawNetMinKappaDecimalSlider", 0.0) or 0.0)
+        head_bboxes_frame = head_bboxes
+        if yawnet_enabled and head_bboxes_frame is None:
+            head_bboxes_frame = self.worker.function_worker.run_detect_head_bboxes(img)
 
         # Swapping / Editing Loop
         if det_faces_data_for_display:
@@ -542,6 +559,21 @@ class StandardProcessor:
                             target_face,
                             face_bbox=best_fface["bbox"],
                         )
+                        # Full-circle head yaw for the occluder / XSeg profile
+                        # safeguard. Computed before the swap so it reads the real head
+                        # pose; the swap preserves pose, so an earlier face already
+                        # composited into img does not affect this one.
+                        _yawnet_deg = None
+                        if yawnet_enabled:
+                            _yaw = self.worker.function_worker.estimate_head_yaw(
+                                img,
+                                best_fface["bbox"],
+                                head_bboxes=head_bboxes_frame,
+                                min_kappa=yawnet_min_kappa,
+                            )
+                            if _yaw is not None:
+                                _yawnet_deg = _yaw[0]
+                                best_fface["yawnet_deg"] = _yawnet_deg
                         try:
                             (
                                 img,
@@ -558,6 +590,7 @@ class StandardProcessor:
                                 control=control,
                                 dfm_model_name=params["DFMModelSelection"],
                                 kv_map=_reaging_kv,
+                                yawnet_deg=_yawnet_deg,
                             )
                             if edit_button_is_checked_global and any(
                                 params[f]
@@ -689,6 +722,18 @@ class StandardProcessor:
                             best_target,
                             face_bbox=fface["bbox"],
                         )
+                        # See the matching block in the best-match branch above.
+                        _yawnet_deg_b = None
+                        if yawnet_enabled:
+                            _yaw_b = self.worker.function_worker.estimate_head_yaw(
+                                img,
+                                fface["bbox"],
+                                head_bboxes=head_bboxes_frame,
+                                min_kappa=yawnet_min_kappa,
+                            )
+                            if _yaw_b is not None:
+                                _yawnet_deg_b = _yaw_b[0]
+                                fface["yawnet_deg"] = _yawnet_deg_b
                         try:
                             img, fface["original_face"], fface["swap_mask"] = (
                                 self.worker.swap_core(
@@ -702,6 +747,7 @@ class StandardProcessor:
                                     control=control,
                                     dfm_model_name=params["DFMModelSelection"],
                                     kv_map=_reaging_kv,
+                                    yawnet_deg=_yawnet_deg_b,
                                 )
                             )
                             if edit_button_is_checked_global and any(
@@ -858,6 +904,28 @@ class StandardProcessor:
                 temp_permuted = processed_tensor_rgb_uint8.permute(1, 2, 0)
                 temp_permuted = paint_landmarks_on_image(temp_permuted, landmarks_data)
                 processed_tensor_rgb_uint8 = temp_permuted.permute(2, 0, 1)
+
+        if (
+            control.get("ShowYawNetRingToggle", False)
+            and control.get("YawNetEnableToggle", False)
+            and det_faces_data_for_display
+        ):
+            # Measure any face the swap loop skipped (unmatched faces still get a
+            # ring), then draw. draw_head_yaw_ring_on_faces ignores faces with no
+            # angle, so a failed estimate simply draws nothing for that face.
+            for _fface in det_faces_data_for_display:
+                if _fface.get("yawnet_deg") is None and _fface.get("bbox") is not None:
+                    _yaw_v = self.worker.function_worker.estimate_head_yaw(
+                        processed_tensor_rgb_uint8,
+                        _fface["bbox"],
+                        head_bboxes=head_bboxes_frame,
+                        min_kappa=yawnet_min_kappa,
+                    )
+                    if _yaw_v is not None:
+                        _fface["yawnet_deg"] = _yaw_v[0]
+            processed_tensor_rgb_uint8 = draw_head_yaw_ring_on_faces(
+                processed_tensor_rgb_uint8, det_faces_data_for_display
+            )
 
         compare_mode_active = (
             self.worker.is_view_face_mask or self.worker.is_view_face_compare

--- a/app/processors/workers/function_worker.py
+++ b/app/processors/workers/function_worker.py
@@ -322,6 +322,30 @@ class FunctionWorker:
             img, score_threshold
         )
 
+    def estimate_head_yaw(
+        self,
+        img: torch.Tensor,
+        bbox: np.ndarray,
+        head_bboxes: np.ndarray | list | None = None,
+        min_kappa: float | None = None,
+    ) -> tuple[float, float] | None:
+        """
+        Full-circle head yaw for one face (YawNet). Returns (orientation_deg, kappa) in
+        the ring convention -- 0 = facing camera, 90 = right, 180 = away, 270 = left --
+        or None when unavailable or too uncertain to act on.
+
+        Pass head_bboxes when the caller already ran the head detector for this frame
+        ('hrffa' landmark mode) so it fires once per frame instead of once per face.
+        """
+        return self.face_landmark_detectors.estimate_head_yaw_yawnet(
+            img, bbox, head_bboxes, min_kappa=min_kappa
+        )
+
+    @staticmethod
+    def yaw_from_frontal(orientation_deg: float) -> float:
+        """Fold a ring angle onto 0..180 degrees away from facing the camera."""
+        return FaceLandmarkDetectors.yaw_from_frontal(orientation_deg)
+
     def get_arcface_model(self, face_swapper_model: str) -> str:
         if face_swapper_model in arcface_mapping_model_dict:
             return arcface_mapping_model_dict[face_swapper_model]
@@ -595,9 +619,14 @@ class FunctionWorker:
         amount: float,
         parameters: Optional[dict] = None,
         original_face_512: Optional[torch.Tensor] = None,
+        yaw_deg: Optional[float] = None,
     ) -> torch.Tensor | np.ndarray:
         return self.face_masks.apply_occlusion(
-            img, amount, parameters=parameters, original_face_512=original_face_512
+            img,
+            amount,
+            parameters=parameters,
+            original_face_512=original_face_512,
+            yaw_deg=yaw_deg,
         )
 
     def apply_dfl_xseg(
@@ -606,10 +635,16 @@ class FunctionWorker:
         amount: float,
         mouth: Any,
         parameters: dict,
-        inner_mouth_mask: Any,
-    ) -> np.ndarray:
+        inner_mouth_mask: Any = None,
+        yaw_deg: Optional[float] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         return self.face_masks.apply_dfl_xseg(
-            img, amount, mouth, parameters, inner_mouth_mask
+            img,
+            amount,
+            mouth,
+            parameters,
+            inner_mouth_mask=inner_mouth_mask,
+            yaw_deg=yaw_deg,
         )
 
     def process_masks_and_masks(

--- a/app/ui/widgets/settings_layout_data.py
+++ b/app/ui/widgets/settings_layout_data.py
@@ -550,6 +550,62 @@ SETTINGS_LAYOUT_DATA: Any = {
             "exec_function": control_actions.handle_landmark_model_selection_change,
             "exec_function_args": ["LandmarkDetectModelSelection"],
         },
+        "YawNetEnableToggle": {
+            "level": 2,
+            "label": "Head Yaw (YawNet)",
+            "default": False,
+            "parentToggle": "LandmarkDetectToggle",
+            "requiredToggleValue": True,
+            "help": (
+                "Estimate head yaw with YawNet, a full-circle (360 deg) pose model.\n\n"
+                "The built-in yaw estimate is a ratio between the nose and the eyes, so "
+                "it saturates near +-90 deg and reads a head turned fully away as "
+                "roughly frontal. YawNet tells those apart, which lets the occluder / "
+                "XSeg profile safeguard fire on the frames that actually need it "
+                "instead of guessing from landmark geometry.\n\n"
+                "Like hrffa it needs a whole-head crop, so it runs a "
+                "DEIMv2-Wholebody49 head detection pass. In 'hrffa' landmark mode that "
+                "pass already happens and this is nearly free; in every other mode it "
+                "adds one inference per frame. YawNet itself is ~0.3 ms.\n\n"
+                "Note this sits under 'Enable Landmark Detection': turning that off "
+                "also turns this off, and the safeguard falls back to the landmark-based "
+                "estimate."
+            ),
+        },
+        "YawNetMinKappaDecimalSlider": {
+            "level": 3,
+            "label": "Min Confidence (kappa)",
+            "min_value": "0.0",
+            "max_value": "10.0",
+            "default": "0.0",
+            "step": 0.1,
+            "decimals": 1,
+            "parentToggle": "YawNetEnableToggle",
+            "requiredToggleValue": True,
+            "help": (
+                "Discard head-angle readings whose confidence falls below this.\n\n"
+                "0 (the default) accepts every reading. Note that 2.0 is YawNet's own "
+                "neutral starting value rather than a confidence floor, so a threshold "
+                "near it will reject ordinary predictions - start low.\n\n"
+                "There is no established value for this: upstream's demo ignores "
+                "confidence entirely. Run with debug logging to see the readings your "
+                "footage actually produces before raising it."
+            ),
+        },
+        "ShowYawNetRingToggle": {
+            "level": 3,
+            "label": "Show Head Yaw Ring",
+            "default": False,
+            "parentToggle": "YawNetEnableToggle",
+            "requiredToggleValue": True,
+            "help": (
+                "Draw a YawNet orientation ring above each face in the preview, like "
+                "the ring in the upstream YawNet demo.\n\n"
+                "The needle points the way the head faces: down = toward the camera, "
+                "right / left = turned to that side, up = facing away from the "
+                "camera. Preview only - it never affects the rendered output."
+            ),
+        },
         "LandmarkDetectScoreSlider": {
             "level": 2,
             "label": "Landmark Detect Score",

--- a/app/ui/widgets/swapper_layout_data.py
+++ b/app/ui/widgets/swapper_layout_data.py
@@ -477,6 +477,65 @@ SWAPPER_LAYOUT_DATA: Any = {  # noqa: F811
             "requiredToggleValue": True,
             "help": "Blend value for Occluder and XSeg.",
         },
+        "SegGuardEnableToggle": {
+            "level": 1,
+            "label": "Profile Safeguard",
+            "default": True,
+            "parentToggle": "OccluderEnableToggle | DFLXSegEnableToggle",
+            "requiredToggleValue": True,
+            "help": (
+                "The Occluder and DFL XSeg models are trained mostly on frontal faces "
+                "and can collapse on extreme side angles, marking the whole face as "
+                "occluded. That empties the mask and the swap silently disappears for "
+                "those frames - the swap comes back if you disable the mask.\n\n"
+                "With this on, a model that collapses is skipped for that frame and "
+                "the swap is applied unmasked instead of vanishing.\n\n"
+                "It only triggers when the head is at an extreme angle AND almost "
+                "nothing of the face survives, because a low face ratio on its own is "
+                "also what a CORRECT prediction looks like when a hand really does "
+                "cover the face. Turn this off to get the old behaviour back."
+            ),
+        },
+        "SegGuardMinYawSlider": {
+            "level": 2,
+            "label": "Min Head Angle",
+            "min_value": "0",
+            "max_value": "180",
+            "default": "40",
+            "step": 1,
+            "parentToggle": "SegGuardEnableToggle",
+            "requiredToggleValue": True,
+            "help": (
+                "How far the head must be turned away from the camera before a "
+                "collapsed mask is treated as model failure. 0 = facing the camera, "
+                "90 = full profile, 180 = facing away.\n\n"
+                "Lower fires on more frames (more swaps rescued, but more risk of "
+                "ignoring real occlusion); higher fires on fewer. 180 effectively "
+                "disables the safeguard.\n\n"
+                "Read from YawNet when 'Head Yaw (YawNet)' is enabled in Settings, "
+                "otherwise from the landmark-based estimate, which is less reliable at "
+                "exactly these angles. This default is a plausible guess, not a "
+                "measured value - tune it on your own footage."
+            ),
+        },
+        "SegGuardMinFaceRatioSlider": {
+            "level": 2,
+            "label": "Min Face Area",
+            "min_value": "0",
+            "max_value": "100",
+            "default": "30",
+            "step": 1,
+            "parentToggle": "SegGuardEnableToggle",
+            "requiredToggleValue": True,
+            "help": (
+                "How little of the face must survive the mask before it counts as a "
+                "collapse, as a percentage of the crop.\n\n"
+                "At 30, a mask keeping less than 30% of the crop is suspect. Raise it "
+                "if profile swaps still vanish; lower it if real occlusion (a hand, a "
+                "microphone) is being ignored. 0 disables the safeguard.\n\n"
+                "This default is a plausible guess, not a measured value."
+            ),
+        },
         "XSegMouthEnableToggle": {
             "level": 2,
             "label": "Xseg Mouth",

--- a/docs/yawnet.md
+++ b/docs/yawnet.md
@@ -1,0 +1,133 @@
+# YawNet
+
+YawNet estimates **head yaw over the full 360°**. Enable **Head Yaw (YawNet)** under
+the Landmark Detect Model list in *Settings → Detectors*, with **Show Head Yaw Ring**
+as an optional preview overlay beneath it.
+
+VisoMaster already had a yaw estimate: `faceutil.calc_face_yaw_pitch` compares the
+horizontal gap from the nose to each eye. That is free, since the 5 keypoints are
+already there, but it has two limits. It saturates near ±90°, and — because it only
+ever sees a face's own landmarks — it reads a head turned *fully away* as roughly
+frontal. YawNet tells those apart, which is what makes it useful here.
+
+Like `hrffa`, it predicts from a crop of the whole **head**, so it shares the same
+DEIMv2-Wholebody49 head detector. In `hrffa` landmark mode that detector already runs
+and YawNet is nearly free; in any other mode enabling it adds one head-detection pass
+per frame. YawNet itself is ~0.3 ms.
+
+## Model
+
+The downloader installs one ONNX file:
+
+| File | Input | Params | MAAE | Acc@30° |
+|---|---|---|---|---|
+| `yawnet_distill_128_unified_v6u_kappa_1x3x128x128.onnx` | 128×128 | 0.77 M | 12.62° | 92.6% |
+
+The author also publishes 64 px and 96 px students. They are the same size and differ
+by under 0.4° MAAE, so the most accurate one is pinned; the 320 px DINOv3 teacher
+(0.97° MAAE) is 1.1 GB and carries Meta's DINOv3 licence, so it is not offered.
+
+The `_kappa` export adds a confidence output at no measurable cost. See *Confidence*
+below for why nothing currently gates on it.
+
+## Implementation notes
+
+**Input.** RGB float32, NCHW `1×3×128×128`, center05 normalised (`(x/255 − 0.5)/0.5`,
+identical to the `x/127.5 − 1` in the upstream README). The head box is squashed to the
+square **without preserving aspect ratio** — upstream's `orientation.ts` does the same,
+and a letterbox would be out of distribution.
+
+**Output.** `cos_sin` `(1,2)`, a unit biternion, plus `kappa` `(1)`.
+
+**The angle convention is easy to get wrong.** YawNet emits the `yawpose` convention
+and needs a mirror to become the ring convention:
+
+```python
+deg = (degrees(atan2(sin, cos)) + 360) % 360
+deg = (360 - deg) % 360          # <- mirror; omitting this swaps left and right
+```
+
+giving **0 = facing the camera, 90 = subject's right, 180 = facing away, 270 = left**.
+`FaceLandmarkDetectors.yaw_from_frontal()` folds that onto 0–180° "degrees away from
+frontal", which is what consumers should compare against a threshold — comparing raw
+ring degrees would read 350° (10° off frontal) as extreme.
+
+**Not fp16-safe.** Untested in fp16, and deliberately excluded for the same reason as
+HRFFA: the product of this model is an *angle* derived from a unit vector, so small
+fp16 drift in `(cos, sin)` is a silently wrong pose rather than a visible artefact.
+
+## What uses it
+
+The **occluder / XSeg profile safeguard**. Those two segmentation models are trained on
+mostly-frontal faces and can collapse on extreme profiles, marking the whole crop as
+occluded, which zeroes the blend mask and makes the swap silently vanish for those
+frames. The safeguard bypasses the failing model, but only when the head really is at
+an extreme angle *and* the mask has collapsed — a low face ratio on its own is also
+exactly what a correct prediction looks like when a hand covers most of the face.
+
+YawNet supplies the angle half of that test. Without it the safeguard falls back to the
+landmark estimate, which is least reliable at precisely the angles being judged.
+
+It is deliberately **not** substituted into the yaw that feeds `get_dynamic_side_mask`.
+That path's `ProfileAngleMaskThresholdSlider` is calibrated in the landmark estimate's
+pseudo-degrees, and changing the scale underneath it would silently change what every
+saved user setting means.
+
+## Confidence
+
+`kappa` is `softplus(logit).clamp(1e-3, 100)`. The gate defaults to **0 — off**:
+
+- The kappa head's bias is initialised so `softplus(1.85) ≈ 2.0`, described upstream as
+  "the same as the previous fixed kappa". **2.0 is the model's neutral prior, not a
+  confidence floor**, so a threshold near it would reject ordinary predictions.
+- Upstream's own demo reads only `cos_sin` and ignores `kappa`, so there is no
+  reference value to copy.
+
+Leaving it off is safe for the safeguard, which also requires a collapsed mask, so a
+spurious angle alone cannot trigger anything.
+
+**Min Confidence (kappa)** under the YawNet toggle raises it. Every reading is logged
+at debug level *before* the gate is applied, and unconditionally, so the readings you
+need in order to choose a threshold are not the ones a gate has already discarded.
+
+## Calibration status
+
+Three values are **plausible guesses, not measured ones**. All are now exposed in the
+UI specifically so they can be tuned on real footage and better defaults chosen later:
+
+| Setting | Where | Default | Constant |
+|---|---|---|---|
+| Profile Safeguard | Swapper, under the mask toggles | on | — |
+| Min Head Angle | same | 40° | `_SEG_GUARD_MIN_ABS_YAW` |
+| Min Face Area | same | 30% | `_SEG_GUARD_MIN_FACE_RATIO` |
+| Min Confidence (kappa) | Settings, under YawNet | 0 (off) | `YAWNET_MIN_KAPPA` |
+
+The module constants remain the fallbacks, so workspaces saved before these controls
+existed — and internal callers that pass no parameters — keep the original behaviour.
+
+Either safeguard slider can switch it off: **Min Face Area 0** (a mask mean can never
+fall below zero) or **Min Head Angle 180**. The explicit toggle is clearer, but a
+slider at those extremes will not misfire.
+
+Useful directions when tuning:
+
+- Profile swaps still vanish → *raise* Min Face Area, or *lower* Min Head Angle.
+- Real occlusion (a hand, a microphone) is being ignored → *lower* Min Face Area, or
+  *raise* Min Head Angle.
+
+## Credits
+
+The ONNX file is downloaded directly from the author's
+[release](https://github.com/PINTO0309/YawNet/releases/tag/resources) rather than
+re-hosted, matching how the HRFFA assets are handled.
+
+YawNet is by Katsuya Hyodo, MIT-licensed. It is trained purely on a synthetic 42k-image
+dataset of fictitious people (CC BY 4.0), so unlike the HRFFA students it inherits no
+teacher-licence question. The preprocessing and angle convention here follow
+`demo/web/src/hrffa/orientation.ts` in the
+[HRFFA repository](https://github.com/PINTO0309/High-Angle_Robust_Fast_FaceAlignment),
+and the `kappa` semantics follow `scripts/yawnet.py` in the YawNet repository.
+
+Note that upstream uses YawNet only for visualisation — its README states the angle
+"doesn't control HRFFA landmark prediction". Feeding it into the segmentation safeguard
+is specific to VisoMaster.

--- a/tests/unit/processors/test_face_masks_logic.py
+++ b/tests/unit/processors/test_face_masks_logic.py
@@ -5,6 +5,7 @@ No ML models loaded; tests cover pure tensor/numpy operations.
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 
@@ -121,3 +122,299 @@ def test_affine_before_blend_ordering():
     assert not torch.allclose(result_correct, result_wrong), (
         "warp-then-blend and blend-then-warp must differ when background is non-constant"
     )
+
+
+# ---------------------------------------------------------------------------
+# FM-08: Occluder / XSeg profile-collapse bypass
+# ---------------------------------------------------------------------------
+
+
+class MockModelsProcessor:
+    def __init__(self):
+        self.device = torch.device("cpu")
+        self.models = {}
+
+
+def _make_face_masks():
+    from unittest.mock import MagicMock
+
+    from app.processors.face_masks import FaceMasks
+
+    return FaceMasks(MockModelsProcessor(), MagicMock())
+
+
+def _occluder_returning(fill):
+    """Build a run_occluder stub whose output keeps `fill` fraction of the crop."""
+
+    rows = int(round(256 * fill))
+
+    def _stub(img, output):
+        output.zero_()
+        output.view(256, 256)[:rows, :] = 1.0
+
+    return _stub
+
+
+def _xseg_returning(fill):
+    rows = int(round(256 * fill))
+
+    def _stub(img, output):
+        output.zero_()
+        output.view(256, 256)[:rows, :] = 1.0
+
+    return _stub
+
+
+PROFILE_YAW = 55.0
+FRONTAL_YAW = 10.0
+
+
+def test_occluder_bypassed_on_profile_when_mask_collapses():
+    """Extreme yaw + collapsed mask == model failure -> bypass, swap still applied."""
+    fm = _make_face_masks()
+    fm.run_occluder = _occluder_returning(0.05)
+
+    mask = fm.apply_occlusion(torch.zeros((3, 256, 256)), amount=0, yaw_deg=PROFILE_YAW)
+
+    assert mask.shape == (1, 256, 256)
+    assert mask.min().item() == 1.0, "bypass must return a fully clear mask"
+
+
+def test_occluder_respected_when_frontal_face_is_heavily_occluded():
+    """
+    The regression guard: a hand covering most of a FRONTAL face produces the same
+    low face ratio as a profile collapse, but it is a correct prediction. The
+    occluder must be honoured, not bypassed.
+    """
+    fm = _make_face_masks()
+    fm.run_occluder = _occluder_returning(0.05)
+
+    mask = fm.apply_occlusion(torch.zeros((3, 256, 256)), amount=0, yaw_deg=FRONTAL_YAW)
+
+    assert mask.min().item() == 0.0, "occlusion must survive on a frontal face"
+    # Tolerance covers row quantization in the stub (1 row == 1/256).
+    assert abs(mask.mean().item() - 0.05) < 0.005
+
+
+def test_occluder_respected_on_profile_when_mask_is_plausible():
+    """Extreme yaw alone must not trigger a bypass if the mask looks sane."""
+    fm = _make_face_masks()
+    fm.run_occluder = _occluder_returning(0.75)
+
+    mask = fm.apply_occlusion(torch.zeros((3, 256, 256)), amount=0, yaw_deg=PROFILE_YAW)
+
+    assert abs(mask.mean().item() - 0.75) < 1e-6
+
+
+def test_occluder_not_bypassed_when_yaw_unknown():
+    """Callers that cannot supply a head angle keep the model authoritative."""
+    fm = _make_face_masks()
+    fm.run_occluder = _occluder_returning(0.05)
+
+    mask = fm.apply_occlusion(torch.zeros((3, 256, 256)), amount=0)
+
+    assert mask.min().item() == 0.0
+
+
+def test_xseg_bypassed_on_profile_returns_four_independent_zero_masks():
+    """
+    XSeg returns inverted masks (0 = Face), so an all-zero bypass makes every
+    consumer's (1 - mask) a no-op. The four results must not alias each other:
+    the pipeline applies in-place mask math to them.
+    """
+    fm = _make_face_masks()
+    fm.run_dfl_xseg = _xseg_returning(0.05)
+
+    masks = fm.apply_dfl_xseg(
+        torch.zeros((3, 256, 256)),
+        amount=0,
+        mouth=torch.zeros((1, 256, 256)),
+        parameters={},
+        yaw_deg=PROFILE_YAW,
+    )
+
+    assert len(masks) == 4
+    for m in masks:
+        assert m.shape == (1, 256, 256)
+        assert m.max().item() == 0.0
+
+    # Aliasing check: mutating one must not disturb the others.
+    masks[0].add_(1.0)
+    assert [m.max().item() for m in masks[1:]] == [0.0, 0.0, 0.0]
+
+
+def test_xseg_respected_when_frontal_face_is_heavily_occluded():
+    fm = _make_face_masks()
+    fm.run_dfl_xseg = _xseg_returning(0.05)
+
+    mask, _, _, _ = fm.apply_dfl_xseg(
+        torch.zeros((3, 256, 256)),
+        amount=0,
+        mouth=torch.zeros((1, 256, 256)),
+        parameters={},
+        yaw_deg=FRONTAL_YAW,
+    )
+
+    # Inverted convention: the 95% non-face region must still be excluded (1 = BG).
+    assert mask.max().item() == 1.0
+    assert abs(mask.mean().item() - 0.95) < 0.005
+
+
+def test_xseg_ratio_uses_binarized_area_not_soft_probability_mass():
+    """
+    The guard must measure thresholded AREA, not soft probability mass. A mask
+    covering 45% of the crop at p=0.6 has a soft mean of 0.27 -- under the 0.30
+    threshold, so a mean-based check would wrongly call it a collapse -- while its
+    binarized area is 0.45 and correctly passes.
+    """
+    fm = _make_face_masks()
+
+    def _soft(img, output):
+        output.zero_()
+        # 45% of the crop at p=0.6 -> soft mean 0.27 (would trip a mean-based
+        # check) but thresholded area 0.45 (correctly passes).
+        output.view(256, 256)[: int(256 * 0.45), :] = 0.6
+
+    fm.run_dfl_xseg = _soft
+
+    mask, _, _, _ = fm.apply_dfl_xseg(
+        torch.zeros((3, 256, 256)),
+        amount=0,
+        mouth=torch.zeros((1, 256, 256)),
+        parameters={},
+        yaw_deg=PROFILE_YAW,
+    )
+
+    # Not bypassed: the face region is inverted to ~0.4, background stays 1.0.
+    assert mask.max().item() == 1.0
+
+
+def test_clip_mask_is_not_silently_overridden():
+    """
+    ClipText is user-typed intent. A prompt that legitimately matches almost the
+    whole crop must still mask it -- no degradation fallback on this path.
+    """
+    import inspect
+
+    from app.processors.face_masks import FaceMasks
+
+    src = inspect.getsource(FaceMasks.run_CLIPs)
+    assert "0.05" not in src, "run_CLIPs must not re-introduce a silent mask override"
+
+
+def test_soft_oval_mask_zero_radius_protection():
+    """Zero radius or feather must not produce inf/NaN (0 * inf at the boundary)."""
+    fm = _make_face_masks()
+
+    mask = fm.soft_oval_mask(
+        height=64, width=64, center=(32, 32), radius_x=0, radius_y=0
+    )
+    assert torch.isfinite(mask).all()
+
+    mask_zero_feather = fm.soft_oval_mask(
+        height=64, width=64, center=(32, 32), radius_x=10, radius_y=10, feather_radius=0
+    )
+    assert torch.isfinite(mask_zero_feather).all()
+
+
+# ---------------------------------------------------------------------------
+# FM-08b: UI-tunable profile-safeguard thresholds
+# ---------------------------------------------------------------------------
+
+
+def _occluder_mask(params, yaw=55.0, fill=0.05):
+    """Run apply_occlusion with a collapsed mask and the given UI parameters."""
+    fm = _make_face_masks()
+    rows = int(round(256 * fill))
+
+    def _stub(img, output):
+        output.zero_()
+        output.view(256, 256)[:rows, :] = 1.0
+
+    fm.run_occluder = _stub
+    return fm.apply_occlusion(
+        torch.zeros((3, 256, 256)), amount=0, parameters=params, yaw_deg=yaw
+    )
+
+
+def test_seg_guard_defaults_match_module_constants():
+    """
+    Workspaces saved before these controls existed have no keys, and internal callers
+    pass none at all. Both must keep the previous always-on behaviour.
+    """
+    from app.processors.face_masks import (
+        _SEG_GUARD_MIN_ABS_YAW,
+        _SEG_GUARD_MIN_FACE_RATIO,
+        FaceMasks,
+    )
+
+    for params in (None, {}):
+        enabled, min_yaw, min_ratio = FaceMasks._seg_guard_settings(params)
+        assert enabled is True
+        assert min_yaw == _SEG_GUARD_MIN_ABS_YAW
+        assert min_ratio == pytest.approx(_SEG_GUARD_MIN_FACE_RATIO)
+
+
+def test_seg_guard_converts_ui_percentage_to_fraction():
+    """The slider is a percentage; the mask mean it is compared against is 0..1."""
+    from app.processors.face_masks import FaceMasks
+
+    _, _, min_ratio = FaceMasks._seg_guard_settings({"SegGuardMinFaceRatioSlider": 45})
+    assert min_ratio == pytest.approx(0.45)
+
+
+def test_seg_guard_toggle_off_restores_unguarded_behaviour():
+    """With the safeguard off, a collapsed mask must survive as-is."""
+    mask = _occluder_mask({"SegGuardEnableToggle": False})
+    assert mask.min().item() == 0.0, "occlusion must not be bypassed when off"
+
+
+def test_seg_guard_min_face_area_zero_disables():
+    """A mean can never be below 0, so 0% must behave as off."""
+    mask = _occluder_mask({"SegGuardMinFaceRatioSlider": 0})
+    assert mask.min().item() == 0.0
+
+
+def test_seg_guard_respects_raised_min_angle():
+    """At 55 deg of yaw, a 90 deg minimum must not fire."""
+    assert _occluder_mask({"SegGuardMinYawSlider": 90}, yaw=55.0).min().item() == 0.0
+    # ...but the same frame fires once the minimum drops below the actual angle.
+    assert _occluder_mask({"SegGuardMinYawSlider": 30}, yaw=55.0).min().item() == 1.0
+
+
+def test_seg_guard_respects_lowered_min_face_area():
+    """
+    A mask keeping 20% of the crop is a collapse at the 30% default but plausible at
+    a 10% setting, so the lower setting must leave the occluder alone.
+    """
+    assert (
+        _occluder_mask({"SegGuardMinFaceRatioSlider": 10}, fill=0.20).min().item()
+        == 0.0
+    )
+    assert (
+        _occluder_mask({"SegGuardMinFaceRatioSlider": 30}, fill=0.20).min().item()
+        == 1.0
+    )
+
+
+def test_seg_guard_settings_are_exposed_in_the_ui():
+    """
+    These constants are uncalibrated, so they must stay reachable from the UI for
+    users to tune. Guards against a later refactor quietly dropping the widgets.
+    """
+    import ast
+    import io
+
+    src = io.open("app/ui/widgets/swapper_layout_data.py", encoding="utf-8").read()
+    keys = {
+        k.value
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Dict)
+        for k in node.keys
+        if isinstance(k, ast.Constant) and isinstance(k.value, str)
+    }
+    assert {
+        "SegGuardEnableToggle",
+        "SegGuardMinYawSlider",
+        "SegGuardMinFaceRatioSlider",
+    } <= keys

--- a/tests/unit/processors/test_yawnet_logic.py
+++ b/tests/unit/processors/test_yawnet_logic.py
@@ -16,6 +16,121 @@ from app.processors.face_landmark_detectors import FaceLandmarkDetectors
 MODEL = "model_assets/yawnet_distill_128_unified_v6u_kappa_1x3x128x128.onnx"
 
 
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+def test_yawnet_normalization_preserves_source_frame(dtype):
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    mp = MagicMock()
+    mp.device = torch.device("cpu")
+    session = MagicMock()
+    session.get_inputs.return_value = [
+        SimpleNamespace(name="image", shape=[1, 3, 128, 128])
+    ]
+    mp.models = {"YawNet": session}
+    det = FaceLandmarkDetectors(mp, MagicMock())
+    frame = torch.full((3, 256, 256), 127, dtype=dtype)
+    original = frame.clone()
+    heads = np.array([[32, 32, 160, 160, 0.9]], dtype=np.float32)
+
+    def infer(name, feed, outputs):
+        crop = feed["image"]
+        assert crop.shape == (1, 3, 128, 128)
+        assert crop.dtype == torch.float32
+        assert crop.device == mp.device
+        assert crop.is_contiguous()
+        torch.testing.assert_close(crop, torch.full_like(crop, 127 / 127.5 - 1))
+        return [np.array([[0.0, 1.0]]), np.array([2.0])]
+
+    det._run_onnx_binding = infer
+    result = det.estimate_head_yaw_yawnet(
+        frame, np.array([60, 60, 120, 140], dtype=np.float32), head_bboxes=heads
+    )
+    assert result == pytest.approx((270.0, 2.0))
+    torch.testing.assert_close(frame, original)
+
+
+@pytest.mark.parametrize("face_count", [0, 1, 2])
+@pytest.mark.parametrize("angle", [0, 90])
+def test_standard_frame_yaw_uses_working_coordinates(monkeypatch, face_count, angle):
+    from collections import OrderedDict, defaultdict
+    import threading
+    from unittest.mock import MagicMock
+
+    from torchvision.transforms import v2
+    from app.processors.workers import frame_worker_standard as standard
+
+    worker = MagicMock()
+    worker.lock = threading.RLock()
+    worker.main_window.target_faces = {}
+    worker.main_window.swapfacesButton.isChecked.return_value = False
+    worker.main_window.editFacesButton.isChecked.return_value = False
+    worker.is_single_frame = True
+    worker.precomputed_bboxes = None
+    worker._resize_cache = OrderedDict()
+    worker._RESIZE_CACHE_MAX = 16
+    worker._MIN_FACE_PIXELS = 20
+    worker.interpolation_scaleback = v2.InterpolationMode.BILINEAR
+    worker.is_view_face_mask = worker.is_view_face_compare = False
+    worker._find_best_target_match.return_value = (None, {}, 0.0)
+    fw = worker.function_worker
+    boxes = np.array([[100, 120, 220, 260]] * face_count, dtype=np.float32).reshape(
+        -1, 4
+    )
+    points = np.array(
+        [[[130, 150], [190, 150], [160, 185], [140, 225], [180, 225]]] * face_count,
+        dtype=np.float32,
+    ).reshape(-1, 5, 2)
+    fw.run_detect.return_value = (boxes, points, None)
+    fw.run_recognize_direct.return_value = (np.ones(512), None)
+    heads = np.array([[80, 80, 240, 280, 0.9]], dtype=np.float32)
+    fw.run_detect_head_bboxes.return_value = heads
+    working_shape = (3, 768, 512) if angle else (3, 512, 768)
+
+    def estimate(img, bbox, head_bboxes, min_kappa):
+        assert tuple(img.shape) == working_shape
+        np.testing.assert_array_equal(bbox, [100, 120, 220, 260])
+        assert head_bboxes is heads
+        assert min_kappa == 1.5
+        return (90.0, 2.0)
+
+    fw.estimate_head_yaw.side_effect = estimate
+    overlays = []
+
+    def draw(img, faces, **kwargs):
+        assert tuple(img.shape) == (3, 256, 384)
+        for face in faces:
+            assert face["yawnet_deg"] == 90.0
+            assert not np.array_equal(face["bbox"], boxes[0])
+        overlays.append(faces)
+        return img
+
+    monkeypatch.setattr(
+        standard, "draw_bounding_boxes_on_detected_faces", lambda img, *a, **kw: img
+    )
+    monkeypatch.setattr(standard, "draw_head_yaw_ring_on_faces", draw)
+    control = defaultdict(
+        bool,
+        {
+            "LandmarkDetectToggle": False,
+            "ShowAllDetectedFacesBBoxToggle": True,
+            "YawNetEnableToggle": True,
+            "ShowYawNetRingToggle": True,
+            "YawNetMinKappaDecimalSlider": 1.5,
+            "ManualRotationEnableToggle": bool(angle),
+            "ManualRotationAngleSlider": angle,
+        },
+    )
+    frame = torch.zeros((3, 256, 384), dtype=torch.uint8)
+    out = standard.StandardProcessor(worker).process_standard_frame(
+        frame, control, threading.Event()
+    )
+    assert out.shape == frame.shape
+    assert fw.run_detect_head_bboxes.call_count == bool(face_count)
+    assert fw.estimate_head_yaw.call_count == face_count
+    assert len(overlays) == bool(face_count)
+
+
 # ---------------------------------------------------------------------------
 # Ring-angle folding
 # ---------------------------------------------------------------------------

--- a/tests/unit/processors/test_yawnet_logic.py
+++ b/tests/unit/processors/test_yawnet_logic.py
@@ -1,0 +1,296 @@
+"""
+YawNet head-yaw tests: ring-angle conventions and the degradation-guard handoff.
+The inference test is skipped unless the ONNX weights are present locally.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from app.processors.face_landmark_detectors import FaceLandmarkDetectors
+
+MODEL = "model_assets/yawnet_distill_128_unified_v6u_kappa_1x3x128x128.onnx"
+
+
+# ---------------------------------------------------------------------------
+# Ring-angle folding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ring, expected",
+    [
+        (0.0, 0.0),  # facing camera
+        (10.0, 10.0),
+        (90.0, 90.0),  # full profile, subject's right
+        (180.0, 180.0),  # facing away
+        (270.0, 90.0),  # full profile, left -> same distance from frontal
+        (350.0, 10.0),  # near-frontal from the other side, NOT 350
+        (359.5, 0.5),
+    ],
+)
+def test_yaw_from_frontal_folds_to_0_180(ring, expected):
+    assert FaceLandmarkDetectors.yaw_from_frontal(ring) == pytest.approx(expected)
+
+
+def test_yaw_from_frontal_is_side_symmetric():
+    """Mirrored angles must fold to the same distance from frontal."""
+    for d in (5.0, 30.0, 75.0, 120.0, 179.0):
+        assert FaceLandmarkDetectors.yaw_from_frontal(d) == pytest.approx(
+            FaceLandmarkDetectors.yaw_from_frontal(360.0 - d)
+        )
+
+
+def test_yaw_from_frontal_never_exceeds_180():
+    for ring in np.arange(-720.0, 720.0, 7.0):
+        v = FaceLandmarkDetectors.yaw_from_frontal(float(ring))
+        assert 0.0 <= v <= 180.0
+
+
+def test_folding_prevents_wraparound_false_negative():
+    """
+    The bug this folding exists to prevent: comparing a RAW ring angle against a
+    threshold. 350 deg is 10 deg off frontal, but a naive `raw >= 40` reads it as
+    extreme and would bypass the occluder on a nearly frontal face.
+    """
+    raw = 350.0
+    assert raw >= 40.0  # naive check fires
+    assert FaceLandmarkDetectors.yaw_from_frontal(raw) < 40.0  # folded check does not
+
+
+# ---------------------------------------------------------------------------
+# Biternion -> ring conversion, including the mirror step
+# ---------------------------------------------------------------------------
+
+
+def _ring_from_cos_sin(cos_v, sin_v):
+    deg = (math.degrees(math.atan2(sin_v, cos_v)) + 360.0) % 360.0
+    return (360.0 - deg) % 360.0
+
+
+def test_mirror_step_is_present_and_matters():
+    """
+    YawNet emits the yawpose convention; the ring convention is its MIRROR. Dropping
+    the (360 - deg) step silently swaps left and right, so assert the two differ for
+    an off-axis angle.
+    """
+    cos_v, sin_v = math.cos(math.radians(60.0)), math.sin(math.radians(60.0))
+    unmirrored = (math.degrees(math.atan2(sin_v, cos_v)) + 360.0) % 360.0
+    assert unmirrored == pytest.approx(60.0)
+    assert _ring_from_cos_sin(cos_v, sin_v) == pytest.approx(300.0)
+
+
+def test_ring_conversion_anchors():
+    assert _ring_from_cos_sin(1.0, 0.0) == pytest.approx(0.0)  # frontal
+    assert _ring_from_cos_sin(-1.0, 0.0) == pytest.approx(180.0)  # facing away
+    # +-90 map to the two profiles and fold to the same distance from frontal
+    right = _ring_from_cos_sin(0.0, -1.0)
+    left = _ring_from_cos_sin(0.0, 1.0)
+    assert sorted([right, left]) == pytest.approx([90.0, 270.0])
+    assert FaceLandmarkDetectors.yaw_from_frontal(right) == pytest.approx(
+        FaceLandmarkDetectors.yaw_from_frontal(left)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard handoff: YawNet degrees must reach the occluder/XSeg bypass
+# ---------------------------------------------------------------------------
+
+
+def test_guard_threshold_is_documented_as_uncalibrated():
+    """
+    The threshold is a plausible value, not a measured one. If someone tunes it they
+    should also update the note, so keep the two coupled.
+    """
+    import inspect
+
+    from app.processors import face_masks
+
+    src = inspect.getsource(face_masks)
+    assert "_SEG_GUARD_MIN_ABS_YAW = 40.0" in src
+    assert "NOT CALIBRATED" in src
+
+
+def test_kappa_gate_defaults_to_off():
+    """
+    2.0 is YawNet's neutral prior (softplus(1.85)), not a confidence floor, so the
+    gate must not default to anything near it.
+    """
+    assert FaceLandmarkDetectors.YAWNET_MIN_KAPPA == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Inference (requires the downloaded weights)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not __import__("pathlib").Path(MODEL).exists(),
+    reason="YawNet weights not downloaded",
+)
+def test_estimate_head_yaw_end_to_end():
+    import onnxruntime as ort
+    from unittest.mock import MagicMock
+
+    sess = ort.InferenceSession(MODEL, providers=["CPUExecutionProvider"])
+    mp = MagicMock()
+    mp.models = {"YawNet": sess}
+    mp.load_model.return_value = sess
+    mp.device = torch.device("cpu")
+
+    det = FaceLandmarkDetectors(mp, MagicMock())
+    # Exercise our crop/normalise/convert code against the real graph.
+    det._run_onnx_binding = lambda name, feed, outs: sess.run(
+        outs, {k: v.cpu().numpy() for k, v in feed.items()}
+    )
+
+    frame = torch.randint(0, 256, (3, 480, 640), dtype=torch.uint8)
+    face = np.array([300.0, 200.0, 380.0, 300.0], dtype=np.float32)
+
+    out = det.estimate_head_yaw_yawnet(frame, face)
+    assert out is not None
+    deg, kappa = out
+    assert 0.0 <= deg < 360.0
+    assert 1e-3 <= kappa <= 100.0  # softplus().clamp(1e-3, 100) upstream
+
+    # A head box that survives clipping to the frame edge must not raise.
+    assert (
+        det.estimate_head_yaw_yawnet(
+            frame, np.array([-40.0, -40.0, 30.0, 30.0], dtype=np.float32)
+        )
+        is not None
+    )
+
+    # A sub-2px box has no usable crop -> None, not an exception.
+    assert (
+        det.estimate_head_yaw_yawnet(
+            frame,
+            np.array([10.0, 10.0, 10.4, 10.4], dtype=np.float32),
+            head_bboxes=np.array([[10.0, 10.0, 11.0, 11.0, 0.9]], dtype=np.float32),
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Preview ring overlay
+# ---------------------------------------------------------------------------
+
+
+def _draw(deg, bbox=(150.0, 200.0, 250.0, 320.0), size=(400, 400)):
+    from app.helpers.miscellaneous import draw_head_yaw_ring_on_faces
+
+    img = torch.zeros((3, size[0], size[1]), dtype=torch.uint8)
+    face = {"bbox": np.array(bbox, dtype=np.float32)}
+    if deg is not None:
+        face["yawnet_deg"] = deg
+    out = draw_head_yaw_ring_on_faces(img, [face])
+    return out.sum(0) > 0
+
+
+def test_ring_not_drawn_without_an_angle():
+    """A face the estimator skipped must draw nothing rather than a default angle."""
+    assert _draw(None).sum().item() == 0
+
+
+def test_ring_is_drawn_with_an_angle():
+    assert _draw(90.0).sum().item() > 0
+
+
+@pytest.mark.parametrize(
+    "deg, axis, sign",
+    [
+        (0.0, "y", +1),  # facing camera -> needle DOWN
+        (90.0, "x", +1),  # right
+        (180.0, "y", -1),  # facing away -> needle UP
+        (270.0, "x", -1),  # left
+    ],
+)
+def test_needle_points_the_right_way(deg, axis, sign):
+    """
+    Guards the dx = sin, dy = cos mapping. Getting this wrong would draw a head
+    turned left as turned right, which is the kind of error nobody notices in code
+    review but everybody notices on screen.
+    """
+    painted = _draw(deg)
+    ys, xs = torch.nonzero(painted, as_tuple=True)
+    cy = (ys.min() + ys.max()).item() / 2.0
+    cx = (xs.min() + xs.max()).item() / 2.0
+    # The needle biases the painted centroid away from the ring's geometric centre.
+    bias_y = ys.float().mean().item() - cy
+    bias_x = xs.float().mean().item() - cx
+    moved, still = (bias_y, bias_x) if axis == "y" else (bias_x, bias_y)
+    assert sign * moved > 0.3, f"needle bias {moved:+.2f} on {axis} for {deg} deg"
+    assert abs(still) < 0.3, f"unexpected bias {still:+.2f} on the other axis"
+
+
+def test_ring_stays_in_bounds_for_a_face_at_the_frame_edge():
+    """A face flush against the top edge must not raise or write out of bounds."""
+    painted = _draw(45.0, bbox=(5.0, 2.0, 60.0, 60.0))
+    assert painted.shape == (400, 400)
+
+
+def test_ring_handles_tiny_and_huge_faces():
+    from app.helpers.miscellaneous import draw_head_yaw_ring_on_faces
+
+    for bbox in [(200.0, 200.0, 203.0, 203.0), (0.0, 0.0, 399.0, 399.0)]:
+        img = torch.zeros((3, 400, 400), dtype=torch.uint8)
+        draw_head_yaw_ring_on_faces(
+            img, [{"bbox": np.array(bbox, dtype=np.float32), "yawnet_deg": 120.0}]
+        )  # must not raise
+
+
+def test_yawnet_kappa_gate_is_exposed_in_the_ui():
+    """
+    kappa has no established threshold, so the control must stay reachable for users
+    to calibrate against their own footage.
+    """
+    import ast
+    import io
+
+    src = io.open("app/ui/widgets/settings_layout_data.py", encoding="utf-8").read()
+    keys = {
+        k.value
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Dict)
+        for k in node.keys
+        if isinstance(k, ast.Constant) and isinstance(k.value, str)
+    }
+    assert "YawNetMinKappaDecimalSlider" in keys
+
+
+@pytest.mark.skipif(
+    not __import__("pathlib").Path(MODEL).exists(),
+    reason="YawNet weights not downloaded",
+)
+def test_kappa_gate_honours_the_ui_override():
+    import onnxruntime as ort
+    from unittest.mock import MagicMock
+
+    sess = ort.InferenceSession(MODEL, providers=["CPUExecutionProvider"])
+    mp = MagicMock()
+    mp.models = {"YawNet": sess}
+    mp.load_model.return_value = sess
+    mp.device = torch.device("cpu")
+    det = FaceLandmarkDetectors(mp, MagicMock())
+    det._run_onnx_binding = lambda name, feed, outs: sess.run(
+        outs, {k: v.cpu().numpy() for k, v in feed.items()}
+    )
+
+    frame = torch.randint(0, 256, (3, 480, 640), dtype=torch.uint8)
+    face = np.array([300.0, 200.0, 380.0, 300.0], dtype=np.float32)
+
+    base = det.estimate_head_yaw_yawnet(frame, face)
+    assert base is not None, "default gate (0) must accept every reading"
+    _, kappa = base
+
+    # A threshold above the reading rejects it; one below accepts it.
+    assert det.estimate_head_yaw_yawnet(frame, face, min_kappa=kappa + 1.0) is None
+    assert (
+        det.estimate_head_yaw_yawnet(frame, face, min_kappa=max(kappa - 0.1, 1e-3))
+        is not None
+    )

--- a/tests/unit/processors/test_yawnet_logic.py
+++ b/tests/unit/processors/test_yawnet_logic.py
@@ -52,7 +52,10 @@ def test_yawnet_normalization_preserves_source_frame(dtype):
 
 @pytest.mark.parametrize("face_count", [0, 1, 2])
 @pytest.mark.parametrize("angle", [0, 90])
-def test_standard_frame_yaw_uses_working_coordinates(monkeypatch, face_count, angle):
+@pytest.mark.parametrize("landmarks_enabled", [True, False, None])
+def test_standard_frame_yaw_uses_working_coordinates(
+    monkeypatch, face_count, angle, landmarks_enabled
+):
     from collections import OrderedDict, defaultdict
     import threading
     from unittest.mock import MagicMock
@@ -81,7 +84,11 @@ def test_standard_frame_yaw_uses_working_coordinates(monkeypatch, face_count, an
         [[[130, 150], [190, 150], [160, 185], [140, 225], [180, 225]]] * face_count,
         dtype=np.float32,
     ).reshape(-1, 5, 2)
-    fw.run_detect.return_value = (boxes, points, None)
+    fw.run_detect.return_value = (
+        boxes,
+        points,
+        np.zeros((face_count, 68, 2), dtype=np.float32),
+    )
     fw.run_recognize_direct.return_value = (np.ones(512), None)
     heads = np.array([[80, 80, 240, 280, 0.9]], dtype=np.float32)
     fw.run_detect_head_bboxes.return_value = heads
@@ -112,7 +119,6 @@ def test_standard_frame_yaw_uses_working_coordinates(monkeypatch, face_count, an
     control = defaultdict(
         bool,
         {
-            "LandmarkDetectToggle": False,
             "ShowAllDetectedFacesBBoxToggle": True,
             "YawNetEnableToggle": True,
             "ShowYawNetRingToggle": True,
@@ -121,14 +127,17 @@ def test_standard_frame_yaw_uses_working_coordinates(monkeypatch, face_count, an
             "ManualRotationAngleSlider": angle,
         },
     )
+    if landmarks_enabled is not None:
+        control["LandmarkDetectToggle"] = landmarks_enabled
     frame = torch.zeros((3, 256, 384), dtype=torch.uint8)
     out = standard.StandardProcessor(worker).process_standard_frame(
         frame, control, threading.Event()
     )
     assert out.shape == frame.shape
-    assert fw.run_detect_head_bboxes.call_count == bool(face_count)
-    assert fw.estimate_head_yaw.call_count == face_count
-    assert len(overlays) == bool(face_count)
+    expected_faces = face_count if landmarks_enabled is not False else 0
+    assert fw.run_detect_head_bboxes.call_count == bool(expected_faces)
+    assert fw.estimate_head_yaw.call_count == expected_faces
+    assert len(overlays) == bool(expected_faces)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Occluder and DFL XSeg can predict almost no face area on extreme profiles, causing the swap to disappear. This PR bypasses a collapsed mask only when both the head angle and mask-area thresholds are met. Frontal occlusions retain the normal mask behavior.

### Profile Safeguard
- Adds a toggle, minimum head angle (40 degrees), and minimum face area (30%). These defaults are provisional and have not been calibrated against representative footage.
- Thresholds XSeg probabilities before measuring face area and returns four independent bypass masks so downstream in-place operations cannot alias them.
- Checks the host-side angle and settings before reading mask area back from the device.

### YawNet
- Adds full-circle head-yaw estimation using the MIT-licensed YawNet model, downloaded from the author's release.
- Shares whole-head detection with HRFFA when available and skips head detection on frames without eligible faces.
- Computes yaw once per face before swapping and before undoing working-frame rotation or scaling. Swapping and preview overlays reuse the result.
- Mirrors model angles with `(360 - deg) % 360` for the ring convention, then folds them to distance from frontal for the safeguard. The existing landmark-based angle remains in use for the dynamic side mask, preserving saved slider calibration.
- Exposes an optional preview ring and kappa confidence gate. The gate defaults to off because no calibrated confidence threshold is available; rejected readings remain visible in debug logging.
- Places inference inputs on the configured device. Normalization preserves the source frame even when a float32 head crop is already at model input size.

### Validation
- 116 focused tests passed across YawNet, face masks, frame-worker quality, and VR behavior.
- Added regression coverage for float32 source-frame preservation and actual frame-processor execution with scaling, 90-degree rotation, multiple faces, and empty frames.
- Existing YawNet tests exercised locally downloaded weights with CPU ONNX Runtime. CUDA/TensorRT execution and visual quality on representative footage were not validated in this audit.
